### PR TITLE
Fix typos

### DIFF
--- a/.tours/creating-the-basekeymapextension.tour
+++ b/.tours/creating-the-basekeymapextension.tour
@@ -4,7 +4,7 @@
     {
       "file": "%40remirror/extension-base-keymap/src/base-keymap-extension.ts",
       "line": 108,
-      "description": "Here the `BaseKeymapExtension` class is declared extending the `PlainExtension` with both settings and properties. \n\nExtensions can define both settings and properties. \n\nSettings are static and can't be changed during the lifecycle of the application. Settings generally apply to items that directly affect the schema, such as supported content. Changing this dynamically can cause things to break. \n\nProperties are dynamic and can be changed by the user during runtime. Typically all callbacks should be registered as properies and settings that the end user may want to tweak while using the editor can also be changed here."
+      "description": "Here the `BaseKeymapExtension` class is declared extending the `PlainExtension` with both settings and properties. \n\nExtensions can define both settings and properties. \n\nSettings are static and can't be changed during the lifecycle of the application. Settings generally apply to items that directly affect the schema, such as supported content. Changing this dynamically can cause things to break. \n\nProperties are dynamic and can be changed by the user during runtime. Typically all callbacks should be registered as properties and settings that the end user may want to tweak while using the editor can also be changed here."
     },
     {
       "file": "%40remirror/extension-base-keymap/src/base-keymap-extension.ts",

--- a/@remirror/core/src/extension/extension-base.ts
+++ b/@remirror/core/src/extension/extension-base.ts
@@ -134,7 +134,7 @@ abstract class Extension<Options extends ValidOptions = EmptyShape> extends Base
   protected get store() {
     invariant(this.#store, {
       code: ErrorConstant.MANAGER_PHASE_ERROR,
-      message: `An error ocurred while attempting to access the 'extension.store' when the Manager has not yet set created the lifecycle methods.`,
+      message: `An error occurred while attempting to access the 'extension.store' when the Manager has not yet set created the lifecycle methods.`,
     });
 
     return freeze(this.#store, { requireKeys: true });

--- a/@remirror/core/src/preset/preset-base.ts
+++ b/@remirror/core/src/preset/preset-base.ts
@@ -73,7 +73,7 @@ export abstract class Preset<Options extends ValidOptions = EmptyShape> extends 
   protected get extensionStore() {
     invariant(this.#extensionStore, {
       code: ErrorConstant.MANAGER_PHASE_ERROR,
-      message: `An error ocurred while attempting to access the 'extension.store' when the Manager has not yet set upt the lifecycle methods.`,
+      message: `An error occurred while attempting to access the 'extension.store' when the Manager has not yet set upt the lifecycle methods.`,
     });
 
     return freeze(this.#extensionStore, { requireKeys: true });

--- a/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/@remirror/extension-code-block/src/code-block-utils.ts
@@ -114,8 +114,8 @@ function getPositionedRefractorNodes(parameter: NodeWithPosition) {
 /**
  * Creates a decoration set for the provided blocks
  */
-export function createDecorations(paramter: CreateDecorationsParameter): Decoration[] {
-  const { blocks, skipLast } = paramter;
+export function createDecorations(parameter: CreateDecorationsParameter): Decoration[] {
+  const { blocks, skipLast } = parameter;
   const decorations: Decoration[] = [];
 
   for (const block of blocks) {

--- a/@remirror/extension-react-ssr/src/react-ssr-extension.ts
+++ b/@remirror/extension-react-ssr/src/react-ssr-extension.ts
@@ -233,7 +233,7 @@ declare global {
        * Use this if the automatic componentization in ReactSerializer of the
        * `toDOM` method doesn't produce the expected results in SSR.
        *
-       * TODO move this into a seperate NodeExtension and MarkExtension based
+       * TODO move this into a separate NodeExtension and MarkExtension based
        * merged interface so that the props can be specified as `{ mark: Mark }`
        * or `{ node: ProsemirrorNode }`.
        */

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@ title: Contributing
 
 ## Getting Started
 
-Fork [this respository][repo], clone your fork and add this repository as the upstream remote.
+Fork [this repository][repo], clone your fork and add this repository as the upstream remote.
 
 You will need to have `pnpm` installed so make sure you follow the installation
 [instructions](https://pnpm.js.org/en/installation).

--- a/docs/guides/01-introduction.mdx
+++ b/docs/guides/01-introduction.mdx
@@ -25,7 +25,7 @@ This guide is targeted at three audiences.
 - Extension developers.
 - Contributors.
 
-Labels will be used to identify advanced areas for extension developors and contributors.
+Labels will be used to identify advanced areas for extension developers and contributors.
 
 Regardless of where you stand, I have endeavoured to make it approachable and interesting for a
 whole range of developers.

--- a/docs/guides/custom-keys.mdx
+++ b/docs/guides/custom-keys.mdx
@@ -65,7 +65,7 @@ const manager = EditorManager.create([
 ```
 
 This manager can now be used to create an editor where the baseKeymap for the `Enter` key is
-overriden.
+overridden.
 
 If override is set to `false`, the method will call all lower priority keybindings while still
 allowing the behaviour you want for the extension.

--- a/docs/guides/naming-conventions.mdx
+++ b/docs/guides/naming-conventions.mdx
@@ -8,7 +8,7 @@ This document is for extension developers who wish to create their own extension
 
 - Packages must supply the following keywords - `remirror`, `extension`.
 - Packages should be named `remirror-extension-[NAME]`.
-  - The name should be hyphen deliniated `remirror-extension-new-rules` to seperate words.
+  - The name should be hyphen deliniated `remirror-extension-new-rules` to separate words.
 - Should export a named extension which uses the pascal version of the npm package name.
   - `remirror-extension-custom` should export `CustomExtension`.
   - `remirror-extension-new-rules` should export `NewRulesExtension.`
@@ -24,7 +24,7 @@ This document is for extension developers who wish to create their own extension
 
 - Packages must supply the following keywords - `remirror`, `preset`.
 - Packages should be named `remirror-preset-[NAME]`.
-  - The name should be hyphen deliniated `remirror-preset-new-rules` to seperate words.
+  - The name should be hyphen deliniated `remirror-preset-new-rules` to separate words.
 - Should export a named preset which uses the pascal version of the npm package name.
   - `remirror-preset-custom` should export `CustomExtension`.
   - `remirror-preset-new-rules` should export `NewRulesExtension`.

--- a/docs/patches.d.ts
+++ b/docs/patches.d.ts
@@ -145,7 +145,7 @@ declare module 'compass-vertical-rhythm' {
       roundToNearestHalfLine?: boolean;
 
       /**
-       * @defualt '2px'
+       * @default '2px'
        */
       minLinePadding?: string;
     }

--- a/docs/tips.mdx
+++ b/docs/tips.mdx
@@ -8,7 +8,7 @@ title: Tips
 
 Most of the time the order of marks is unimportant. Whether a `<strong />` tag wraps an `<em />` tag
 or visa versa has little impact on the user experience. However in some cases, as with links (anchor
-tags) it can lead to some odd behaviour when tags the link tag isn't prioritied.
+tags) it can lead to some odd behaviour when tags the link tag isn't prioritized.
 
 The following is one statement where the user has created a link and afterward gone and made some of
 the text bold. Unfortunately the bold is given priority and wraps the anchor tag causing the link to

--- a/docs/tooling.mdx
+++ b/docs/tooling.mdx
@@ -14,7 +14,7 @@ seen so far.
 - Fast
 - I like the colors in the CLI
 - Regular updates. One of the things that scared me about `yarn` was the sudden break between
-  version 1 and 2. They're basically two seperate projects with the same name. Pnpm has a track
+  version 1 and 2. They're basically two separate projects with the same name. Pnpm has a track
   record of incremental updates and speedy bug fixes.
 - Reduce multiple copies of node_modules being downloaded and installed on my machine
 

--- a/e2e/patches.d.ts
+++ b/e2e/patches.d.ts
@@ -134,7 +134,7 @@ declare module 'signal-exit' {
 
   /**
    * The exit
-   * @param code - the exitCode number or null if artifically induced
+   * @param code - the exitCode number or null if artificially induced
    * @param signal - the string signal which triggered the exit or null when artificially triggered
    */
   type ExitListener = (code: number | null, signal: string | null) => void;

--- a/packages/multishift/src/multishift-types.ts
+++ b/packages/multishift/src/multishift-types.ts
@@ -521,7 +521,7 @@ export interface GetRemoveButtonOptions<Element extends HTMLElement = any, Item 
 export interface GetRemoveButtonReturn<Element extends HTMLElement = any>
   extends DetailedHTMLProps<HTMLAttributes<Element>, Element> {
   /**
-   * The aria role for the button. This can be overriden in the options.
+   * The aria role for the button. This can be overridden in the options.
    *
    * @defaultValue 'button'
    */


### PR DESCRIPTION
## Description

Fix typos in the following files

```
remirror/.tours/creating-the-basekeymapextension.tour:7:548: "properies" is a misspelling of "properties"
remirror/@remirror/core/src/extension/extension-base.ts:137:25: "ocurred" is a misspelling of "occurred"
remirror/@remirror/core/src/preset/preset-base.ts:76:25: "ocurred" is a misspelling of "occurred"
remirror/@remirror/extension-code-block/src/code-block-utils.ts:117:34: "paramter" is a misspelling of "parameter"
remirror/@remirror/extension-code-block/src/code-block-utils.ts:118:31: "paramter" is a misspelling of "parameter"
remirror/@remirror/extension-react-ssr/src/react-ssr-extension.ts:236:31: "seperate" is a misspelling of "separate"
remirror/docs/contributing.md:11:11: "respository" is a misspelling of "repository"
remirror/docs/guides/01-introduction.mdx:28:61: "developors" is a misspelling of "develops"
remirror/docs/guides/custom-keys.mdx:68:0: "overriden" is a misspelling of "overridden"
remirror/docs/guides/naming-conventions.mdx:11:75: "seperate" is a misspelling of "separate"
remirror/docs/guides/naming-conventions.mdx:27:72: "seperate" is a misspelling of "separate"
remirror/docs/patches.d.ts:148:10: "defualt" is a misspelling of "default"
remirror/docs/tips.mdx:11:69: "prioritied" is a misspelling of "prioritize"
remirror/docs/tooling.mdx:17:41: "seperate" is a misspelling of "separate"
remirror/e2e/patches.d.ts:137:50: "artifically" is a misspelling of "artificially"
remirror/packages/multishift/src/multishift-types.ts:524:47: "overriden" is a misspelling of "overridden"
```