### PR TITLE
fix: do not inherit marks when insert hard break

### DIFF
--- a/@remirror/core-extensions/src/nodes/hard-break-extension.ts
+++ b/@remirror/core-extensions/src/nodes/hard-break-extension.ts
@@ -28,7 +28,7 @@ export class HardBreakExtension extends NodeExtension {
   public keys({ type }: ExtensionManagerNodeTypeParams): KeyBindings {
     const command = chainCommands(convertCommand(exitCode), ({ state, dispatch }) => {
       if (dispatch) {
-        dispatch(state.tr.replaceSelectionWith(type.create()).scrollIntoView());
+        dispatch(state.tr.replaceSelectionWith(type.create(), false).scrollIntoView());
       }
 
       return true;


### PR DESCRIPTION
## Description

Fixes #280

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots

<!-- Delete this section if not applicable -->
