### PR TITLE
chore: add option to output JSON in Next example

### DIFF
--- a/@remirror/cli/CHANGELOG.md
+++ b/@remirror/cli/CHANGELOG.md
@@ -1,8 +1,10 @@
 # @remirror/cli
 
 ## 0.7.4
+
 ### Patch Changes
 
-- 7380e18f: Update repository url from ifiokjr/remirror to remirror/remirror to reflect new GitHub organisation.
+- 7380e18f: Update repository url from ifiokjr/remirror to remirror/remirror to reflect new GitHub
+  organisation.
 - Updated dependencies [7380e18f]
   - @remirror/core-helpers@0.7.4

--- a/examples/with-next/pages/editor/rich-social/rich.tsx
+++ b/examples/with-next/pages/editor/rich-social/rich.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { take, EditorState } from '@remirror/core';
+import { EditorState, take } from '@remirror/core';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -25,7 +25,7 @@ import { CodeBlockExtension } from '@remirror/extension-code-block';
 import { RemirrorStateListenerParams } from '@remirror/react';
 import { userData } from '@remirror/showcase';
 import matchSorter from 'match-sorter';
-import { useMemo, useState, useCallback, ChangeEvent } from 'react';
+import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 import bash from 'refractor/lang/bash';
 import markdown from 'refractor/lang/markdown';
 import tsx from 'refractor/lang/tsx';
@@ -121,7 +121,7 @@ export const ExampleRichSocialEditor = (props: Partial<SocialEditorProps>) => {
     ];
   }, [defaultLanguage, formatter, supportedLanguages]);
 
-  const [value, setValue] = useState<EditorState<any> | null>(null);
+  const [value, setValue] = useState<EditorState | null>(null);
 
   const handleStateChange = useCallback((params: RemirrorStateListenerParams<SocialExtensions>): void => {
     setValue(params.newState);
@@ -147,7 +147,7 @@ export const ExampleRichSocialEditor = (props: Partial<SocialEditorProps>) => {
 
   const jsonValue = useMemo(() => {
     return value && showJSON ? JSON.stringify(value.toJSON(), null, 2) : '';
-  }, [value]);
+  }, [showJSON, value]);
 
   return (
     <div>


### PR DESCRIPTION
## Description

It's often useful when experimenting to see what's going on under the covers. This adds a checkbox to start rendering the prosemirror JSON out.

To make things easier I've persisted this setting to localStorage so it can store your preference.

I've only applied this to the rich social editor so far, but it could easily be extended to other editors. It could easily be extracted into a shared hook.

**WARNING**: onStateChange states "If this exists the editor becomes a controlled component. Nothing will be updated unless you explicitly set the value prop to the updated state. Without a deep understanding of Prosemirror this is not recommended." but I've used that API since I don't know what else to use?

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

![Screenshot_20200206_150706](https://user-images.githubusercontent.com/129910/73949478-5dba5700-48f2-11ea-930c-284aeaf1578d.png)
