### PR TITLE
fix(extension-mention): parse extraAttrs when parsing DOM

### DIFF
--- a/.changeset/big-pans-kneel.md
+++ b/.changeset/big-pans-kneel.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-mention': patch
+---
+
+parse extraAttrs when parsing mention DOM elements

--- a/@remirror/extension-mention/src/__tests__/mention.spec.ts
+++ b/@remirror/extension-mention/src/__tests__/mention.spec.ts
@@ -36,6 +36,33 @@ describe('schema', () => {
     const expected = doc(p(mention(attrs.label)));
     expect(node).toEqualProsemirrorNode(expected);
   });
+
+  describe('extraAttrs', () => {
+    const custom = 'test';
+    const { schema } = createBaseTestManager([
+      {
+        extension: new MentionExtension({
+          matchers: [],
+          extraAttrs: ['data-custom'],
+        }),
+        priority: 1,
+      },
+    ]);
+
+    const { doc, p, mention } = pmBuild(schema, {
+      mention: { markType: 'mention', ['data-custom']: custom, ...attrs },
+    });
+
+    it('parses the dom structure and finds itself with custom attributes', () => {
+      const node = fromHTML({
+        schema,
+        content: `<a class="mention mention-at" data-custom="${custom}" data-mention-id="${attrs.id}" data-mention-name="${attrs.name}">${attrs.label}</a>`,
+      });
+
+      const expected = doc(p(mention(attrs.label)));
+      expect(node).toEqualProsemirrorNode(expected);
+    });
+  });
 });
 
 describe('constructor', () => {

--- a/@remirror/extension-mention/src/mention-extension.ts
+++ b/@remirror/extension-mention/src/mention-extension.ts
@@ -90,7 +90,7 @@ export class MentionExtension extends MarkExtension<MentionExtensionOptions> {
             const id = node.getAttribute(dataAttributeId);
             const name = node.getAttribute(dataAttributeName);
             const label = node.innerText;
-            return { id, label, name };
+            return { ...this.getExtraAttrs(node), id, label, name };
           },
         },
       ],


### PR DESCRIPTION
First swing at this after reading over the documentation. Let me know if it needs any adjustments! 🙏 

## Description

<!-- Describe your changes in detail and reference any issues it addresses-->
- Fixes #263.
- Adds `this.getExtraAttrs(node)` to the `parseDOM` attribute results when parsing mention elements.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .