### PR TITLE
feat(core-utils): allow toggling between bullet and ordered list

### DIFF
--- a/.changeset/eighty-lies-judge.md
+++ b/.changeset/eighty-lies-judge.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Allow toggling between bullet and ordered list and vice versa.

--- a/.changeset/eighty-lies-judge.md
+++ b/.changeset/eighty-lies-judge.md
@@ -2,4 +2,6 @@
 '@remirror/core-utils': minor
 ---
 
-Allow toggling between bullet and ordered list and vice versa.
+- Allow toggling between bullet and ordered list and vice versa.
+- Add depth to findParentNode(), findPositionOfNodeBefore(), findPositionOfNodeAfter().
+- Fix findPositionOfNodeBefore(), findPositionOfNodeAfter() returning incorrect start position.

--- a/@remirror/core-utils/src/__tests__/command-utils.spec.ts
+++ b/@remirror/core-utils/src/__tests__/command-utils.spec.ts
@@ -1,4 +1,4 @@
-import { atomInline, blockquote, doc, h1, li, p, schema, strong, ul } from 'jest-prosemirror';
+import { atomInline, blockquote, doc, h1, li, ol, p, schema, strong, ul } from 'jest-prosemirror';
 
 import {
   removeMark,
@@ -130,9 +130,35 @@ describe('toggleBlockItem', () => {
 });
 
 describe('toggleList', () => {
-  it('toggles to the specified list type', () => {
+  it('toggles pagaraph to bullet list', () => {
     const from = doc(p('make <cursor>list'));
     const to = doc(ul(li(p('make list'))));
+    expect(toggleList(schema.nodes.bulletList, schema.nodes.listItem)).toTransformNode({
+      from,
+      to,
+    });
+  });
+  it('toggles bullet list to paragraph', () => {
+    const from = doc(ul(li(p('make <cursor>list'))));
+    const to = doc(p('make list'));
+    expect(toggleList(schema.nodes.bulletList, schema.nodes.listItem)).toTransformNode({
+      from,
+      to,
+    });
+  });
+  it('toggles ordered list to bullet list', () => {
+    const from = doc(ol(li(p('make <cursor>list'))));
+    const to = doc(ul(li(p('make list'))));
+    expect(toggleList(schema.nodes.bulletList, schema.nodes.listItem)).toTransformNode({
+      from,
+      to,
+    });
+  });
+  it('toggles nested ordered list to bullet list', () => {
+    const fromNested = ol(li('1.1'), li(p('1.2<cursor>')), li(p('1.3')));
+    const from = doc(ol(li(p('1'), fromNested), li(p('2'))));
+    const toNested = ul(li('1.1'), li(p('1.2')), li(p('1.3')));
+    const to = doc(ol(li(p('1'), toNested), li(p('2'))));
     expect(toggleList(schema.nodes.bulletList, schema.nodes.listItem)).toTransformNode({
       from,
       to,

--- a/@remirror/core-utils/src/__tests__/command-utils.spec.ts
+++ b/@remirror/core-utils/src/__tests__/command-utils.spec.ts
@@ -138,6 +138,7 @@ describe('toggleList', () => {
       to,
     });
   });
+
   it('toggles bullet list to paragraph', () => {
     const from = doc(ul(li(p('make <cursor>list'))));
     const to = doc(p('make list'));
@@ -146,6 +147,7 @@ describe('toggleList', () => {
       to,
     });
   });
+
   it('toggles ordered list to bullet list', () => {
     const from = doc(ol(li(p('make <cursor>list'))));
     const to = doc(ul(li(p('make list'))));
@@ -154,6 +156,7 @@ describe('toggleList', () => {
       to,
     });
   });
+
   it('toggles nested ordered list to bullet list', () => {
     const fromNested = ol(li('1.1'), li(p('1.2<cursor>')), li(p('1.3')));
     const from = doc(ol(li(p('1'), fromNested), li(p('2'))));


### PR DESCRIPTION
## Description

### Change Set 1
toggleList() from command-utils is now able to convert between list types. The implementation has been taken [from tiptap](https://github.com/scrumpy/tiptap/blob/3102d00a626be03c036122128d79b995a9d67f77/packages/tiptap-commands/src/commands/toggleList.js). Also, more units tests for toggleLists() have been added.

### Change Set 2
Tiptatp's toggleList implementation required findParentNode() to return a depth value, hence this parameter was implemented and tests were updated to include it. To be consistent, this also has been implemented for findPositionOfNodeBefore/findPositionOfNodeAfter. While doing so I noticed some missing tests and (I think) incorrect start position being returned by  findPositionOfNodeBefore/findPositionOfNodeAfter.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- prettier-ignore-start -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

<!-- prettier-ignore-end -->

## Screenshots

![toggle-list](https://user-images.githubusercontent.com/5213953/75271791-b182d680-57f4-11ea-8ebf-57c58a616575.gif)
