### PR TITLE
docs: fix link to examples on install page

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -100,4 +100,4 @@ const EditorLayout: FunctionComponent = () => {
 };
 ```
 
-Then see the [examples](https://github.com/remirror/remirror/docs/examples) for more sample code.
+Then see the [examples](https://github.com/remirror/remirror/tree/master/examples) for more sample code.


### PR DESCRIPTION
## Description

link to examples leads to Page not found. Changed the link to the examples directory.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .
