### PR TITLE
feat: add `focus()` method to `RemirrorContext`

### DIFF
--- a/.changeset/bright-foxes-report.md
+++ b/.changeset/bright-foxes-report.md
@@ -1,0 +1,23 @@
+---
+'@remirror/react': minor
+---
+
+Add a `focus` method to the remirror editor context object. It allows focusing at a provided position which
+can be `start`, `end`, a specific position or a range using the `{from: number; to: number}` type signature.
+
+To use this run
+
+```tsx
+import { useRemirrorContext } from '@remirror/react';
+
+const MyEditor = () => {
+  const { focus, getRootProps } = useRemirrorContext();
+
+  useEffect(() => {
+    focus('end'); // Autofocus to the end once
+  }, []);
+};
+return <div {...getRootProps()} />;
+```
+
+Resolves the initial issue raised in #229.

--- a/@remirror/react/src/hooks/context-hooks.ts
+++ b/@remirror/react/src/hooks/context-hooks.ts
@@ -11,7 +11,7 @@ import { InjectedRemirrorProps, UsePositionerParams } from '../react-types';
  * import { RemirrorProvider, useRemirrorContext } from 'remirror';
  *
  * function HooksComponent(props) {
- *   // This pull the remirror props out from the context.
+ *   // This pulls the remirror props out from the context.
  *   const { getPositionerProps } = useRemirrorContext();
  *
  *   return <Menu {...getPositionerProps()} />;

--- a/@remirror/react/src/react-types.ts
+++ b/@remirror/react/src/react-types.ts
@@ -11,6 +11,7 @@ import {
   EditorViewParams,
   ElementParams,
   ExtensionManager,
+  FromToParams,
   HelpersFromExtensions,
   ObjectNode,
   OptionsOfExtension,
@@ -405,6 +406,11 @@ export interface InjectedRemirrorProps<GExtension extends AnyExtension = any> {
    * The previous and next state
    */
   state: CompareStateParams<SchemaFromExtensions<GExtension>>;
+
+  /**
+   * Focus the editor at the `start` | `end` a specific position or at a valid range between `{ from, to }`
+   */
+  focus(position?: FromToParams | number | 'start' | 'end'): void;
 }
 
 /**


### PR DESCRIPTION
## Description

Add a `focus` method to the remirror editor context object. It allows focusing at a provided position which can be `start`, `end`, a specific position or a range using the `{from: number; to: number}` type signature.

To use this run the following.

```tsx
import { useRemirrorContext } from '@remirror/react';

const MyEditor = () => {
  const { focus, getRootProps } = useRemirrorContext();

  useEffect(() => {
    focus('end'); // Autofocus to the end of the editor text when this component loads.
  }, []);
};
return <div {...getRootProps()} />;
```

Resolves the initial issue raised in #229.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
