### PR TITLE
fix(core): Allow empty string default value for extraAttrs

### DIFF
--- a/.changeset/loud-schools-breathe.md
+++ b/.changeset/loud-schools-breathe.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Allow empty string default value for extraAttrs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
-          coverageCommand: 'echo Coverage'
+          coverageCommand: "echo Coverage"
           debug: false
 
       - name: build project
@@ -76,7 +76,7 @@ jobs:
 
       - name: notify slack
         uses: 8398a7/action-slack@v2
-        if: always() # Pick up events even if the job fails or is canceled.
+        if: github.ref == 'refs/heads/canary'
         with:
           status: ${{ job.status }}
           author_name: Remirror GitHub CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
-          coverageCommand: "echo Coverage"
+          coverageCommand: 'echo Coverage'
           debug: false
 
       - name: build project

--- a/@remirror/core/src/__tests__/node-extension.spec.ts
+++ b/@remirror/core/src/__tests__/node-extension.spec.ts
@@ -43,6 +43,14 @@ describe('extraAttrs', () => {
             getAttrs: domNode => (domNode as Element).getAttribute('simple'),
             name: 'crazy',
           },
+          {
+            name: 'foo',
+            default: '',
+          },
+          {
+            name: 'bar',
+            default: null,
+          },
         ],
       }),
       priority: 1,
@@ -58,6 +66,8 @@ describe('extraAttrs', () => {
       title: { default: '' },
       run: { default: 'failure' },
       crazy: { default: 'yo' },
+      foo: { default: '' },
+      bar: { default: null },
     });
   });
 

--- a/@remirror/core/src/extension.ts
+++ b/@remirror/core/src/extension.ts
@@ -146,7 +146,7 @@ export abstract class Extension<GOptions extends BaseExtensionOptions, GType = n
         attrs[item] = { default: fallback };
       } else {
         const { name, default: def } = item;
-        attrs[name] = def ? { default: def } : {};
+        attrs[name] = def !== undefined ? { default: def } : {};
       }
     }
     return attrs;


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail and reference any issues it addresses-->

`ExtraAttrsObject.default` should be a `sting`, `null` or `undefined` value. Based on the [definition](https://github.com/remirror/remirror/blob/c4645570d3e128d1decf3b9e904684263df7bf0c/%40remirror/core-types/src/base-types.ts#L224-L229), an attr is a required only if its `default` is  `undefined`. 

However, when `default` is an empty string (or `null`), this attr becomes a required unexpectedly. 

This PR fixs it.



## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- prettier-ignore-start -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

<!-- prettier-ignore-end -->

