### PR TITLE
feat(code-extension): support syntax highlight for upper language name

### DIFF
--- a/.changeset/chatty-deers-guess.md
+++ b/.changeset/chatty-deers-guess.md
@@ -2,4 +2,4 @@
 "@remirror/extension-code-block": patch
 ---
 
-fix(code-extension): support syntax highlight for json5 and jinjia2.
+Support syntax highlight for `json5` and `jinjia2`.

--- a/.changeset/chatty-deers-guess.md
+++ b/.changeset/chatty-deers-guess.md
@@ -1,0 +1,5 @@
+---
+"@remirror/extension-code-block": patch
+---
+
+fix(code-extension): support syntax highlight for json5 and jinjia2.

--- a/.changeset/selfish-suits-look.md
+++ b/.changeset/selfish-suits-look.md
@@ -2,6 +2,6 @@
 "@remirror/extension-code-block": minor
 ---
 
-feat(code-extension): support syntax highlight for upper language names.
+Support syntax highlighting for uppercase language names.
 
 Removed `getSupportedLanguagesMap` and `isSupportedLanguage`.

--- a/.changeset/selfish-suits-look.md
+++ b/.changeset/selfish-suits-look.md
@@ -1,0 +1,7 @@
+---
+"@remirror/extension-code-block": minor
+---
+
+feat(code-extension): support syntax highlight for upper language names.
+
+Removed `getSupportedLanguagesMap` and `isSupportedLanguage`.

--- a/.changeset/sixty-colts-wave.md
+++ b/.changeset/sixty-colts-wave.md
@@ -1,0 +1,5 @@
+---
+"jest-prosemirror": patch
+---
+
+chore(deps): support jest v25+.

--- a/.changeset/sixty-colts-wave.md
+++ b/.changeset/sixty-colts-wave.md
@@ -2,4 +2,4 @@
 "jest-prosemirror": patch
 ---
 
-chore(deps): support jest v25+.
+Support `jest` v25+.

--- a/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
+++ b/@remirror/extension-code-block/src/__tests__/code-block.spec.ts
@@ -2,10 +2,13 @@ import { pmBuild } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
 import typescriptPlugin from 'prettier/parser-typescript';
 import { formatWithCursor } from 'prettier/standalone';
+import cssExtras from 'refractor/lang/css-extras';
+import graphql from 'refractor/lang/graphql';
 import javascript from 'refractor/lang/javascript';
 import markdown from 'refractor/lang/markdown';
 import tsx from 'refractor/lang/tsx';
 import typescript from 'refractor/lang/typescript';
+import yaml from 'refractor/lang/yaml';
 
 import { fromHTML, toHTML } from '@remirror/core';
 import { BaseKeymapExtension } from '@remirror/core-extensions';
@@ -414,5 +417,44 @@ describe('commands', () => {
         ),
       );
     });
+  });
+});
+
+describe('language', () => {
+  const getLang = (language: string) =>
+    getLanguage({
+      language,
+      supportedLanguages: [yaml, graphql, cssExtras],
+      fallback: '',
+    });
+
+  it('yaml', () => {
+    expect(yaml.name).toEqual('yaml');
+    expect(yaml.aliases[0]).toEqual('yml');
+
+    expect(getLang('yaml')).toEqual(yaml.name);
+    expect(getLang('yml')).toEqual(yaml.aliases[0]);
+    expect(getLang('YAML')).toEqual(yaml.name);
+    expect(getLang('YML')).toEqual(yaml.aliases[0]);
+  });
+
+  it('graphql', () => {
+    expect(graphql.name).toEqual('graphql');
+
+    expect(getLang('graphql')).toEqual(graphql.name);
+    expect(getLang('GraphQL')).toEqual(graphql.name);
+    expect(getLang('GRAPHQL')).toEqual(graphql.name);
+  });
+
+  it('cssExtras', () => {
+    expect(cssExtras.name).toEqual('cssExtras');
+
+    expect(getLang('cssExtras')).toEqual(cssExtras.name);
+    expect(getLang('cssextras')).toEqual(cssExtras.name);
+    expect(getLang('CSSExtras')).toEqual(cssExtras.name);
+  });
+
+  it('unknow', () => {
+    expect(getLang(`this_language_does_not_exist`)).toEqual('');
   });
 });

--- a/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/@remirror/extension-code-block/src/code-block-extension.ts
@@ -181,7 +181,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockExtensionOptions>
    * Create an input rule that listens converts the code fence into a code block with space.
    */
   public inputRules({ type }: ExtensionManagerNodeTypeParams) {
-    const regexp = /^```([a-zA-Z]*)? $/;
+    const regexp = /^```([a-zA-Z0-9]*) $/;
     const getAttrs: GetAttrs = match => {
       const language = getLanguage({
         language: getMatchString(match, 1),

--- a/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/@remirror/extension-code-block/src/code-block-utils.ts
@@ -198,19 +198,12 @@ const PRELOADED_LANGUAGES = [markup, clike, css, js];
  * The list of strings that are recognised language names based on the the configured
  * supported languages.
  */
-export const getLanguageNamesAndAliases = (supportedLanguages: RefractorSyntax[]) => {
+export const getLanguageNamesAndAliases = (supportedLanguages: RefractorSyntax[]): string[] => {
   return uniqueArray(
     flattenArray(
       [...PRELOADED_LANGUAGES, ...supportedLanguages].map(({ name, aliases }) => [name, ...aliases]),
     ),
   );
-};
-
-/**
- * Returns true if the language is supported.
- */
-export const isSupportedLanguage = (language: string, supportedLanguages: RefractorSyntax[]) => {
-  return getLanguageNamesAndAliases(supportedLanguages).includes(language);
 };
 
 interface GetLanguageParams {
@@ -233,8 +226,17 @@ interface GetLanguageParams {
 /**
  * Get the language from user input.
  */
-export const getLanguage = ({ language, supportedLanguages, fallback }: GetLanguageParams) =>
-  !isSupportedLanguage(language, supportedLanguages) ? fallback : language;
+export const getLanguage = ({ language, supportedLanguages, fallback }: GetLanguageParams): string => {
+  if (!language) {
+    return fallback;
+  }
+  for (const name of getLanguageNamesAndAliases(supportedLanguages)) {
+    if (name.toLowerCase() === language.toLowerCase()) {
+      return name;
+    }
+  }
+  return fallback;
+};
 
 interface FormatCodeBlockFactoryParams
   extends NodeTypeParams,
@@ -306,18 +308,4 @@ export const formatCodeBlockFactory = ({
   }
 
   return true;
-};
-
-/**
- * Retrieve the supported language names based on configuration.
- */
-export const getSupportedLanguagesMap = (supportedLanguages: RefractorSyntax[]) => {
-  const obj: Record<string, string> = Object.create(null);
-  for (const { name, aliases } of [...PRELOADED_LANGUAGES, ...supportedLanguages]) {
-    obj[name] = name;
-    aliases.forEach(alias => {
-      obj[alias] = name;
-    });
-  }
-  return obj;
 };

--- a/packages/jest-prosemirror/package.json
+++ b/packages/jest-prosemirror/package.json
@@ -50,7 +50,7 @@
     "test-keyboard": "^0.7.6"
   },
   "peerDependencies": {
-    "jest": "^24"
+    "jest": ">= 24"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This simple PR add syntax highlight support for language name who has different case then the definition from Refractor. 

For example, Remirror support `yml` and `yaml` currently. With this PR, `YAML` and `YML` will also been supported.

As a proof of the necessity, GitHub website provides syntax highlight for all four language names below:

```yaml
language: "yaml"
```

```yml
language: "yml"
```

```YAML
language: "YAML"
```

```YML
language: "YML"
```

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

## Breaking changes

Removed  `isSupportedLanguage` and `getSupportedLanguagesMap`.

For `isSupportedLanguage`, I removed it just because it's unused in this repository. If you think we shouldn't break the backward compatibility easily, I can add this function back.

For `getSupportedLanguagesMap`, one reason is that it's never used in the repository, but the more important reason is the complex. Base on the new logic this PR provide, `getSupportedLanguagesMap` should return all possible word cases, which is a large amount of data with mostly garbage.

```
> getSupportedLanguagesMap([graphql])
{
	"GrApHqL": "graphql",
	"gRaPhQl": "graphql",
	"grAPhql": "graphql",
	...
}
```


