### PR TITLE
fix: compat across build systems

### DIFF
--- a/@remirror/core-helpers/src/core-helpers.ts
+++ b/@remirror/core-helpers/src/core-helpers.ts
@@ -1,4 +1,4 @@
-import { all as merge } from 'deepmerge';
+import deepmerge from 'deepmerge';
 import fastDeepEqual from 'fast-deep-equal';
 import fastMemoize, { MemoizeFunc } from 'fast-memoize';
 import nano from 'nanoid';
@@ -706,7 +706,7 @@ export class Merge {
  * replaces it's key with a completely new object
  */
 export const deepMerge = <GType = any>(...objects: Array<PlainObject | unknown[]>): GType => {
-  return merge<GType>(objects as any, { isMergeableObject: isPlainObject });
+  return deepmerge.all<GType>(objects as any, { isMergeableObject: isPlainObject });
 };
 
 interface ClampParams {


### PR DESCRIPTION
## Description

Rollup doesn't recognize all being output by deepmerge. This solves that problem so that I can use prosemirror in a rollup environment. 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- prettier-ignore-start -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully. (fails on unrelated graphql stuff)
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

<!-- prettier-ignore-end -->