### PR TITLE
chore(playground): hoist extensions to root scope

### DIFF
--- a/@remirror/playground/src/make-code.tsx
+++ b/@remirror/playground/src/make-code.tsx
@@ -100,6 +100,10 @@ export function makeCode(codeOptions: CodeOptions): string {
   const code = `\
 ${importLines.join('\n')}
 
+const EXTENSIONS = [
+  ${combinedList.join(',\n  ')}
+];
+
 /**
  * This component contains the editor and any toolbars/chrome it requires.
  */
@@ -117,9 +121,7 @@ const SmallEditor: FC = () => {
 };
 
 const SmallEditorWrapper = () => {
-  const extensionManager = useManager([
-    ${combinedList.join(',\n    ')}
-  ]);
+  const extensionManager = useManager(EXTENSIONS);
 
   return (
     <RemirrorProvider manager={extensionManager}>


### PR DESCRIPTION
## Description

Since a Remirror schema is not expected to change dynamically, we can (and should?) hoist the extensions to the root scope to prevent dynamically re-creating them on every render. This will reduce the load on the garbage collector, on React comparisons, and is also a better way of demoing to the user.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test` .

## Example code

```ts
import { useRemirrorPlayground } from "@remirror/playground";
import React, { FC } from "react";
import { BoldExtension } from "remirror/extension/bold";
import { ItalicExtension } from "remirror/extension/italic";
import { RemirrorProvider, useManager, useRemirror } from "remirror/react";

const EXTENSIONS = [new BoldExtension(), new ItalicExtension()];

/**
 * This component contains the editor and any toolbars/chrome it requires.
 */
const SmallEditor: FC = () => {
  const { getRootProps, commands } = useRemirror();

  useRemirrorPlayground(); // Delete this line

  return (
    <div>
      <button onClick={() => commands.toggleBold()}>bold</button>
      <button onClick={() => commands.toggleItalic()}>italic</button>
      <div {...getRootProps()} />
    </div>
  );
};

const SmallEditorWrapper = () => {
  const extensionManager = useManager(EXTENSIONS);

  return (
    <RemirrorProvider manager={extensionManager}>
      <SmallEditor />
    </RemirrorProvider>
  );
};

export default SmallEditorWrapper;
```