### PR TITLE
fix: image-extension `toDOM` can now safely access `this`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -157,6 +157,16 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "lanyusan",
+      "name": "lanyusan",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/56706512?v=4",
+      "profile": "https://github.com/lanyusan",
+      "contributions": [
+        "code",
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.changeset/four-bikes-unite.md
+++ b/.changeset/four-bikes-unite.md
@@ -2,4 +2,4 @@
 "@remirror/extension-image": patch
 ---
 
-Make the `schema.toDOM` and arrow function so that it can access `this`.
+Make the `schema.toDOM` an arrow function so that it can access `this`.

--- a/.changeset/four-bikes-unite.md
+++ b/.changeset/four-bikes-unite.md
@@ -2,4 +2,4 @@
 "@remirror/extension-image": patch
 ---
 
-Fix the `schema.parseDOM` property so that it can access `this.getExtraAttrs`.
+Make the `schema.toDOM` and arrow function so that it can access `this`.

--- a/.changeset/four-bikes-unite.md
+++ b/.changeset/four-bikes-unite.md
@@ -1,0 +1,5 @@
+---
+"@remirror/extension-image": patch
+---
+
+Fix the `schema.parseDOM` property so that it can access `this.getExtraAttrs`.

--- a/@remirror/extension-image/src/image-extension.ts
+++ b/@remirror/extension-image/src/image-extension.ts
@@ -42,10 +42,10 @@ export class ImageExtension extends NodeExtension {
       parseDOM: [
         {
           tag: 'img[src]',
-          getAttrs: (domNode) => (isElementDOMNode(domNode) ? getAttrs(this.getExtraAttrs(domNode)) : {}),
+          getAttrs: domNode => (isElementDOMNode(domNode) ? getAttrs(this.getExtraAttrs(domNode)) : {}),
         },
       ],
-      toDOM: (node) => {
+      toDOM: node => {
         return ['img', node.attrs];
       },
     };

--- a/@remirror/extension-image/src/image-extension.ts
+++ b/@remirror/extension-image/src/image-extension.ts
@@ -42,10 +42,10 @@ export class ImageExtension extends NodeExtension {
       parseDOM: [
         {
           tag: 'img[src]',
-          getAttrs: domNode => (isElementDOMNode(domNode) ? getAttrs(this.getExtraAttrs(domNode)) : {}),
+          getAttrs: (domNode) => (isElementDOMNode(domNode) ? getAttrs(this.getExtraAttrs(domNode)) : {}),
         },
       ],
-      toDOM(node) {
+      toDOM: (node) => {
         return ['img', node.attrs];
       },
     };

--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,7 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/watlandc"><img src="https://avatars3.githubusercontent.com/u/6117504?v=4" width="100px;" alt=""/><br /><sub><b>Chris Watland</b></sub></a><br /><a href="https://github.com/remirror/remirror/issues?q=author%3Awatlandc" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://github.com/lanyusan"><img src="https://avatars3.githubusercontent.com/u/56706512?v=4" width="100px;" alt=""/><br /><sub><b>lanyusan</b></sub></a><br /><a href="https://github.com/remirror/remirror/commits?author=lanyusan" title="Code">💻</a> <a href="https://github.com/remirror/remirror/issues?q=author%3Alanyusan" title="Bug reports">🐛</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Description

image-extenison's `toDOM` is defined as object method, which couldn't pick up the extension's `this`, which would be a problem if `toDOM` needs to access `options` passed to the extension when it is setup.

This fix simply converts `toDOM` to arrow function to pick up `this` of extension.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .

## Screenshots


