### PR TITLE
feat(react): enable custom `autoFocus`

### DIFF
--- a/.changeset/curvy-fireants-destroy.md
+++ b/.changeset/curvy-fireants-destroy.md
@@ -1,0 +1,6 @@
+---
+'@remirror/react': minor
+---
+
+Add custom arguments to `autoFocus` props. The same arguments that can added to the `focus()` context method
+can now be passed as a prop.

--- a/@remirror/react/src/components/remirror.tsx
+++ b/@remirror/react/src/components/remirror.tsx
@@ -48,6 +48,7 @@ import {
   BaseListenerParams,
   CalculatePositionerParams,
   EditorStateEventListenerParams,
+  FocusType,
   GetPositionerPropsConfig,
   GetPositionerReturn,
   GetRootPropsConfig,
@@ -531,7 +532,7 @@ export class Remirror<GExtension extends AnyExtension = any> extends PureCompone
     const { autoFocus, onFirstRender, onStateChange } = this.props;
     this.addProsemirrorViewToDom(this.editorRef, this.view.dom);
     if (autoFocus) {
-      this.view.focus();
+      this.focus(autoFocus);
     }
 
     if (onFirstRender) {
@@ -699,8 +700,12 @@ export class Remirror<GExtension extends AnyExtension = any> extends PureCompone
   /**
    * Set the focus for the editor.
    */
-  private readonly focus = (position?: FromToParams | number | 'start' | 'end') => {
-    if (this.view.hasFocus() && !position) {
+  private readonly focus = (position?: FocusType) => {
+    if (position === false) {
+      return;
+    }
+
+    if (this.view.hasFocus() && (position === undefined || position === true)) {
       return;
     }
 
@@ -712,7 +717,7 @@ export class Remirror<GExtension extends AnyExtension = any> extends PureCompone
     /** Ensure the selection is within the current document range */
     const clampToDoc = (value: number) => clamp({ min: 0, max: doc.content.size, value });
 
-    if (position === undefined) {
+    if (position === undefined || position === true) {
       pos = { from, to };
     } else if (position === 'start') {
       pos = 0;

--- a/@remirror/react/src/react-types.ts
+++ b/@remirror/react/src/react-types.ts
@@ -31,6 +31,16 @@ import {
 } from '@remirror/core';
 import { ReactNode, Ref } from 'react';
 
+/**
+ * The type of arguments acceptable for the focus parameter.
+ *
+ * - Can be a selection of `{ from, to }
+ * - A single position with a `number`
+ * - `start` | `end`
+ * - `true` which sets the focus to the current position or start.
+ */
+export type FocusType = FromToParams | number | 'start' | 'end' | boolean;
+
 export interface RemirrorProps<GExtension extends AnyExtension = any> extends StringHandlerParams {
   /**
    * Pass in the extension manager.
@@ -86,7 +96,7 @@ export interface RemirrorProps<GExtension extends AnyExtension = any> extends St
    *
    * @defaultValue false
    */
-  autoFocus?: boolean;
+  autoFocus?: FocusType;
 
   /**
    * An event listener which is called whenever the editor gains focus.
@@ -410,7 +420,7 @@ export interface InjectedRemirrorProps<GExtension extends AnyExtension = any> {
   /**
    * Focus the editor at the `start` | `end` a specific position or at a valid range between `{ from, to }`
    */
-  focus(position?: FromToParams | number | 'start' | 'end'): void;
+  focus(position?: FocusType): void;
 }
 
 /**

--- a/docs/generated/gatsby.ts
+++ b/docs/generated/gatsby.ts
@@ -1617,12 +1617,14 @@ export type Query = {
   readonly allDirectory: DirectoryConnection;
   readonly sitePage: Maybe<SitePage>;
   readonly allSitePage: SitePageConnection;
+  readonly site: Maybe<Site>;
+  readonly allSite: SiteConnection;
   readonly imageSharp: Maybe<ImageSharp>;
   readonly allImageSharp: ImageSharpConnection;
   readonly mdx: Maybe<Mdx>;
   readonly allMdx: MdxConnection;
-  readonly site: Maybe<Site>;
-  readonly allSite: SiteConnection;
+  readonly siteBuildMetadata: Maybe<SiteBuildMetadata>;
+  readonly allSiteBuildMetadata: SiteBuildMetadataConnection;
   readonly sitePlugin: Maybe<SitePlugin>;
   readonly allSitePlugin: SitePluginConnection;
 };
@@ -1748,6 +1750,26 @@ export type Query_allSitePageArgs = {
   limit: Maybe<Scalars['Int']>;
 };
 
+export type Query_siteArgs = {
+  buildTime: Maybe<DateQueryOperatorInput>;
+  siteMetadata: Maybe<SiteSiteMetadataFilterInput>;
+  port: Maybe<IntQueryOperatorInput>;
+  host: Maybe<StringQueryOperatorInput>;
+  polyfill: Maybe<BooleanQueryOperatorInput>;
+  pathPrefix: Maybe<StringQueryOperatorInput>;
+  id: Maybe<StringQueryOperatorInput>;
+  parent: Maybe<NodeFilterInput>;
+  children: Maybe<NodeFilterListInput>;
+  internal: Maybe<InternalFilterInput>;
+};
+
+export type Query_allSiteArgs = {
+  filter: Maybe<SiteFilterInput>;
+  sort: Maybe<SiteSortInput>;
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+};
+
 export type Query_imageSharpArgs = {
   fixed: Maybe<ImageSharpFixedFilterInput>;
   resolutions: Maybe<ImageSharpResolutionsFilterInput>;
@@ -1794,22 +1816,17 @@ export type Query_allMdxArgs = {
   limit: Maybe<Scalars['Int']>;
 };
 
-export type Query_siteArgs = {
+export type Query_siteBuildMetadataArgs = {
   id: Maybe<StringQueryOperatorInput>;
   parent: Maybe<NodeFilterInput>;
   children: Maybe<NodeFilterListInput>;
   internal: Maybe<InternalFilterInput>;
-  siteMetadata: Maybe<SiteSiteMetadataFilterInput>;
-  port: Maybe<IntQueryOperatorInput>;
-  host: Maybe<StringQueryOperatorInput>;
-  polyfill: Maybe<BooleanQueryOperatorInput>;
-  pathPrefix: Maybe<StringQueryOperatorInput>;
   buildTime: Maybe<DateQueryOperatorInput>;
 };
 
-export type Query_allSiteArgs = {
-  filter: Maybe<SiteFilterInput>;
-  sort: Maybe<SiteSortInput>;
+export type Query_allSiteBuildMetadataArgs = {
+  filter: Maybe<SiteBuildMetadataFilterInput>;
+  sort: Maybe<SiteBuildMetadataSortInput>;
   skip: Maybe<Scalars['Int']>;
   limit: Maybe<Scalars['Int']>;
 };
@@ -1838,16 +1855,16 @@ export type Query_allSitePluginArgs = {
 };
 
 export type Site = Node & {
-  readonly id: Scalars['ID'];
-  readonly parent: Maybe<Node>;
-  readonly children: ReadonlyArray<Node>;
-  readonly internal: Internal;
+  readonly buildTime: Maybe<Scalars['Date']>;
   readonly siteMetadata: Maybe<SiteSiteMetadata>;
   readonly port: Maybe<Scalars['Int']>;
   readonly host: Maybe<Scalars['String']>;
   readonly polyfill: Maybe<Scalars['Boolean']>;
   readonly pathPrefix: Maybe<Scalars['String']>;
-  readonly buildTime: Maybe<Scalars['Date']>;
+  readonly id: Scalars['ID'];
+  readonly parent: Maybe<Node>;
+  readonly children: ReadonlyArray<Node>;
+  readonly internal: Internal;
 };
 
 export type Site_buildTimeArgs = {
@@ -1857,32 +1874,47 @@ export type Site_buildTimeArgs = {
   locale: Maybe<Scalars['String']>;
 };
 
-export type SiteConnection = {
+export type SiteBuildMetadata = Node & {
+  readonly id: Scalars['ID'];
+  readonly parent: Maybe<Node>;
+  readonly children: ReadonlyArray<Node>;
+  readonly internal: Internal;
+  readonly buildTime: Maybe<Scalars['Date']>;
+};
+
+export type SiteBuildMetadata_buildTimeArgs = {
+  formatString: Maybe<Scalars['String']>;
+  fromNow: Maybe<Scalars['Boolean']>;
+  difference: Maybe<Scalars['String']>;
+  locale: Maybe<Scalars['String']>;
+};
+
+export type SiteBuildMetadataConnection = {
   readonly totalCount: Scalars['Int'];
-  readonly edges: ReadonlyArray<SiteEdge>;
-  readonly nodes: ReadonlyArray<Site>;
+  readonly edges: ReadonlyArray<SiteBuildMetadataEdge>;
+  readonly nodes: ReadonlyArray<SiteBuildMetadata>;
   readonly pageInfo: PageInfo;
   readonly distinct: ReadonlyArray<Scalars['String']>;
-  readonly group: ReadonlyArray<SiteGroupConnection>;
+  readonly group: ReadonlyArray<SiteBuildMetadataGroupConnection>;
 };
 
-export type SiteConnection_distinctArgs = {
-  field: SiteFieldsEnum;
+export type SiteBuildMetadataConnection_distinctArgs = {
+  field: SiteBuildMetadataFieldsEnum;
 };
 
-export type SiteConnection_groupArgs = {
+export type SiteBuildMetadataConnection_groupArgs = {
   skip: Maybe<Scalars['Int']>;
   limit: Maybe<Scalars['Int']>;
-  field: SiteFieldsEnum;
+  field: SiteBuildMetadataFieldsEnum;
 };
 
-export type SiteEdge = {
-  readonly next: Maybe<Site>;
-  readonly node: Site;
-  readonly previous: Maybe<Site>;
+export type SiteBuildMetadataEdge = {
+  readonly next: Maybe<SiteBuildMetadata>;
+  readonly node: SiteBuildMetadata;
+  readonly previous: Maybe<SiteBuildMetadata>;
 };
 
-export enum SiteFieldsEnum {
+export enum SiteBuildMetadataFieldsEnum {
   id = 'id',
   parent___id = 'parent.id',
   parent___parent___id = 'parent.parent.id',
@@ -1969,26 +2001,163 @@ export enum SiteFieldsEnum {
   internal___mediaType = 'internal.mediaType',
   internal___owner = 'internal.owner',
   internal___type = 'internal.type',
+  buildTime = 'buildTime',
+}
+
+export type SiteBuildMetadataFilterInput = {
+  readonly id: Maybe<StringQueryOperatorInput>;
+  readonly parent: Maybe<NodeFilterInput>;
+  readonly children: Maybe<NodeFilterListInput>;
+  readonly internal: Maybe<InternalFilterInput>;
+  readonly buildTime: Maybe<DateQueryOperatorInput>;
+};
+
+export type SiteBuildMetadataGroupConnection = {
+  readonly totalCount: Scalars['Int'];
+  readonly edges: ReadonlyArray<SiteBuildMetadataEdge>;
+  readonly nodes: ReadonlyArray<SiteBuildMetadata>;
+  readonly pageInfo: PageInfo;
+  readonly field: Scalars['String'];
+  readonly fieldValue: Maybe<Scalars['String']>;
+};
+
+export type SiteBuildMetadataSortInput = {
+  readonly fields: Maybe<ReadonlyArray<Maybe<SiteBuildMetadataFieldsEnum>>>;
+  readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
+};
+
+export type SiteConnection = {
+  readonly totalCount: Scalars['Int'];
+  readonly edges: ReadonlyArray<SiteEdge>;
+  readonly nodes: ReadonlyArray<Site>;
+  readonly pageInfo: PageInfo;
+  readonly distinct: ReadonlyArray<Scalars['String']>;
+  readonly group: ReadonlyArray<SiteGroupConnection>;
+};
+
+export type SiteConnection_distinctArgs = {
+  field: SiteFieldsEnum;
+};
+
+export type SiteConnection_groupArgs = {
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+  field: SiteFieldsEnum;
+};
+
+export type SiteEdge = {
+  readonly next: Maybe<Site>;
+  readonly node: Site;
+  readonly previous: Maybe<Site>;
+};
+
+export enum SiteFieldsEnum {
+  buildTime = 'buildTime',
   siteMetadata___siteUrl = 'siteMetadata.siteUrl',
   siteMetadata___description = 'siteMetadata.description',
   port = 'port',
   host = 'host',
   polyfill = 'polyfill',
   pathPrefix = 'pathPrefix',
-  buildTime = 'buildTime',
+  id = 'id',
+  parent___id = 'parent.id',
+  parent___parent___id = 'parent.parent.id',
+  parent___parent___parent___id = 'parent.parent.parent.id',
+  parent___parent___parent___children = 'parent.parent.parent.children',
+  parent___parent___children = 'parent.parent.children',
+  parent___parent___children___id = 'parent.parent.children.id',
+  parent___parent___children___children = 'parent.parent.children.children',
+  parent___parent___internal___content = 'parent.parent.internal.content',
+  parent___parent___internal___contentDigest = 'parent.parent.internal.contentDigest',
+  parent___parent___internal___description = 'parent.parent.internal.description',
+  parent___parent___internal___fieldOwners = 'parent.parent.internal.fieldOwners',
+  parent___parent___internal___ignoreType = 'parent.parent.internal.ignoreType',
+  parent___parent___internal___mediaType = 'parent.parent.internal.mediaType',
+  parent___parent___internal___owner = 'parent.parent.internal.owner',
+  parent___parent___internal___type = 'parent.parent.internal.type',
+  parent___children = 'parent.children',
+  parent___children___id = 'parent.children.id',
+  parent___children___parent___id = 'parent.children.parent.id',
+  parent___children___parent___children = 'parent.children.parent.children',
+  parent___children___children = 'parent.children.children',
+  parent___children___children___id = 'parent.children.children.id',
+  parent___children___children___children = 'parent.children.children.children',
+  parent___children___internal___content = 'parent.children.internal.content',
+  parent___children___internal___contentDigest = 'parent.children.internal.contentDigest',
+  parent___children___internal___description = 'parent.children.internal.description',
+  parent___children___internal___fieldOwners = 'parent.children.internal.fieldOwners',
+  parent___children___internal___ignoreType = 'parent.children.internal.ignoreType',
+  parent___children___internal___mediaType = 'parent.children.internal.mediaType',
+  parent___children___internal___owner = 'parent.children.internal.owner',
+  parent___children___internal___type = 'parent.children.internal.type',
+  parent___internal___content = 'parent.internal.content',
+  parent___internal___contentDigest = 'parent.internal.contentDigest',
+  parent___internal___description = 'parent.internal.description',
+  parent___internal___fieldOwners = 'parent.internal.fieldOwners',
+  parent___internal___ignoreType = 'parent.internal.ignoreType',
+  parent___internal___mediaType = 'parent.internal.mediaType',
+  parent___internal___owner = 'parent.internal.owner',
+  parent___internal___type = 'parent.internal.type',
+  children = 'children',
+  children___id = 'children.id',
+  children___parent___id = 'children.parent.id',
+  children___parent___parent___id = 'children.parent.parent.id',
+  children___parent___parent___children = 'children.parent.parent.children',
+  children___parent___children = 'children.parent.children',
+  children___parent___children___id = 'children.parent.children.id',
+  children___parent___children___children = 'children.parent.children.children',
+  children___parent___internal___content = 'children.parent.internal.content',
+  children___parent___internal___contentDigest = 'children.parent.internal.contentDigest',
+  children___parent___internal___description = 'children.parent.internal.description',
+  children___parent___internal___fieldOwners = 'children.parent.internal.fieldOwners',
+  children___parent___internal___ignoreType = 'children.parent.internal.ignoreType',
+  children___parent___internal___mediaType = 'children.parent.internal.mediaType',
+  children___parent___internal___owner = 'children.parent.internal.owner',
+  children___parent___internal___type = 'children.parent.internal.type',
+  children___children = 'children.children',
+  children___children___id = 'children.children.id',
+  children___children___parent___id = 'children.children.parent.id',
+  children___children___parent___children = 'children.children.parent.children',
+  children___children___children = 'children.children.children',
+  children___children___children___id = 'children.children.children.id',
+  children___children___children___children = 'children.children.children.children',
+  children___children___internal___content = 'children.children.internal.content',
+  children___children___internal___contentDigest = 'children.children.internal.contentDigest',
+  children___children___internal___description = 'children.children.internal.description',
+  children___children___internal___fieldOwners = 'children.children.internal.fieldOwners',
+  children___children___internal___ignoreType = 'children.children.internal.ignoreType',
+  children___children___internal___mediaType = 'children.children.internal.mediaType',
+  children___children___internal___owner = 'children.children.internal.owner',
+  children___children___internal___type = 'children.children.internal.type',
+  children___internal___content = 'children.internal.content',
+  children___internal___contentDigest = 'children.internal.contentDigest',
+  children___internal___description = 'children.internal.description',
+  children___internal___fieldOwners = 'children.internal.fieldOwners',
+  children___internal___ignoreType = 'children.internal.ignoreType',
+  children___internal___mediaType = 'children.internal.mediaType',
+  children___internal___owner = 'children.internal.owner',
+  children___internal___type = 'children.internal.type',
+  internal___content = 'internal.content',
+  internal___contentDigest = 'internal.contentDigest',
+  internal___description = 'internal.description',
+  internal___fieldOwners = 'internal.fieldOwners',
+  internal___ignoreType = 'internal.ignoreType',
+  internal___mediaType = 'internal.mediaType',
+  internal___owner = 'internal.owner',
+  internal___type = 'internal.type',
 }
 
 export type SiteFilterInput = {
-  readonly id: Maybe<StringQueryOperatorInput>;
-  readonly parent: Maybe<NodeFilterInput>;
-  readonly children: Maybe<NodeFilterListInput>;
-  readonly internal: Maybe<InternalFilterInput>;
+  readonly buildTime: Maybe<DateQueryOperatorInput>;
   readonly siteMetadata: Maybe<SiteSiteMetadataFilterInput>;
   readonly port: Maybe<IntQueryOperatorInput>;
   readonly host: Maybe<StringQueryOperatorInput>;
   readonly polyfill: Maybe<BooleanQueryOperatorInput>;
   readonly pathPrefix: Maybe<StringQueryOperatorInput>;
-  readonly buildTime: Maybe<DateQueryOperatorInput>;
+  readonly id: Maybe<StringQueryOperatorInput>;
+  readonly parent: Maybe<NodeFilterInput>;
+  readonly children: Maybe<NodeFilterListInput>;
+  readonly internal: Maybe<InternalFilterInput>;
 };
 
 export type SiteGroupConnection = {
@@ -2587,6 +2756,19 @@ export type StringQueryOperatorInput = {
   readonly glob: Maybe<Scalars['String']>;
 };
 
+export type EntryQueryVariables = {
+  id: Scalars['String'];
+};
+
+export type EntryQuery = {
+  readonly mdx: Maybe<
+    Pick<Mdx, 'id' | 'body' | 'timeToRead'> & {
+      readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'fullWidth' | 'title'>>;
+      readonly wordCount: Maybe<Pick<MdxWordCount, 'paragraphs' | 'words' | 'sentences'>>;
+    }
+  >;
+};
+
 export type GatsbyImageSharpFixedFragment = Pick<
   ImageSharpFixed,
   'base64' | 'width' | 'height' | 'src' | 'srcSet'
@@ -2706,19 +2888,6 @@ export type GatsbyImageSharpSizes_withWebp_noBase64Fragment = Pick<
   ImageSharpSizes,
   'aspectRatio' | 'src' | 'srcSet' | 'srcWebp' | 'srcSetWebp' | 'sizes'
 >;
-
-export type EntryQueryVariables = {
-  id: Scalars['String'];
-};
-
-export type EntryQuery = {
-  readonly mdx: Maybe<
-    Pick<Mdx, 'id' | 'body' | 'timeToRead'> & {
-      readonly frontmatter: Maybe<Pick<MdxFrontmatter, 'fullWidth' | 'title'>>;
-      readonly wordCount: Maybe<Pick<MdxWordCount, 'paragraphs' | 'words' | 'sentences'>>;
-    }
-  >;
-};
 
 export type PagesQueryQueryVariables = {};
 

--- a/docs/showcase/social.mdx
+++ b/docs/showcase/social.mdx
@@ -6,10 +6,9 @@ import { ExampleSocialEditor } from '@remirror/showcase/lib/social';
 
 # Social Editor
 
-Below is an example of a social editor using the `@remirror/editor-social`
-package.
+Below is an example of a social editor using the `@remirror/editor-social` package.
 
-To test it out try adding an **`@`** mention or a **`#`** mention. Also typing **`:`** will
-activate the emoji search extension.
+To test it out try adding an **`@`** mention or a **`#`** mention. Also typing **`:`** will activate the emoji
+search extension.
 
-<ExampleSocialEditor />
+<ExampleSocialEditor autoFocus={true} />

--- a/docs/showcase/wysiwyg.mdx
+++ b/docs/showcase/wysiwyg.mdx
@@ -6,4 +6,4 @@ import { ExampleWysiwygEditor } from '@remirror/showcase/lib/wysiwyg';
 
 # Wysiwyg Editor
 
-<ExampleWysiwygEditor />
+<ExampleWysiwygEditor autoFocus={true} />

--- a/docs/src/components/layout.tsx
+++ b/docs/src/components/layout.tsx
@@ -26,7 +26,9 @@ export const Layout: FC<LayoutProps> = ({ children, relativePath, ...props }) =>
   const sidebarRef = useRef<HTMLDivElement>(null);
   const onSidebarFocus = useCallback(() => setMenuOpen(true), [setMenuOpen]);
   const onSidebarBlur = useCallback(() => setMenuOpen(false), [setMenuOpen]);
-  const onSidebarClick = useCallback(() => setMenuOpen(false), [setMenuOpen]);
+  const onSidebarClick = useCallback(() => {
+    setMenuOpen(false);
+  }, [setMenuOpen]);
 
   return (
     <Styled.root>


### PR DESCRIPTION
## Description

- Enable `autoFocus` in docs.
- Extends `autoFocus` to accept the same types as `focus()` context method.

Closes #261

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

*Tested in a simulator*

![2020-03-06 08 30 33](https://user-images.githubusercontent.com/1160934/76061922-df9ab000-5f84-11ea-8c73-f2ea6cc5a7f9.gif)
