### PR TITLE
TypeScript should not perform ESLint's tasks

### DIFF
--- a/support/tsconfig.base.json
+++ b/support/tsconfig.base.json
@@ -12,16 +12,17 @@
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "pretty": true,
     "forceConsistentCasingInFileNames": true,
-    "allowUnreachableCode": false,
     "experimentalDecorators": true,
     "strict": true,
     "alwaysStrict": true,
     "resolveJsonModule": true,
     "plugins": [{ "name": "typescript-styled-plugin" }],
-    "preserveWatchOutput": true
+    "preserveWatchOutput": true,
+
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "allowUnreachableCode": true
   }
 }


### PR DESCRIPTION
## Description

When developing, it's common to comment out lines of code. When doing so, you shouldn't have to remove the import just for the development bundle to build. Similarly you may add arguments to a method that you're not using _yet_ but will be, or declaring variables again which you don't use right this second but will need. Detecting these issues are a job for ESLint; preventing a CI pass when these issues makes sense, but preventing you from even using your new code because it doesn't pass lint rules is a huge barrier to productivity.

This PR removes these lint-y rules from the base tsconfig, delegating them to ESLint.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .
