### PR TITLE
fix: remove `.step` property from collaboration steps

### DIFF
--- a/.changeset/eighty-trainers-change.md
+++ b/.changeset/eighty-trainers-change.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-collaboration': patch
+---
+
+[fix] API mismatch in step enumeration

--- a/.changeset/eighty-trainers-change.md
+++ b/.changeset/eighty-trainers-change.md
@@ -1,5 +1,5 @@
 ---
-'@remirror/extension-collaboration': patch
+"@remirror/extension-collaboration": patch
 ---
 
 [fix] API mismatch in step enumeration

--- a/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -74,7 +74,7 @@ export class CollaborationExtension extends Extension<CollaborationExtensionOpti
           dispatch(
             receiveTransaction(
               state,
-              steps.map(item => Step.fromJSON(schema, item.step)),
+              steps.map(item => Step.fromJSON(schema, item)),
               steps.map(item => item.clientID),
             ),
           );


### PR DESCRIPTION
## Description

There doesn't seem to be any `.step` sub-structure in collaboration steps passed to e.g. [`onSendableReceived`](https://github.com/remirror/remirror/blob/000fdfb0d5e8da63e7ab8241ac4e6b8ccdc4ace0/%40remirror/extension-collaboration/src/collaboration-extension.ts#L120). Looking into the history of both Remirror and ProseMirror, I see that [Branch items can have a `.step`](https://github.com/ProseMirror/prosemirror-history/blob/master/src/history.js#L52), which might be where the confusion came from

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .
(but on the other hand, neither was the old one.)

