### PR TITLE
insert image menu item for wysiwyg editor

### DIFF
--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-menu.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-menu.tsx
@@ -10,6 +10,7 @@ import {
   H2Icon,
   H3Icon,
   IconProps,
+  ImagesRegularIcon,
   ItalicIcon,
   LinkIcon,
   ListOlIcon,
@@ -59,6 +60,7 @@ const menuItems: Array<[ActionNames<WysiwygExtensions>, [ComponentType<IconProps
   ['blockquote', [QuoteRightIcon]],
   ['toggleCodeBlock', [CodeIcon]],
   ['horizontalRule', [RulerHorizontalIcon]],
+  ['insertImage', [ImagesRegularIcon], { src: 'https://avatars0.githubusercontent.com/u/2158740?s=460&v=4' }],
 ];
 
 const runAction = (method: AnyFunction, attrs?: Attrs): MouseEventHandler<HTMLElement> => e => {


### PR DESCRIPTION
## Description

Improve image insert and inline editing. Opening PR draft to add visibility.
#209 

#### Proposed Features
- Add image icon `WysiwygEditor` menu bar with dropdown options
  - from URL
  - from computer
- Resize inline images

#### References
1. ProseMirror's [basic editor](https://prosemirror.net/examples/basic) has a simple implementation of this feature.
2. CZI ProseMirror's [rich text editor](https://github.com/chanzuckerberg/czi-prosemirror) has an advanced implementation of this feature.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- prettier-ignore-start -->

- [x] I have read the [**contributing**](https://github.com/ifiokjr/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

<!-- prettier-ignore-end -->

## Screenshots

#### Coming Soon!
<!-- Delete this section if not applicable -->
