### PR TITLE
feat(social): enable overriding mention and tag ids and hrefs

### DIFF
--- a/.changeset/angry-books-shop.md
+++ b/.changeset/angry-books-shop.md
@@ -1,0 +1,6 @@
+---
+'@remirror/editor-social': minor
+---
+
+- Allow the override of mention and tag id and href properties.
+- BREAKING Changed `uid` property of of `UserData` to `id`

--- a/.changeset/tricky-cheetahs-provide.md
+++ b/.changeset/tricky-cheetahs-provide.md
@@ -1,0 +1,5 @@
+---
+'@remirror/showcase': patch
+---
+
+- Update a username in exported showcase data to reflect a failing scenario.

--- a/@remirror/cli/CHANGELOG.md
+++ b/@remirror/cli/CHANGELOG.md
@@ -1,8 +1,10 @@
 # @remirror/cli
 
 ## 0.7.4
+
 ### Patch Changes
 
-- 7380e18f: Update repository url from ifiokjr/remirror to remirror/remirror to reflect new GitHub organisation.
+- 7380e18f: Update repository url from ifiokjr/remirror to remirror/remirror to reflect new GitHub
+  organisation.
 - Updated dependencies [7380e18f]
   - @remirror/core-helpers@0.7.4

--- a/@remirror/editor-social/src/components/social-editor.tsx
+++ b/@remirror/editor-social/src/components/social-editor.tsx
@@ -125,31 +125,35 @@ export class SocialEditor extends PureComponent<SocialEditorProps, State> {
      * Handle the enter key being pressed
      */
     Enter: ({ suggester: { char, name }, command }) => {
-      const { activeIndex, hideMentionSuggestions: hideSuggestions } = this.state;
+      const {
+        users,
+        tags,
+        state: { activeIndex, hideMentionSuggestions: hideSuggestions },
+      } = this;
 
       if (hideSuggestions) {
         return false;
       }
 
-      const id =
-        name === 'at' && this.users.length
-          ? this.users[activeIndex].username
-          : name === 'tag' && this.tags.length
-          ? this.tags[activeIndex].tag
-          : undefined;
+      const userData = name === 'at' && users.length > activeIndex ? users[activeIndex] : null;
+      const tagData = name === 'tag' && tags.length > activeIndex ? tags[activeIndex] : null;
 
-      // Check if a matching id exists because the user has selected something.
-      if (!id) {
+      const id = userData ? userData.id : tagData ? tagData.id : null;
+      const label = userData ? userData.username : tagData ? tagData.tag : null;
+      const href = userData ? userData.href : tagData ? tagData.href : null;
+
+      // Check if the user has selected something.
+      if (!label) {
         return false;
       }
 
       this.setMentionExitTriggeredInternally();
       command({
         replacementType: 'full',
-        id,
-        label: `${char}${id}`,
+        id: id ?? label,
+        label: `${char}${label}`,
         role: 'presentation',
-        href: `/${id}`,
+        href: href ?? `/${id ?? label}`,
       });
 
       return true;

--- a/@remirror/editor-social/src/social-types.ts
+++ b/@remirror/editor-social/src/social-types.ts
@@ -79,13 +79,16 @@ export type MatchName = 'at' | 'tag';
 export type MentionState = AtMentionState | HashMentionState;
 
 export interface UserData {
-  uid: string;
+  id?: string;
+  href?: string;
   username: string;
   displayName: string;
   avatarUrl: string;
 }
 
 export interface TagData {
+  id?: string;
+  href?: string;
   tag: string;
 }
 

--- a/@remirror/showcase/src/data/fake-users.ts
+++ b/@remirror/showcase/src/data/fake-users.ts
@@ -109,7 +109,7 @@ export const fakeUsers: FakeUserObject = {
       email: 'jacinto.darosa@example.com',
       login: {
         uuid: '85d3419f-484b-48e2-b290-119d75d561de',
-        username: 'purplebird177',
+        username: 'purple_bird177',
         password: 'berlin',
         salt: 'rGrUG5i9',
         md5: '868275f6718b3cdca3eaed5ad31eba73',

--- a/@remirror/showcase/src/social.tsx
+++ b/@remirror/showcase/src/social.tsx
@@ -32,8 +32,9 @@ const userData: UserData[] = fakeUsers.results.map(
   (user): UserData => ({
     avatarUrl: user.picture.thumbnail,
     displayName: startCase(`${user.name.first} ${user.name.last}`),
-    uid: user.login.uuid,
+    id: user.login.uuid,
     username: user.login.username,
+    href: `/u/${user.login.username}`,
   }),
 );
 


### PR DESCRIPTION
## Description

Currently the code uses the username as the id; but users may edit their username over time so this could lead to broken content. A user's `id` never changes, so this PR allows you to store the ID you specify.

Similarly not every website users `/${username}` as the URL for a user; e.g. reddit uses `/u/${username}`. This PR allows overriding and storing custom id and href with mentions and tags.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
