### PR TITLE
feat(core): isEnabled via commands with dispatch=undefined

### DIFF
--- a/.changeset/silver-impalas-provide.md
+++ b/.changeset/silver-impalas-provide.md
@@ -1,0 +1,11 @@
+---
+'@remirror/core-types': minor
+'@remirror/core': minor
+'@remirror/core-extensions': patch
+---
+
+- Auto defined `isEnabled` via commands with `dispatch=undefined`.
+- `HistoryExtension` now checks that whether `dispatch=undefined`.
+- Remove `CommandStatusCheck`.
+- Add new type `ExtensionIsActiveFunction` which doesn't take the command name.
+- Remove `isEnabled` from `Extension` interface.

--- a/@remirror/core-extensions/src/extensions/history-extension.ts
+++ b/@remirror/core-extensions/src/extensions/history-extension.ts
@@ -80,7 +80,7 @@ export class HistoryExtension extends Extension<HistoryExtensionOptions> {
       const { getState, getDispatch } = this.options;
 
       const wrappedState = isFunction(getState) ? getState() : state;
-      const wrappedDispatch = isFunction(getDispatch) ? getDispatch() : dispatch;
+      const wrappedDispatch = isFunction(getDispatch) && dispatch ? getDispatch() : dispatch;
 
       return method(wrappedState, wrappedDispatch, view);
     };

--- a/@remirror/core-types/src/core-types.ts
+++ b/@remirror/core-types/src/core-types.ts
@@ -243,6 +243,7 @@ export interface ExtensionManagerInitParams<GSchema extends EditorSchema = any> 
    * Retrieve the portal container
    */
   portalContainer: PortalContainer;
+
   /**
    * Retrieve the editor state via a function call
    */
@@ -303,20 +304,7 @@ export interface ViewExtensionManagerParams<GSchema extends EditorSchema = any>
 
 export type ExtensionCommandFunction = (...args: any[]) => ProsemirrorCommandFunction;
 
-export interface CommandStatusFunctionParams<GCommand extends string> extends Partial<AttrsParams> {
-  /**
-   * When provided check the status of this particular command
-   */
-  command?: GCommand;
-}
-export type CommandStatusFunction<GCommand extends string> = (
-  params: CommandStatusFunctionParams<GCommand>,
-) => boolean;
-
-/**
- * The return signature for an extension's `isActive` and `isEnabled` method
- */
-export type CommandStatusCheck<GCommand extends string = string> = CommandStatusFunction<GCommand>;
+export type ExtensionIsActiveFunction = (params: Partial<AttrsParams>) => boolean;
 
 /**
  * The return signature for an extensions command method.

--- a/@remirror/core/src/extension.ts
+++ b/@remirror/core/src/extension.ts
@@ -6,10 +6,10 @@ import {
   Attrs,
   AttrsWithClass,
   BaseExtensionOptions,
-  CommandStatusCheck,
   CommandTypeParams,
   ExtensionCommandReturn,
   ExtensionHelperReturn,
+  ExtensionIsActiveFunction,
   ExtensionManagerParams,
   ExtensionManagerTypeParams,
   ExtraAttrs,
@@ -411,23 +411,9 @@ export interface Extension<GOptions extends BaseExtensionOptions = BaseExtension
    * Determines whether this extension is currently active (only applies to Node
    * Extensions and Mark Extensions).
    *
-   * If a command name is provided (to the return function) then this method
-   * should return true if that command is currently active. Conceptually this
-   * doesn't always make sense and in those cases it should be save to just
-   * return false.
-   *
    * @param params - extension manager params
    */
-  isActive?(params: ExtensionManagerParams): CommandStatusCheck;
-
-  /**
-   * Determines whether this extension is enabled. If a command name is provided
-   * then it should return a value determining whether that command is able to
-   * be run.
-   *
-   * @param params - extension manager parameters
-   */
-  isEnabled?(params: ExtensionManagerParams): CommandStatusCheck;
+  isActive?(params: ExtensionManagerParams): ExtensionIsActiveFunction;
 
   /**
    * Add key bindings for this extension.

--- a/@remirror/core/src/mark-extension.ts
+++ b/@remirror/core/src/mark-extension.ts
@@ -1,7 +1,7 @@
 import { ExtensionType } from '@remirror/core-constants';
 import {
-  CommandStatusCheck,
   EditorSchema,
+  ExtensionIsActiveFunction,
   ExtensionManagerMarkTypeParams,
   MarkExtensionOptions,
   MarkExtensionSpec,
@@ -57,17 +57,7 @@ export abstract class MarkExtension<
    *
    * @param params - see {@link @remirror/core-types#ExtensionManagerMarkTypeParams}
    */
-  public isActive({ getState, type }: ExtensionManagerMarkTypeParams): CommandStatusCheck {
+  public isActive({ getState, type }: ExtensionManagerMarkTypeParams): ExtensionIsActiveFunction {
     return () => isMarkActive({ state: getState(), type });
-  }
-
-  /**
-   * By default all marks extensions are set to be enabled. In your extension
-   * this can be overridden and set to false based on the context.
-   *
-   * @param _ - see see {@link @remirror/core-types#ExtensionManagerMarkTypeParams}
-   */
-  public isEnabled(_: ExtensionManagerMarkTypeParams): CommandStatusCheck {
-    return () => true;
   }
 }

--- a/@remirror/core/src/node-extension.ts
+++ b/@remirror/core/src/node-extension.ts
@@ -1,7 +1,7 @@
 import { ExtensionType } from '@remirror/core-constants';
 import {
-  CommandStatusCheck,
   EditorSchema,
+  ExtensionIsActiveFunction,
   ExtensionManagerNodeTypeParams,
   NodeExtensionOptions,
   NodeExtensionSpec,
@@ -37,13 +37,9 @@ export abstract class NodeExtension<
    */
   public abstract readonly schema: NodeExtensionSpec;
 
-  public isActive({ getState, type }: ExtensionManagerNodeTypeParams): CommandStatusCheck {
+  public isActive({ getState, type }: ExtensionManagerNodeTypeParams): ExtensionIsActiveFunction {
     return ({ attrs }) => {
       return isNodeActive({ state: getState(), type, attrs });
     };
-  }
-
-  public isEnabled(_: ExtensionManagerNodeTypeParams): CommandStatusCheck {
-    return () => true;
   }
 }

--- a/@remirror/editor-wysiwyg/src/components/wysiwyg-menu.tsx
+++ b/@remirror/editor-wysiwyg/src/components/wysiwyg-menu.tsx
@@ -126,7 +126,7 @@ interface MenuItemProps extends Partial<WithPaddingProps> {
 const MenuItem: FC<MenuItemProps> = ({ state, onClick, Icon, variant, disabled = false, index }) => {
   return (
     <IconButton onClick={onClick} state={state} disabled={disabled} index={index}>
-      <Icon variant={variant} />
+      <Icon variant={variant} styles={{ color: disabled ? 'gray' : undefined }} />
     </IconButton>
   );
 };

--- a/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/@remirror/extension-code-block/src/code-block-extension.ts
@@ -1,6 +1,5 @@
 import {
   CommandNodeTypeParams,
-  CommandStatusCheck,
   ExtensionManagerNodeTypeParams,
   findParentNodeOfType,
   GetAttrs,
@@ -172,34 +171,6 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
        * ```
        */
       formatCodeBlock: formatCodeBlockFactory({ type, formatter, defaultLanguage, supportedLanguages }),
-    };
-  }
-
-  public active({ type, getState }: CommandNodeTypeParams): CommandStatusCheck {
-    return ({ command }) => {
-      switch (command) {
-        case 'updateCodeBlock':
-        case 'createCodeBlock':
-        case 'formatCodeBlock': // The formatter could be run to check but this seems expensive
-          return isNodeActive({ state: getState(), type });
-
-        default:
-          return false;
-      }
-    };
-  }
-
-  public enabled({ type, getState }: CommandNodeTypeParams): CommandStatusCheck {
-    return ({ command }) => {
-      switch (command) {
-        case 'toggleCodeBlock':
-          return true;
-        case 'createCodeBlock':
-          return !isNodeActive({ state: getState(), type });
-
-        default:
-          return true;
-      }
     };
   }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @remirror/docs
 
 ## 0.0.1
+
 ### Patch Changes
 
 - Updated dependencies [24f83413]

--- a/e2e/CHANGELOG.md
+++ b/e2e/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @remirror/e2e
 
 ## 0.0.1
+
 ### Patch Changes
 
 - Updated dependencies [24f83413]


### PR DESCRIPTION
## Description

This PR changes code related to Extension.isActive() and Extension.isEnabled(). 

The action.isActive() and action.isEnabled() behaviour remains the same so this should not break code that doesn't access extensions directly.

### Change 1
Before this PR extensions by default would return true when calling Extension.isEnabled() and most extensions never implemented a custom Extension.isEnabled(). This resulted in issues such as #226 where action.isEnabled() would be true but command could not be run successfully. 

Extensions no longer need to implement isEnabled. It is provided by extension manager by calling commands with dispatch=undefined [as Prosemirror intended](https://prosemirror.net/docs/guide/#commands). It's now much more difficult to have action.isEnabled() return true unless a command can be successfully run. 

### Change 2

Extension.isActive previously allowed passing in a command name argument in the same way as Extension.isEnabled. I could not find any uses of this feature. I checked scrumpy/tiptap code and they only define a single isActive method per extension, not per action command. It seems to me that the main reason why isActive allowed passing in command names was because isEnabled allowed it too.

I got rid of this feature in this PR. It doesn't change the action.isActive() signature so if people later feel this was actually useful, it can be added in back later. Unless there was a reason for this that I missed?

### ~Change 3~

~History extension allowed to override getState() and dispatch methods which made it impossible to call a command with dispatch=undefined. I could not find any uses of this feature but if this is still needed I think a better way would be to have the extension manager provide this functionality for all extensions.~
 
## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- prettier-ignore-start -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

<!-- prettier-ignore-end -->

Closes #226 