### PR TITLE
feat(core): improve keybinding composition

### DIFF
--- a/.changeset/orange-swans-bathe.md
+++ b/.changeset/orange-swans-bathe.md
@@ -1,0 +1,15 @@
+---
+'@remirror/core-types': minor
+'@remirror/core': minor
+---
+
+- Change the signature of `CommandFunction` to only accept one parameter which contains `dispatch`, `view`,
+  `state`.
+- Create a new exported `ProsemirrorCommandFunction` type to describe the prosemirror commands which are still
+  used in the codebase.
+- Rename `KeyboardBindings` to `KeyBindings`. Allow `CommandFunctionParams` to provide extra parameters like
+  `next` in the newly named `KeyBindings`.
+- Create a new `KeyBindingCommandFunction` to describe the `Extension.keys()` return type. Update the name of
+  the `ExcludeOptions.keymaps` -> `ExcludeOptions.keys`.
+
+**BREAKING CHANGE**

--- a/.changeset/polite-tigers-sing.md
+++ b/.changeset/polite-tigers-sing.md
@@ -1,0 +1,6 @@
+---
+'jest-prosemirror': minor
+---
+
+Create a new class `ProsemirrorTestChain` for chaining the return from `createEditor`. Previously it was
+manually chained with a function. The plan is to extend this class within the `jest-remirror` codebase.

--- a/.changeset/pretty-apricots-hug.md
+++ b/.changeset/pretty-apricots-hug.md
@@ -1,0 +1,14 @@
+---
+'@remirror/core': minor
+---
+
+Improve the way `ExtensionManager` calls `Extension.keys` methods. Keys now use the new api for
+CommandFunctions which provides a `next` method. This method allows for better control when deciding whether
+or not to defer to the next keybinding in the chain.
+
+To override, create a new keybinding with another extension. Make sure the extension is created with a higher
+priority. The keybinding you create can either return true or false. By default if it returns true, no other
+keybindings will run. However if it returns `false` all other keybindings will be run until one returns `true`
+
+`next` basically calls the every lower priority keybinding in the extensions list. It gives you full control
+of how the bindings are called.

--- a/@remirror/core-extensions/package.json
+++ b/@remirror/core-extensions/package.json
@@ -33,6 +33,7 @@
     "@types/prosemirror-schema-list": "^1.0.1",
     "@types/prosemirror-state": "^1.2.3",
     "@types/prosemirror-view": "^1.11.2",
+    "map-obj": "^4.1.0",
     "prosemirror-commands": "^1.0.8",
     "prosemirror-dropcursor": "^1.2.0",
     "prosemirror-gapcursor": "^1.0.4",

--- a/@remirror/core-extensions/src/extensions/position-tracker-extension.ts
+++ b/@remirror/core-extensions/src/extensions/position-tracker-extension.ts
@@ -2,10 +2,10 @@ import { Extension } from '@remirror/core';
 import { isNullOrUndefined, isNumber, isString } from '@remirror/core-helpers';
 import {
   BaseExtensionOptions,
-  CommandFunction,
   CommandParams,
   ExtensionManagerParams,
   PosParams,
+  ProsemirrorCommandFunction,
   Transaction,
 } from '@remirror/core-types';
 import { getPluginMeta, getPluginState } from '@remirror/core-utils';
@@ -132,7 +132,10 @@ export class PositionTrackerExtension extends Extension<PositionTrackerExtension
   }
 
   public commands({ getHelpers }: CommandParams) {
-    const commandFactory = <GArg>(helperName: string) => (params: GArg): CommandFunction => (_, dispatch) => {
+    const commandFactory = <GArg>(helperName: string) => (params: GArg): ProsemirrorCommandFunction => (
+      _,
+      dispatch,
+    ) => {
       const helper = getHelpers(helperName);
       const tr = helper(params);
 

--- a/@remirror/core-extensions/src/marks/bold-extension.ts
+++ b/@remirror/core-extensions/src/marks/bold-extension.ts
@@ -1,9 +1,10 @@
 import {
   CommandMarkTypeParams,
+  convertCommand,
   ExtensionManagerMarkTypeParams,
   isElementDOMNode,
   isString,
-  KeyboardBindings,
+  KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -39,9 +40,9 @@ export class BoldExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyBindings {
     return {
-      'Mod-b': toggleMark(type),
+      'Mod-b': convertCommand(toggleMark(type)),
     };
   }
 

--- a/@remirror/core-extensions/src/marks/code-extension.ts
+++ b/@remirror/core-extensions/src/marks/code-extension.ts
@@ -1,7 +1,8 @@
 import {
   CommandMarkTypeParams,
+  convertCommand,
   ExtensionManagerMarkTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -23,9 +24,9 @@ export class CodeExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyBindings {
     return {
-      'Mod-`': toggleMark(type),
+      'Mod-`': convertCommand(toggleMark(type)),
     };
   }
 

--- a/@remirror/core-extensions/src/marks/italic-extension.ts
+++ b/@remirror/core-extensions/src/marks/italic-extension.ts
@@ -1,7 +1,8 @@
 import {
   CommandMarkTypeParams,
+  convertCommand,
   ExtensionManagerMarkTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -23,9 +24,9 @@ export class ItalicExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyBindings {
     return {
-      'Mod-i': toggleMark(type),
+      'Mod-i': convertCommand(toggleMark(type)),
     };
   }
 

--- a/@remirror/core-extensions/src/marks/link-extension.ts
+++ b/@remirror/core-extensions/src/marks/link-extension.ts
@@ -9,7 +9,7 @@ import {
   getSelectedWord,
   isMarkActive,
   isTextSelection,
-  KeyboardBindings,
+  KeyBindings,
   MarkExtension,
   MarkExtensionOptions,
   MarkExtensionSpec,
@@ -71,16 +71,18 @@ export class LinkExtension extends MarkExtension<LinkExtensionOptions> {
     };
   }
 
-  public keys(): KeyboardBindings {
+  public keys(): KeyBindings {
     return {
-      'Mod-k': (state, dispatch) => {
+      'Mod-k': ({ state, dispatch }) => {
         // Expand selection
         const range = getSelectedWord(state);
         if (!range) {
           return false;
         }
+
         const { from, to } = range;
         const tr = state.tr.setSelection(TextSelection.create(state.doc, from, to));
+
         if (dispatch) {
           dispatch(tr);
         }

--- a/@remirror/core-extensions/src/marks/strike-extension.ts
+++ b/@remirror/core-extensions/src/marks/strike-extension.ts
@@ -1,7 +1,8 @@
 import {
   CommandMarkTypeParams,
+  convertCommand,
   ExtensionManagerMarkTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -37,9 +38,9 @@ export class StrikeExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyBindings {
     return {
-      'Mod-d': toggleMark(type),
+      'Mod-d': convertCommand(toggleMark(type)),
     };
   }
 

--- a/@remirror/core-extensions/src/marks/underline-extension.ts
+++ b/@remirror/core-extensions/src/marks/underline-extension.ts
@@ -1,7 +1,8 @@
 import {
   CommandMarkTypeParams,
+  convertCommand,
   ExtensionManagerMarkTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
@@ -29,9 +30,9 @@ export class UnderlineExtension extends MarkExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerMarkTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerMarkTypeParams): KeyBindings {
     return {
-      'Mod-u': toggleMark(type),
+      'Mod-u': convertCommand(toggleMark(type)),
     };
   }
 

--- a/@remirror/core-extensions/src/nodes/blockquote-extension.ts
+++ b/@remirror/core-extensions/src/nodes/blockquote-extension.ts
@@ -1,8 +1,9 @@
 import {
   CommandNodeTypeParams,
+  convertCommand,
   EDITOR_CLASS_SELECTOR,
   ExtensionManagerNodeTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -57,9 +58,9 @@ export class BlockquoteExtension extends NodeExtension {
     `;
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyBindings {
     return {
-      'Ctrl->': toggleWrap(type),
+      'Ctrl->': convertCommand(toggleWrap(type)),
     };
   }
 

--- a/@remirror/core-extensions/src/nodes/bullet-list-extension.ts
+++ b/@remirror/core-extensions/src/nodes/bullet-list-extension.ts
@@ -1,7 +1,8 @@
 import {
   CommandNodeTypeParams,
+  convertCommand,
   ExtensionManagerNodeTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -28,9 +29,9 @@ export class BulletListExtension extends NodeExtension {
     return { toggleBulletList: () => toggleList(type, schema.nodes.listItem) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyboardBindings {
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyBindings {
     return {
-      'Shift-Ctrl-8': toggleList(type, schema.nodes.listItem),
+      'Shift-Ctrl-8': convertCommand(toggleList(type, schema.nodes.listItem)),
     };
   }
 

--- a/@remirror/core-extensions/src/nodes/hard-break-extension.ts
+++ b/@remirror/core-extensions/src/nodes/hard-break-extension.ts
@@ -1,10 +1,12 @@
 import {
+  chainCommands,
+  convertCommand,
   ExtensionManagerNodeTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
 } from '@remirror/core';
-import { chainCommands, exitCode } from 'prosemirror-commands';
+import { exitCode } from 'prosemirror-commands';
 
 export class HardBreakExtension extends NodeExtension {
   get name() {
@@ -22,14 +24,15 @@ export class HardBreakExtension extends NodeExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
-    const command = chainCommands(exitCode, (state, dispatch) => {
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyBindings {
+    const command = chainCommands(convertCommand(exitCode), ({ state, dispatch }) => {
       if (dispatch) {
         dispatch(state.tr.replaceSelectionWith(type.create()).scrollIntoView());
       }
 
       return true;
     });
+
     return {
       'Mod-Enter': command,
       'Shift-Enter': command,

--- a/@remirror/core-extensions/src/nodes/heading-extension.ts
+++ b/@remirror/core-extensions/src/nodes/heading-extension.ts
@@ -1,8 +1,9 @@
 import {
   Attrs,
   CommandNodeTypeParams,
+  convertCommand,
   ExtensionManagerNodeTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionOptions,
   NodeExtensionSpec,
@@ -76,11 +77,11 @@ export class HeadingExtension extends NodeExtension<HeadingExtensionOptions> {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
-    const keys: KeyboardBindings = Object.create(null);
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyBindings {
+    const keys: KeyBindings = Object.create(null);
 
     this.options.levels.forEach(level => {
-      keys[`Shift-Ctrl-${level}`] = setBlockType(type, { level });
+      keys[`Shift-Ctrl-${level}`] = convertCommand(setBlockType(type, { level }));
     });
     return keys;
   }

--- a/@remirror/core-extensions/src/nodes/horizontal-rule-extension.ts
+++ b/@remirror/core-extensions/src/nodes/horizontal-rule-extension.ts
@@ -1,11 +1,11 @@
 import {
-  CommandFunction,
   CommandNodeTypeParams,
   ExtensionManagerNodeTypeParams,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
   nodeInputRule,
+  ProsemirrorCommandFunction,
 } from '@remirror/core';
 
 export class HorizontalRuleExtension extends NodeExtension {
@@ -24,7 +24,7 @@ export class HorizontalRuleExtension extends NodeExtension {
 
   public commands({ type }: CommandNodeTypeParams) {
     return {
-      horizontalRule: (): CommandFunction => (state, dispatch) => {
+      horizontalRule: (): ProsemirrorCommandFunction => (state, dispatch) => {
         if (dispatch) {
           dispatch(state.tr.replaceSelectionWith(type.create()));
         }

--- a/@remirror/core-extensions/src/nodes/list-item-extension.ts
+++ b/@remirror/core-extensions/src/nodes/list-item-extension.ts
@@ -1,6 +1,7 @@
 import {
+  convertCommand,
   ExtensionManagerNodeTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
 } from '@remirror/core';
@@ -22,11 +23,11 @@ export class ListItemExtension extends NodeExtension {
     };
   }
 
-  public keys({ type }: ExtensionManagerNodeTypeParams): KeyboardBindings {
+  public keys({ type }: ExtensionManagerNodeTypeParams): KeyBindings {
     return {
-      Enter: splitListItem(type),
-      Tab: sinkListItem(type),
-      'Shift-Tab': liftListItem(type),
+      Enter: convertCommand(splitListItem(type)),
+      Tab: convertCommand(sinkListItem(type)),
+      'Shift-Tab': convertCommand(liftListItem(type)),
     };
   }
 }

--- a/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
+++ b/@remirror/core-extensions/src/nodes/ordered-list-extension.ts
@@ -1,8 +1,9 @@
 import {
   CommandNodeTypeParams,
+  convertCommand,
   ExtensionManagerNodeTypeParams,
   isElementDOMNode,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -47,9 +48,9 @@ export class OrderedListExtension extends NodeExtension {
     return { toggleOrderedList: () => toggleList(type, schema.nodes.listItem) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyboardBindings {
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyBindings {
     return {
-      'Shift-Ctrl-9': toggleList(type, schema.nodes.listItem),
+      'Shift-Ctrl-9': convertCommand(toggleList(type, schema.nodes.listItem)),
     };
   }
 

--- a/@remirror/core-extensions/src/nodes/simple-code-block-extension.ts
+++ b/@remirror/core-extensions/src/nodes/simple-code-block-extension.ts
@@ -1,9 +1,10 @@
 import { Interpolation } from '@emotion/core';
 import {
   CommandNodeTypeParams,
+  convertCommand,
   EDITOR_CLASS_SELECTOR,
   ExtensionManagerNodeTypeParams,
-  KeyboardBindings,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -34,9 +35,9 @@ export class CodeBlockExtension extends NodeExtension {
     return { toggleCodeBlock: () => toggleBlockItem({ type, toggleType: schema.nodes.paragraph }) };
   }
 
-  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyboardBindings {
+  public keys({ type, schema }: ExtensionManagerNodeTypeParams): KeyBindings {
     return {
-      'Shift-Ctrl-\\': toggleBlockItem({ type, toggleType: schema.nodes.paragraph }),
+      'Shift-Ctrl-\\': convertCommand(toggleBlockItem({ type, toggleType: schema.nodes.paragraph })),
     };
   }
 

--- a/@remirror/core-types/package.json
+++ b/@remirror/core-types/package.json
@@ -34,7 +34,8 @@
     "prosemirror-model": "^1.7.4",
     "prosemirror-schema-list": "^1.0.4",
     "prosemirror-state": "^1.2.4",
-    "prosemirror-transform": "^1.1.5"
+    "prosemirror-transform": "^1.1.5",
+    "type-fest": "^0.10.0"
   },
   "peerDependencies": {
     "@emotion/core": "^10",

--- a/@remirror/core-utils/src/command-utils.ts
+++ b/@remirror/core-utils/src/command-utils.ts
@@ -3,11 +3,11 @@ import {
   AnyFunction,
   Attrs,
   AttrsParams,
-  CommandFunction,
   MarkType,
   MarkTypeParams,
   NodeType,
   NodeTypeParams,
+  ProsemirrorCommandFunction,
   RangeParams,
   TransformTransactionParams,
 } from '@remirror/core-types';
@@ -43,7 +43,7 @@ export const updateMark = ({
   attrs = Object.create(null),
   appendText,
   range,
-}: UpdateMarkParams): CommandFunction => (state, dispatch) => {
+}: UpdateMarkParams): ProsemirrorCommandFunction => (state, dispatch) => {
   const { selection } = state;
   const { tr } = state;
   const { from, to } = range ?? selection;
@@ -69,7 +69,10 @@ export const updateMark = ({
  *
  * @public
  */
-export const toggleWrap = (type: NodeType, attrs?: Attrs): CommandFunction => (state, dispatch) => {
+export const toggleWrap = (type: NodeType, attrs?: Attrs): ProsemirrorCommandFunction => (
+  state,
+  dispatch,
+) => {
   const isActive = isNodeActive({ state, type });
 
   if (isActive) {
@@ -91,7 +94,10 @@ export const toggleWrap = (type: NodeType, attrs?: Attrs): CommandFunction => (s
  *
  * @public
  */
-export const toggleList = (type: NodeType, itemType: NodeType): CommandFunction => (state, dispatch) => {
+export const toggleList = (type: NodeType, itemType: NodeType): ProsemirrorCommandFunction => (
+  state,
+  dispatch,
+) => {
   const isActive = isNodeActive({ state, type });
 
   if (isActive) {
@@ -119,7 +125,7 @@ export const toggleBlockItem = ({
   type,
   toggleType,
   attrs = Object.create(null),
-}: ToggleBlockItemParams): CommandFunction => (state, dispatch) => {
+}: ToggleBlockItemParams): ProsemirrorCommandFunction => (state, dispatch) => {
   const isActive = isNodeActive({ state, type, attrs });
 
   if (isActive) {
@@ -190,7 +196,7 @@ export const replaceText = ({
   content = '',
   startTransaction,
   endTransaction,
-}: ReplaceTextParams): CommandFunction => (state, dispatch) => {
+}: ReplaceTextParams): ProsemirrorCommandFunction => (state, dispatch) => {
   const { schema, selection } = state;
   // const { $from, $to } = selection;
   const index = selection.$from.index();
@@ -251,7 +257,7 @@ export const removeMark = ({
   range,
   endTransaction,
   startTransaction,
-}: RemoveMarkParams): CommandFunction => (state, dispatch) => {
+}: RemoveMarkParams): ProsemirrorCommandFunction => (state, dispatch) => {
   const { selection } = state;
   const tr = callMethod({ fn: startTransaction, defaultReturn: state.tr }, [state.tr, state]);
   let { from, to } = range ?? selection;
@@ -273,3 +279,12 @@ export const removeMark = ({
 
   return true;
 };
+
+/**
+ * An empty (noop) command function.
+ *
+ * @remarks
+ *
+ * This is typically to represent the default _do nothing_ action.
+ */
+export const emptyCommandFunction: ProsemirrorCommandFunction = () => false;

--- a/@remirror/core/src/__tests__/extension-manager.spec.tsx
+++ b/@remirror/core/src/__tests__/extension-manager.spec.tsx
@@ -1,9 +1,21 @@
 import { EMPTY_PARAGRAPH_NODE, Tags } from '@remirror/core-constants';
 import { Cast } from '@remirror/core-helpers';
-import { Attrs, EditorState, NodeExtensionSpec } from '@remirror/core-types';
+import {
+  Attrs,
+  EditorState,
+  KeyBindingCommandFunction,
+  KeyBindings,
+  NodeExtensionSpec,
+} from '@remirror/core-types';
 import { PortalContainer } from '@remirror/react-portals';
-import { createTestManager, extensions } from '@remirror/test-fixtures';
+import {
+  baseExtensions,
+  createTestManager,
+  extensions,
+  helpers as initHelpers,
+} from '@remirror/test-fixtures';
 import { defaultRemirrorThemeValue } from '@remirror/ui';
+import { createEditor, doc, p } from 'jest-prosemirror';
 import { EditorView } from 'prosemirror-view';
 import React, { FC } from 'react';
 
@@ -11,136 +23,215 @@ import { Extension } from '../extension';
 import { ExtensionManager, isExtensionManager } from '../extension-manager';
 import { NodeExtension } from '../node-extension';
 
-export const helpers = {
-  getState: Cast(jest.fn(() => state)),
-  portalContainer: new PortalContainer(),
-  getTheme: () => defaultRemirrorThemeValue,
-};
+describe('ExtensionManager', () => {
+  let state: EditorState;
 
-const innerMock = jest.fn();
-const mock = jest.fn((_: Attrs) => innerMock);
-const getInformation = jest.fn(() => 'information');
-
-const SSRComponent: FC<Attrs> = () => <div />;
-
-class DummyExtension extends Extension {
-  public name = 'dummy';
-  public tags = ['simple', Tags.LastNodeCompatible];
-  public commands() {
-    return { dummy: mock };
-  }
-
-  public helpers() {
-    return {
-      getInformation,
-    };
-  }
-
-  public attributes() {
-    return {
-      class: 'custom',
-    };
-  }
-}
-
-class BigExtension extends NodeExtension {
-  public name = 'big' as const;
-
-  public schema: NodeExtensionSpec = {
-    toDOM: () => ['h1', 0],
+  const helpers = {
+    getState: Cast(jest.fn(() => state)),
+    portalContainer: new PortalContainer(),
+    getTheme: () => defaultRemirrorThemeValue,
   };
+  const innerMock = jest.fn();
+  const mock = jest.fn((_: Attrs) => innerMock);
+  const getInformation = jest.fn(() => 'information');
 
-  get defaultOptions() {
-    return {
-      SSRComponent,
-    };
+  const SSRComponent: FC<Attrs> = () => <div />;
+
+  class DummyExtension extends Extension {
+    public name = 'dummy';
+    public tags = ['simple', Tags.LastNodeCompatible];
+    public commands() {
+      return { dummy: mock };
+    }
+
+    public helpers() {
+      return {
+        getInformation,
+      };
+    }
+
+    public attributes() {
+      return {
+        class: 'custom',
+      };
+    }
   }
-}
 
-const dummy = new DummyExtension();
-const big = new BigExtension();
-let manager = ExtensionManager.create([
-  ...extensions,
-  { extension: dummy, priority: 1 },
-  { extension: big, priority: 10 },
-]);
+  class BigExtension extends NodeExtension {
+    public name = 'big' as const;
 
-let state: EditorState;
-let view: EditorView;
+    public schema: NodeExtensionSpec = {
+      toDOM: () => ['h1', 0],
+    };
 
-beforeEach(() => {
-  manager = ExtensionManager.create([
+    get defaultOptions() {
+      return {
+        SSRComponent,
+      };
+    }
+  }
+
+  const dummy = new DummyExtension();
+  const big = new BigExtension();
+  let manager = ExtensionManager.of([
     ...extensions,
     { extension: dummy, priority: 1 },
     { extension: big, priority: 10 },
   ]);
-  manager.init(helpers);
-  state = manager.createState({ content: EMPTY_PARAGRAPH_NODE });
-  view = new EditorView(document.createElement('div'), {
-    state,
-    editable: () => true,
+
+  let view: EditorView;
+
+  beforeEach(() => {
+    manager = ExtensionManager.create([
+      ...extensions,
+      { extension: dummy, priority: 1 },
+      { extension: big, priority: 10 },
+    ]);
+    manager.init(helpers);
+    state = manager.createState({ content: EMPTY_PARAGRAPH_NODE });
+    view = new EditorView(document.createElement('div'), {
+      state,
+      editable: () => true,
+    });
+    manager.initView(view);
   });
-  manager.initView(view);
+
+  test('commands', () => {
+    const attrs = { a: 'a' };
+    manager.data.actions.dummy(attrs);
+    expect(mock).toHaveBeenCalledWith(attrs);
+    expect(innerMock).toHaveBeenCalledWith(state, view.dispatch, view);
+  });
+
+  test('helpers', () => {
+    const val = manager.data.helpers.getInformation();
+    expect(val).toBe('information');
+    expect(getInformation).toHaveBeenCalled();
+  });
+
+  describe('#properties', () => {
+    it('should sort extensions by priority', () => {
+      expect(manager.extensions).toHaveLength(11);
+      expect(manager.extensions[0]).toEqual(dummy);
+      expect(manager.extensions[10]).toEqual(big);
+    });
+
+    it('should throw if data accessed without init', () => {
+      const testManager = createTestManager();
+      expect(() => testManager.data).toThrowErrorMatchingInlineSnapshot(
+        `"Extension Manager must be initialized before attempting to access the data"`,
+      );
+    });
+    it('should provide the schema at instantiation', () => {
+      expect(createTestManager().schema).toBeTruthy();
+    });
+
+    it('should provide access to `attributes`', () => {
+      expect(manager.attributes.class).toInclude('custom');
+    });
+
+    it('should provide access to `components`', () => {
+      expect(manager.components.big).toEqual(SSRComponent);
+    });
+  });
+
+  test('isExtensionManager', () => {
+    expect(isExtensionManager({})).toBeFalse();
+    expect(isExtensionManager(manager)).toBeTrue();
+  });
+
+  describe('#isEqual', () => {
+    it('should be equal for the same instance', () => {
+      expect(manager.isEqual(manager)).toBeTrue();
+    });
+
+    it('should be equal for different instances but identical otherwise', () => {
+      expect(createTestManager().isEqual(createTestManager())).toBeTrue();
+    });
+
+    it('should not be equal for different managers', () => {
+      expect(manager.isEqual(createTestManager())).toBeFalse();
+    });
+
+    it('should not be equal for different objects', () => {
+      expect(manager.isEqual({})).toBeFalse();
+    });
+  });
 });
 
-test('commands', () => {
-  const attrs = { a: 'a' };
-  manager.data.actions.dummy(attrs);
-  expect(mock).toHaveBeenCalledWith(attrs);
-  expect(innerMock).toHaveBeenCalledWith(state, view.dispatch, view);
-});
+test('keymaps', () => {
+  const mocks = {
+    firstEnter: jest.fn((..._: Parameters<KeyBindingCommandFunction>) => false),
+    secondEnter: jest.fn((..._: Parameters<KeyBindingCommandFunction>) => false),
+    thirdEnter: jest.fn((..._: Parameters<KeyBindingCommandFunction>) => false),
+  };
 
-test('helpers', () => {
-  const val = manager.data.helpers.getInformation();
-  expect(val).toBe('information');
-  expect(getInformation).toHaveBeenCalled();
-});
+  class FirstExtension extends Extension {
+    public name = 'first' as const;
 
-describe('#properties', () => {
-  it('should sort extensions by priority', () => {
-    expect(manager.extensions).toHaveLength(11);
-    expect(manager.extensions[0]).toEqual(dummy);
-    expect(manager.extensions[10]).toEqual(big);
-  });
+    public keys(): KeyBindings {
+      return {
+        Enter: mocks.firstEnter,
+      };
+    }
+  }
 
-  it('should throw if data accessed without init', () => {
-    const testManager = createTestManager();
-    expect(() => testManager.data).toThrowErrorMatchingInlineSnapshot(
-      `"Extension Manager must be initialized before attempting to access the data"`,
-    );
-  });
-  it('should provide the schema at instantiation', () => {
-    expect(createTestManager().schema).toBeTruthy();
-  });
+  class SecondExtension extends Extension {
+    public name = 'second' as const;
 
-  it('should provide access to `attributes`', () => {
-    expect(manager.attributes.class).toInclude('custom');
-  });
+    public keys() {
+      return {
+        Enter: mocks.secondEnter,
+      };
+    }
+  }
+  class ThirdExtension extends Extension {
+    public name = 'third' as const;
 
-  it('should provide access to `components`', () => {
-    expect(manager.components.big).toEqual(SSRComponent);
-  });
-});
+    public keys() {
+      return {
+        Enter: mocks.thirdEnter,
+      };
+    }
+  }
 
-test('isExtensionManager', () => {
-  expect(isExtensionManager({})).toBeFalse();
-  expect(isExtensionManager(manager)).toBeTrue();
-});
+  const manager = ExtensionManager.of([
+    ...baseExtensions,
+    { extension: new FirstExtension(), priority: 1 },
+    { extension: new SecondExtension(), priority: 10 },
+    { extension: new ThirdExtension(), priority: 100 },
+  ]);
+  manager.init(initHelpers);
 
-describe('#isEqual', () => {
-  it('should be equal for the same instance', () => {
-    expect(manager.isEqual(manager)).toBeTrue();
-  });
-
-  it('should be equal for different instances but identical otherwise', () => {
-    expect(createTestManager().isEqual(createTestManager())).toBeTrue();
-  });
-
-  it('should not be equal for different managers', () => {
-    expect(manager.isEqual(createTestManager())).toBeFalse();
-  });
-
-  it('should not be equal for different objects', () => {
-    expect(manager.isEqual({})).toBeFalse();
-  });
+  createEditor(doc(p('simple<cursor>')), { plugins: manager.data.keymaps })
+    .press('Enter')
+    .callback(() => {
+      expect(mocks.firstEnter).toHaveBeenCalled();
+      expect(mocks.secondEnter).toHaveBeenCalled();
+      expect(mocks.thirdEnter).toHaveBeenCalled();
+      jest.clearAllMocks();
+      mocks.firstEnter.mockImplementation(() => true);
+    })
+    .press('Enter')
+    .callback(() => {
+      expect(mocks.firstEnter).toHaveBeenCalled();
+      expect(mocks.secondEnter).not.toHaveBeenCalled();
+      expect(mocks.thirdEnter).not.toHaveBeenCalled();
+      jest.clearAllMocks();
+      mocks.firstEnter.mockImplementation(({ next }) => {
+        return next();
+      });
+    })
+    .press('Enter')
+    .callback(() => {
+      expect(mocks.secondEnter).toHaveBeenCalledTimes(1);
+      expect(mocks.thirdEnter).toHaveBeenCalledTimes(1);
+      jest.clearAllMocks();
+      mocks.secondEnter.mockImplementation(() => true);
+    })
+    .press('Enter')
+    .callback(() => {
+      expect(mocks.secondEnter).toHaveBeenCalledTimes(1);
+      expect(mocks.thirdEnter).not.toHaveBeenCalled();
+    });
 });

--- a/@remirror/core/src/extension-manager.helpers.ts
+++ b/@remirror/core/src/extension-manager.helpers.ts
@@ -333,9 +333,9 @@ export const createExtensionTags = <
     });
   }
 
-  return {
+  return ({
     general,
     mark,
     node,
-  } as any;
+  } as unknown) as ExtensionTags<GNodes, GMarks, GPlain>;
 };

--- a/@remirror/core/src/extension.ts
+++ b/@remirror/core/src/extension.ts
@@ -13,7 +13,7 @@ import {
   ExtensionManagerParams,
   ExtensionManagerTypeParams,
   ExtraAttrs,
-  KeyboardBindings,
+  KeyBindings,
   NodeViewMethod,
   OnTransactionParams,
   PlainObject,
@@ -32,7 +32,7 @@ const defaultOptions: Required<BaseExtensionOptions> = {
   extraAttrs: [],
   exclude: {
     inputRules: false,
-    keymaps: false,
+    keys: false,
     pasteRules: false,
     plugin: false,
     styles: false,
@@ -434,7 +434,7 @@ export interface Extension<GOptions extends BaseExtensionOptions = BaseExtension
    *
    * @param params - schema params with type included
    */
-  keys?(params: ExtensionManagerTypeParams<GType>): KeyboardBindings;
+  keys?(params: ExtensionManagerTypeParams<GType>): KeyBindings;
 
   /**
    * Registers a node view for the extension.

--- a/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
+++ b/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
@@ -89,11 +89,14 @@ describe('plugin', () => {
 
   it('can be updated', () => {
     const plainBlock = codeBlock({});
-    const adder = add(doc(tsBlock(`const a = 'test';<cursor>`), plainBlock('Nothing to see here')));
-
-    expect(dom.querySelector('.language-typescript code')!.innerHTML).toMatchSnapshot();
-    adder.insertText('\n\nlog(a);');
-    expect(dom.querySelector('.language-typescript code')!.innerHTML).toMatchSnapshot();
+    add(doc(tsBlock(`const a = 'test';<cursor>`), plainBlock('Nothing to see here')))
+      .callback(() => {
+        expect(dom.querySelector('.language-typescript code')!.innerHTML).toMatchSnapshot();
+      })
+      .insertText('\n\nlog(a);')
+      .callback(() => {
+        expect(dom.querySelector('.language-typescript code')!.innerHTML).toMatchSnapshot();
+      });
   });
 
   it('updates when multiple changes occur', () => {

--- a/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/@remirror/extension-code-block/src/code-block-extension.ts
@@ -8,7 +8,7 @@ import {
   isElementDOMNode,
   isNodeActive,
   isTextSelection,
-  KeyboardBindings,
+  KeyBindings,
   mod,
   NodeExtension,
   NodeExtensionSpec,
@@ -227,11 +227,11 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
     ];
   }
 
-  public keys({ type, getActions }: ExtensionManagerNodeTypeParams): KeyboardBindings {
+  public keys({ type, getActions }: ExtensionManagerNodeTypeParams): KeyBindings {
     const { keyboardShortcut, toggleType } = this.options;
 
     return {
-      Backspace: (state, dispatch) => {
+      Backspace: ({ state, dispatch }) => {
         const { selection } = state;
 
         // If the selection is not empty, return false and let other extension (ie: BaseKeymapExtension) to do
@@ -265,7 +265,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
         }
         return true;
       },
-      Enter: (state, dispatch) => {
+      Enter: ({ state, dispatch }) => {
         const { selection, tr } = state;
         if (!isTextSelection(selection) || !selection.$cursor) {
           return false;
@@ -311,7 +311,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
 
         return true;
       },
-      [keyboardShortcut]: state => {
+      [keyboardShortcut]: ({ state }) => {
         const command = getActions('formatCodeBlock');
 
         if (!isNodeActive({ type, state }) || !command) {

--- a/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/@remirror/extension-code-block/src/code-block-utils.ts
@@ -1,7 +1,6 @@
 import {
   Attrs,
   bool,
-  CommandFunction,
   EditorState,
   findParentNodeOfType,
   flattenArray,
@@ -13,6 +12,7 @@ import {
   NodeTypeParams,
   NodeWithPosition,
   PosParams,
+  ProsemirrorCommandFunction,
   ProsemirrorNodeParams,
   TextParams,
   uniqueArray,
@@ -167,7 +167,7 @@ export const isValidCodeBlockAttrs = (attrs?: Attrs): attrs is CodeBlockAttrs =>
  *
  * This is used to update the language for the codeBlock.
  */
-export const updateNodeAttrs = (type: NodeType) => (attrs: CodeBlockAttrs): CommandFunction => (
+export const updateNodeAttrs = (type: NodeType) => (attrs: CodeBlockAttrs): ProsemirrorCommandFunction => (
   { tr, selection },
   dispatch,
 ) => {
@@ -247,10 +247,9 @@ export const formatCodeBlockFactory = ({
   formatter,
   supportedLanguages,
   defaultLanguage: fallback,
-}: FormatCodeBlockFactoryParams) => ({ pos }: Partial<PosParams> = Object.create(null)): CommandFunction => (
-  state,
-  dispatch,
-) => {
+}: FormatCodeBlockFactoryParams) => (
+  { pos }: Partial<PosParams> = Object.create(null),
+): ProsemirrorCommandFunction => (state, dispatch) => {
   const { tr, selection } = state;
 
   const { from, to } = pos ? { from: pos, to: pos } : selection;

--- a/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -1,6 +1,5 @@
 import {
   Attrs,
-  CommandFunction,
   CommandParams,
   debounce,
   EditorState,
@@ -9,6 +8,7 @@ import {
   isNumber,
   OnTransactionParams,
   Plugin,
+  ProsemirrorCommandFunction,
   uniqueId,
 } from '@remirror/core';
 import { collab, getVersion, receiveTransaction, sendableSteps } from 'prosemirror-collab';
@@ -57,7 +57,7 @@ export class CollaborationExtension extends Extension<CollaborationExtensionOpti
    */
   public commands({ getState, schema }: CommandParams) {
     return {
-      collaborationUpdate: (attrs: CollaborationAttrs): CommandFunction => (_, dispatch) => {
+      collaborationUpdate: (attrs: CollaborationAttrs): ProsemirrorCommandFunction => (_, dispatch) => {
         if (!isValidCollaborationAttrs(attrs)) {
           throw new Error('Invalid attributes passed to the collaboration command.');
         }

--- a/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/@remirror/extension-emoji/src/emoji-extension.ts
@@ -1,11 +1,11 @@
 import {
-  CommandFunction,
   Extension,
   ExtensionManagerParams,
   FromToParams,
   isNullOrUndefined,
   noop,
   plainInputRule,
+  ProsemirrorCommandFunction,
 } from '@remirror/core';
 import escapeStringRegex from 'escape-string-regexp';
 import { Suggester } from 'prosemirror-suggest';
@@ -89,7 +89,7 @@ export class EmojiExtension extends Extension<EmojiExtensionOptions> {
       insertEmojiByName: (
         name: string,
         options: EmojiCommandOptions = Object.create(null),
-      ): CommandFunction => (...args) => {
+      ): ProsemirrorCommandFunction => (...args) => {
         const emoji = getEmojiByName(name);
         if (!emoji) {
           console.warn('invalid emoji name passed into emoji insertion');
@@ -110,7 +110,7 @@ export class EmojiExtension extends Extension<EmojiExtensionOptions> {
       insertEmojiByObject: (
         emoji: EmojiObject,
         { from, to, skinVariation }: EmojiCommandOptions = Object.create(null),
-      ): CommandFunction => (state, dispatch) => {
+      ): ProsemirrorCommandFunction => (state, dispatch) => {
         const { tr } = state;
         const emojiChar = skinVariation ? emoji.char + SKIN_VARIATIONS[skinVariation] : emoji.char;
         tr.insertText(emojiChar, from, to);
@@ -126,10 +126,9 @@ export class EmojiExtension extends Extension<EmojiExtensionOptions> {
        * Inserts the suggestion character into the current position in the editor
        * in order to activate the suggestion popup..
        */
-      openEmojiSuggestions: ({ from, to }: Partial<FromToParams> = Object.create(null)): CommandFunction => (
-        state,
-        dispatch,
-      ) => {
+      openEmojiSuggestions: (
+        { from, to }: Partial<FromToParams> = Object.create(null),
+      ): ProsemirrorCommandFunction => (state, dispatch) => {
         if (dispatch) {
           dispatch(state.tr.insertText(suggestionCharacter, from, to));
         }

--- a/@remirror/extension-image/src/image-extension.ts
+++ b/@remirror/extension-image/src/image-extension.ts
@@ -2,11 +2,11 @@ import {
   Attrs,
   bool,
   Cast,
-  CommandFunction,
   CommandNodeTypeParams,
   isElementDOMNode,
   NodeExtension,
   NodeExtensionSpec,
+  ProsemirrorCommandFunction,
 } from '@remirror/core';
 import { ResolvedPos } from 'prosemirror-model';
 
@@ -52,7 +52,7 @@ export class ImageExtension extends NodeExtension {
 
   public commands({ type }: CommandNodeTypeParams) {
     return {
-      insertImage: (attrs?: Attrs): CommandFunction => (state, dispatch) => {
+      insertImage: (attrs?: Attrs): ProsemirrorCommandFunction => (state, dispatch) => {
         const { selection } = state;
         const position = hasCursor(selection) ? selection.$cursor.pos : selection.$to.pos;
         const node = type.create(attrs);

--- a/docs/guides/custom-keys.mdx
+++ b/docs/guides/custom-keys.mdx
@@ -1,0 +1,77 @@
+---
+title: Advanced Guide
+---
+
+The following is an example where the enter key can be customised to ignore all lower priority `Enter` key
+bindings.
+
+The `next` method allows full control beyond the return value. It allows both calling all lower priority key
+bindings regardless of whether true or false has been called.
+
+```tsx
+import { BaseExtensionOptions, Extension, KeyBindings } from '@remirror/core';
+
+interface CustomKeymapExtensionOptions extends BaseExtensionOptions {
+  override: boolean;
+}
+
+export class CustomKeymapExtension extends Extension<CustomKeymapExtensionOptions> {
+  /**
+   * Shorthand method for creating the `BaseKeymapExtension`
+   */
+  public static of(options: CustomKeymapExtensionOptions) {
+    return new CustomKeymapExtension(options);
+  }
+
+  get name() {
+    return 'customKeymap' as const;
+  }
+
+  get defaultOptions() {
+    return {
+      override: false,
+    };
+  }
+
+  /**
+   * Injects the baseKeymap into the editor.
+   */
+  public keys(): KeyBindings {
+    const { override } = this.options;
+
+    return {
+      Enter({ next }) {
+        if (override) {
+          // No other commands will be run
+          return true;
+        }
+
+        next(); // Runs all lower priority commands
+
+        return true;
+      },
+    };
+  }
+}
+```
+
+### Usage
+
+To use the above example you could do the following.
+
+```ts
+import { ExtensionManager } from '@remirror/core';
+import { baseExtensions } from '@remirror/core-extensions';
+
+import { CustomKeymapExtension } from './custom-keymap-extension';
+
+const manager = ExtensionManager.of([
+  ...baseExtensions,
+  { priority: 1, extension: CustomKeymapExtension.of({ override: true }) },
+]);
+```
+
+This manager can now be used to create an editor where the baseKeymap for the `Enter` key is overriden.
+
+If override is set to `false`, the method will call all lower priority keybindings while still allowing the
+behaviour you want for the extension.

--- a/docs/package.json
+++ b/docs/package.json
@@ -79,6 +79,6 @@
     "@types/styled-system__css": "^5.0.4",
     "@types/theme-ui": "^0.2.2",
     "@types/theme-ui__components": "^0.2.0",
-    "type-fest": "^0.8.1"
+    "type-fest": "^0.10.0"
   }
 }

--- a/docs/src/sidebar.mdx
+++ b/docs/src/sidebar.mdx
@@ -4,6 +4,7 @@
   - [Quick start](/guides/quickstart)
   - [Controlled](/guides/controlled)
   - [Advanced guide](/guides/advanced-guide)
+  - [Custom Keys](/guides/custom-keys)
 - [Showcase](/showcase)
   - [Social editor](/showcase/social)
   - [Wysiwyg editor](/showcase/wysiwyg)

--- a/packages/jest-prosemirror/src/jest-prosemirror-matchers.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-matchers.ts
@@ -1,5 +1,5 @@
 import { bool } from '@remirror/core-helpers';
-import { CommandFunction, ProsemirrorNode as _ProsemirrorNode } from '@remirror/core-types';
+import { ProsemirrorCommandFunction, ProsemirrorNode as _ProsemirrorNode } from '@remirror/core-types';
 import { TaggedProsemirrorNode } from 'prosemirror-test-builder';
 
 import { apply } from './jest-prosemirror-editor';
@@ -7,7 +7,11 @@ import { transformsNodeFailMessage, transformsNodePassMessage } from './jest-pro
 import { CommandTransformation } from './jest-prosemirror-types';
 
 export const prosemirrorMatchers = {
-  toTransformNode(this: jest.MatcherUtils, command: CommandFunction, { from, to }: CommandTransformation) {
+  toTransformNode(
+    this: jest.MatcherUtils,
+    command: ProsemirrorCommandFunction,
+    { from, to }: CommandTransformation,
+  ) {
     if (typeof command !== 'function') {
       return {
         message: () => `Please specify a valid command`,

--- a/packages/jest-remirror/src/jest-remirror-types.ts
+++ b/packages/jest-remirror/src/jest-remirror-types.ts
@@ -3,7 +3,6 @@ import {
   AnyExtension,
   Attrs,
   AttrsParams,
-  CommandFunction,
   EditorSchema,
   EditorState,
   EditorStateParams,
@@ -13,6 +12,7 @@ import {
   HelpersFromExtensions,
   MarkExtension,
   NodeExtension,
+  ProsemirrorCommandFunction,
   ProsemirrorNode,
   SchemaFromExtensions,
 } from '@remirror/core';
@@ -237,7 +237,7 @@ export interface AddContentReturn<GExtension extends AnyExtension>
    *
    * @param command - the command function to run with the current state and view
    */
-  dispatchCommand(command: CommandFunction): AddContentReturn<GExtension>;
+  dispatchCommand(command: ProsemirrorCommandFunction): AddContentReturn<GExtension>;
 
   /**
    * Fires a custom event at the specified dom node.

--- a/packages/prosemirror-suggest/src/suggest-utils.ts
+++ b/packages/prosemirror-suggest/src/suggest-utils.ts
@@ -1,9 +1,9 @@
 import { NULL_CHARACTER } from '@remirror/core-constants';
 import { bool, findMatches, isUndefined } from '@remirror/core-helpers';
 import {
-  CommandFunction,
   EditorStateParams,
   MakeOptional,
+  ProsemirrorCommandFunction,
   ResolvedPosParams,
   TextParams,
 } from '@remirror/core-types';
@@ -277,8 +277,8 @@ interface TransformKeyBindingsParams {
 export const transformKeyBindings = ({
   bindings,
   params,
-}: TransformKeyBindingsParams): Record<string, CommandFunction> => {
-  const keys: Record<string, CommandFunction> = Object.create(null);
+}: TransformKeyBindingsParams): Record<string, ProsemirrorCommandFunction> => {
+  const keys: Record<string, ProsemirrorCommandFunction> = Object.create(null);
   return Object.entries(bindings).reduce((prev, [key, method]) => {
     return {
       ...prev,

--- a/support/dts-jest/__snapshots__/extension-manager.dts.ts.snap
+++ b/support/dts-jest/__snapshots__/extension-manager.dts.ts.snap
@@ -16,7 +16,7 @@ exports[`historyActions.undo (type) should match snapshot 1`] = `"ActionMethod<[
 
 exports[`historyActions.undo({}) (type) should match snapshot 1`] = `"Expected 0 arguments, but got 1."`;
 
-exports[`manager1.data.actions (type) should match snapshot 1`] = `"MapCommandToAction<{}> & MapCommandToAction<{ undo: () => CommandFunction<any>; redo: () => CommandFunction<any>; }> & MapCommandToAction<{ addPositionTracker: (params: AddPositionTrackerParams) => CommandFunction<any>; removePositionTracker: (params: RemovePositionTrackerParams) => CommandFunction<any>; clearPositionTrackers: (params: void) => CommandFunction<any>; }> & MapCommandToAction<{ createParagraph: (attrs?: Attrs<{ align?: \\"left\\" | \\"right\\" | \\"center\\" | \\"justify\\" | null | undefined; indent?: number | null | undefined; lineSpacing?: string | null | undefined; id?: string | null | undefined; }> | undefined) => (state: EditorState<EditorSchema<string, string>>, dispatch?: ((tr: Transaction<EditorSchema<string, string>>) => void) | undefined) => boolean; }> & MapCommandToAction<{ bold: () => (state: EditorState<EditorSchema<string, string>>, dispatch?: ((tr: Transaction<EditorSchema<string, string>>) => void) | undefined) => boolean; }> & MapCommandToAction<{ toggleCodeBlock: () => CommandFunction<any>; }>"`;
+exports[`manager1.data.actions (type) should match snapshot 1`] = `"MapCommandToAction<{}> & MapCommandToAction<{ undo: () => ProsemirrorCommandFunction<any>; redo: () => ProsemirrorCommandFunction<any>; }> & MapCommandToAction<{ addPositionTracker: (params: AddPositionTrackerParams) => ProsemirrorCommandFunction<any>; removePositionTracker: (params: RemovePositionTrackerParams) => ProsemirrorCommandFunction<any>; clearPositionTrackers: (params: void) => ProsemirrorCommandFunction<any>; }> & MapCommandToAction<{ createParagraph: (attrs?: Attrs<{ align?: \\"left\\" | \\"right\\" | \\"center\\" | \\"justify\\" | null | undefined; indent?: number | null | undefined; lineSpacing?: string | null | undefined; id?: string | null | undefined; }> | undefined) => (state: EditorState<EditorSchema<string, string>>, dispatch?: ((tr: Transaction<EditorSchema<string, string>>) => void) | undefined) => boolean; }> & MapCommandToAction<{ bold: () => (state: EditorState<EditorSchema<string, string>>, dispatch?: ((tr: Transaction<EditorSchema<string, string>>) => void) | undefined) => boolean; }> & MapCommandToAction<{ toggleCodeBlock: () => ProsemirrorCommandFunction<any>; }>"`;
 
 exports[`manager1.data.actions.addPositionTracker (type) should match snapshot 1`] = `"ActionMethod<[AddPositionTrackerParams]>"`;
 
@@ -42,7 +42,7 @@ exports[`public commands() {
     Type '{ nothing: (param: string) => () => string; }' is not assignable to type 'ExtensionCommandReturn'.
       Property 'nothing' is incompatible with index signature.
         Type '(param: string) => () => string' is not assignable to type 'ExtensionCommandFunction'.
-          Call signature return types '() => string' and 'CommandFunction<any>' are incompatible.
+          Call signature return types '() => string' and 'ProsemirrorCommandFunction<any>' are incompatible.
             Type 'string' is not assignable to type 'boolean'."
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15308,6 +15308,11 @@ map-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
   integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
+map-obj@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
+  integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
+
 map-or-similar@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
@@ -23136,6 +23141,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.10.0.tgz#7f06b2b9fbfc581068d1341ffabd0349ceafc642"
+  integrity sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==
 
 type-fest@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
## Description

Keys now use the new api for `CommandFunction` which provides a `next` method. This method allows for better control when deciding whether or not to defer to the `next` keybinding in the chain.

To override, create a new keybinding with another extension. Make sure the extension is created with a higher priority. The keybinding you create can either return true or false. By default if it returns true, no other keybindings will run. However if it returns `false` all other keybindings will be run until one returns `true`

`next` basically calls the every other keybinding regardless of what you return. It gives you full control of how the bindings are called.

**BREAKING CHANGE** - `CommandFunction` now takes in one parameter with the `dispatch`, `state`, and `view` properties. A new type `ProsemirrorCommandFunction` replaces the previous functionality. 

Closes #204

## Example

The following is an example where the enter key can be customised to ignore all lower priority `Enter` key bindings.

The `next` method allows full control beyond the return value. It allows both calling all lower priority key
bindings regardless of whether true or false has been called.

```tsx
import { BaseExtensionOptions, Extension, KeyBindings } from '@remirror/core';

interface CustomKeymapExtensionOptions extends BaseExtensionOptions {
  override: boolean;
}

export class CustomKeymapExtension extends Extension<CustomKeymapExtensionOptions> {
  /**
   * Shorthand method for creating the `BaseKeymapExtension`
   */
  public static of(options: CustomKeymapExtensionOptions) {
    return new CustomKeymapExtension(options);
  }

  get name() {
    return 'customKeymap' as const;
  }

  get defaultOptions() {
    return {
      override: false,
    };
  }

  /**
   * Injects the baseKeymap into the editor.
   */
  public keys(): KeyBindings {
    const { override } = this.options;
    return {
      Enter({ next }) {
        if (override) {
          // No other commands will be run
          return true;
        }
        next(); // Runs all lower priority commands
        return true;
      },
    };
  }
}
```

## Usage

To use the above example you could do the following.

```ts
import { ExtensionManager } from '@remirror/core';
import { baseExtensions } from '@remirror/core-extensions';
import { CustomKeymapExtension } from './custom-keymap-extension';

const manager = ExtensionManager.of([
  ...baseExtensions,
  { priority: 1, extension: CustomKeymapExtension.of({ override: true }) },
]);
```

This manager can now be used to create an editor where the `baseKeymap` for the `Enter` key is overridden.

If override is set to `false`, the method will call all lower priority keybindings while still allowing the behaviour you want for the extension.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- prettier-ignore-start -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

<!-- prettier-ignore-end -->
