### PR TITLE
Playground tidyup

### DIFF
--- a/packages/@remirror/playground/src/code-editor.tsx
+++ b/packages/@remirror/playground/src/code-editor.tsx
@@ -86,7 +86,7 @@ const CodeEditor: FC<CodeEditorProps> = function (props) {
     });
   }, [model, onChange]);
 
-  return <div style={{ flex: '1', overflow: 'hidden', backgroundColor: '#f3f' }} ref={ref} />;
+  return <div style={{ flex: '1', overflow: 'hidden', backgroundColor: 'white' }} ref={ref} />;
 };
 
 export default CodeEditor;

--- a/packages/@remirror/playground/src/compile.tsx
+++ b/packages/@remirror/playground/src/compile.tsx
@@ -51,7 +51,7 @@ export function compile(
        * **MUST NOT** have their `@babel/preset-` or `@babel/plugin-` prefixes
        * otherwise they WILL NOT WORK.
        */
-      presets: ['react', 'env', 'typescript'],
+      presets: ['react', ['env', { useBuiltIns: false }], 'typescript'],
       plugins: [
         ['transform-runtime'],
         ['proposal-object-rest-spread'],

--- a/packages/@remirror/playground/src/execute.tsx
+++ b/packages/@remirror/playground/src/execute.tsx
@@ -234,5 +234,5 @@ export const Execute: FC<ExecuteProps> = function (props) {
     };
   }, [code, requires]);
 
-  return <div ref={ref} />;
+  return <div ref={ref} style={{ height: '100%' }} />;
 };

--- a/packages/@remirror/playground/src/index.tsx
+++ b/packages/@remirror/playground/src/index.tsx
@@ -66,6 +66,7 @@ const Loading: FC<{ hasBabel: boolean }> = ({ hasBabel }) => {
   return (
     <div
       style={{
+        height: '100%',
         display: 'flex',
         maxWidth: '50rem',
         margin: '0 auto',

--- a/packages/@remirror/playground/src/index.tsx
+++ b/packages/@remirror/playground/src/index.tsx
@@ -33,12 +33,62 @@ export const Playground: FC = () => {
     });
   }, [hasBabel]);
 
-  return Component ? (
-    <Component />
-  ) : hasBabel ? (
-    <p>Loading monaco editor...</p>
-  ) : (
-    <p>Waiting for babel...</p>
+  return Component ? <Component /> : <Loading hasBabel={hasBabel} />;
+};
+
+const Loading: FC<{ hasBabel: boolean }> = ({ hasBabel }) => {
+  const [numberOfDots, setNumberOfDots] = useState(3);
+  useEffect(() => {
+    const dotsPlusPlus = () => {
+      setNumberOfDots((dots) => (dots > 2 ? 0 : dots + 1));
+    };
+    const interval = setInterval(dotsPlusPlus, 300);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  const show = {};
+  const hide = { visibility: 'hidden' };
+
+  const dots = [
+    <span key={1} style={numberOfDots >= 1 ? show : hide}>
+      .
+    </span>,
+    <span key={2} style={numberOfDots >= 2 ? show : hide}>
+      .
+    </span>,
+    <span key={3} style={numberOfDots >= 3 ? show : hide}>
+      .
+    </span>,
+  ];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        maxWidth: '50rem',
+        margin: '0 auto',
+        padding: '2rem',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <div style={{ flex: '0 0 300px' }}>
+        <img
+          width='300'
+          height='300'
+          src='https://raw.githubusercontent.com/remirror/remirror/next/support/assets/logo-animated-light.svg?sanitize=true'
+          alt='animated remirror logo'
+        />
+      </div>
+      <div style={{ flex: '1 0 16rem', padding: '0 0 0 2rem', textAlign: 'center' }}>
+        Loading {!hasBabel ? 'babel' : 'monaco'}
+        {dots}
+      </div>
+    </div>
   );
 };
 

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -249,10 +249,10 @@ const copy = (text: string) => {
   textarea.style.top = '0';
   textarea.style.left = '-10000px';
   textarea.style.opacity = '0.0001';
-  document.body.appendChild(textarea);
+  document.body.append(textarea);
   textarea.value = text;
   textarea.select();
   textarea.setSelectionRange(0, 999999);
   document.execCommand('copy');
-  document.body.removeChild(textarea);
+  textarea.remove();
 };

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -181,26 +181,41 @@ export const Playground: FC = () => {
   return (
     <Container>
       <Main>
-        <Panel flex='0 0 16rem' overflow>
-          {advanced ? (
-            <div>
-              <button onClick={handleToggleAdvanced}>Enter simple mode</button>
-            </div>
-          ) : (
-            <SimplePanel
-              options={options}
-              setOptions={setOptions}
-              modules={modules}
-              addModule={addModule}
-              removeModule={removeModule}
-              onAdvanced={handleToggleAdvanced}
-            />
-          )}
-        </Panel>
-        <Divide />
+        {advanced ? null : (
+          <>
+            <Panel flex='0 0 18rem' overflow>
+              <SimplePanel
+                options={options}
+                setOptions={setOptions}
+                modules={modules}
+                addModule={addModule}
+                removeModule={removeModule}
+                onAdvanced={handleToggleAdvanced}
+              />
+            </Panel>
+            <Divide />
+          </>
+        )}
         <Panel vertical>
           <ErrorBoundary>
-            <CodeEditor value={code} onChange={setValue} readOnly={!advanced} />
+            <div
+              style={{
+                flex: '1',
+                overflow: 'hidden',
+                backgroundColor: 'white',
+                display: 'flex',
+                position: 'relative',
+              }}
+            >
+              <CodeEditor value={code} onChange={setValue} readOnly={!advanced} />
+              <div style={{ position: 'absolute', bottom: '1rem', right: '2rem' }}>
+                {advanced ? (
+                  <button onClick={handleToggleAdvanced}>Enter simple mode</button>
+                ) : (
+                  <button onClick={handleToggleAdvanced}>Enter advanced mode</button>
+                )}
+              </div>
+            </div>
           </ErrorBoundary>
           <Divide />
           <ErrorBoundary>

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -232,7 +232,9 @@ export const Playground: FC = () => {
           </ErrorBoundary>
           <Divide />
           <ErrorBoundary>
-            <Viewer options={options} code={code} />
+            <div style={{ padding: '1rem', flex: '0 0 10rem', overflow: 'auto' }}>
+              <Viewer options={options} code={code} />
+            </div>
           </ErrorBoundary>
         </Panel>
       </Main>

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -178,6 +178,16 @@ export const Playground: FC = () => {
   }, [advanced, options]);
 
   const code = advanced ? value : makeCode(options);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    copy(code);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [code]);
+
   return (
     <Container>
       <Main>
@@ -210,10 +220,13 @@ export const Playground: FC = () => {
               <CodeEditor value={code} onChange={setValue} readOnly={!advanced} />
               <div style={{ position: 'absolute', bottom: '1rem', right: '2rem' }}>
                 {advanced ? (
-                  <button onClick={handleToggleAdvanced}>Enter simple mode</button>
+                  <button onClick={handleToggleAdvanced}>☑️ Enter simple mode</button>
                 ) : (
-                  <button onClick={handleToggleAdvanced}>Enter advanced mode</button>
+                  <button onClick={handleToggleAdvanced}>🤓 Enter advanced mode</button>
                 )}
+                <button onClick={handleCopy} style={{ marginLeft: '0.5rem' }}>
+                  📋 {copied ? 'Copied code!' : 'Copy code'}
+                </button>
               </div>
             </div>
           </ErrorBoundary>
@@ -225,4 +238,19 @@ export const Playground: FC = () => {
       </Main>
     </Container>
   );
+};
+
+/** Copies text to the clipboard */
+const copy = (text: string) => {
+  const textarea = document.createElement('textarea');
+  textarea.style.position = 'absolute';
+  textarea.style.top = '0';
+  textarea.style.left = '-10000px';
+  textarea.style.opacity = '0.0001';
+  document.body.appendChild(textarea);
+  textarea.value = text;
+  textarea.select();
+  textarea.setSelectionRange(0, 999999);
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
 };

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from './error-boundary';
 import { makeRequire, REQUIRED_MODULES } from './execute';
 import { CodeOptions, Exports, RemirrorModules } from './interfaces';
 import { makeCode } from './make-code';
-import { Container, Divide, Header, Main, Panel } from './primitives';
+import { Container, Divide, Main, Panel } from './primitives';
 import { SimplePanel } from './simple-panel';
 import { Viewer } from './viewer';
 
@@ -42,11 +42,9 @@ const PRETTIER_SCRIPTS = [
 ];
 
 export const Playground: FC = () => {
-  console.log('Playground pre hooks');
   const [value, setValue] = useState('// Add some code here\n');
   const [advanced, setAdvanced] = useState(false);
   const [modules, setModules] = useState<RemirrorModules>({});
-  console.log('Playground post hooks');
   const addModule = useCallback((moduleName: string) => {
     setModules((oldModules) => ({
       ...oldModules,
@@ -182,9 +180,8 @@ export const Playground: FC = () => {
   const code = advanced ? value : makeCode(options);
   return (
     <Container>
-      <Header>Playground</Header>
       <Main>
-        <Panel flex='0 0 16rem'>
+        <Panel flex='0 0 16rem' overflow>
           {advanced ? (
             <div>
               <button onClick={handleToggleAdvanced}>Enter simple mode</button>

--- a/packages/@remirror/playground/src/primitives.tsx
+++ b/packages/@remirror/playground/src/primitives.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+
 const BG_COLOR = '#e0dbf5';
 
 export const Container: FC = function ({ children }) {

--- a/packages/@remirror/playground/src/primitives.tsx
+++ b/packages/@remirror/playground/src/primitives.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+const BG_COLOR = '#e0dbf5';
 
 export const Container: FC = function ({ children }) {
   return (
@@ -17,26 +18,19 @@ export const Container: FC = function ({ children }) {
   );
 };
 
-export const Header: FC = function ({ children }) {
-  return (
-    <div style={{ flex: '0 0 3rem', borderBottom: '1px solid black', background: '#aaa' }}>
-      {children}
-    </div>
-  );
-};
-
 export const Main: FC = function ({ children }) {
   return (
-    <div style={{ flex: '1', display: 'flex', backgroundColor: '#ddd', overflow: 'hidden' }}>
+    <div style={{ flex: '1', display: 'flex', backgroundColor: BG_COLOR, overflow: 'hidden' }}>
       {children}
     </div>
   );
 };
 
-export const Panel: FC<{ flex?: string; vertical?: boolean }> = function ({
+export const Panel: FC<{ flex?: string; vertical?: boolean; overflow?: boolean }> = function ({
   children,
   flex = '1 0 0',
   vertical,
+  overflow = false,
 }) {
   return (
     <div
@@ -45,7 +39,7 @@ export const Panel: FC<{ flex?: string; vertical?: boolean }> = function ({
         flex,
         display: 'flex',
         flexDirection: vertical ? 'column' : 'row',
-        overflow: 'hidden',
+        overflow: overflow ? 'auto' : 'hidden',
       }}
     >
       {children}

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -62,10 +62,10 @@ const ExtensionOrPresetCheckbox: FC<ExtensionCheckboxProps> = function (props) {
 };
 
 export const SimplePanel: FC<SimplePanelProps> = function (props) {
-  const { options, setOptions, onAdvanced, modules, addModule, removeModule } = props;
+  const { options, setOptions, modules, addModule, removeModule } = props;
 
   const onAddModule = useCallback(() => {
-    const moduleName = prompt('What module name do you wish to add?');
+    const moduleName = prompt('Enter the name of the npm module you want to import:');
 
     if (moduleName) {
       addModule(moduleName);

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -124,9 +124,7 @@ export const SimplePanel: FC<SimplePanelProps> = function (props) {
   externalModules.sort((a, b) => a[0].localeCompare(b[0]));
 
   return (
-    <div>
-      <button onClick={onAdvanced}>Switch to advanced mode</button>
-
+    <div style={{ padding: '1rem' }}>
       {/* REMIRROR CORE */}
       <p>
         <strong>Remirror core</strong>{' '}

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -125,7 +125,7 @@ export const SimplePanel: FC<SimplePanelProps> = function (props) {
 
   return (
     <div>
-      <button onClick={onAdvanced}>Enter advanced mode</button>
+      <button onClick={onAdvanced}>Switch to advanced mode</button>
 
       {/* REMIRROR CORE */}
       <p>

--- a/packages/@remirror/playground/src/viewer.tsx
+++ b/packages/@remirror/playground/src/viewer.tsx
@@ -16,7 +16,7 @@ export const Viewer: FC<ViewerProps> = function (props) {
   const { code: compiledCode, error, requires } = result;
 
   return (
-    <div style={{ flex: '1 0 0', overflow: 'auto' }}>
+    <div>
       {!error && typeof compiledCode === 'string' ? (
         <Execute code={compiledCode} requires={requires} />
       ) : (

--- a/support/root/.huskyrc
+++ b/support/root/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "pnpm if-config hooks.preCommit lint-staged",
-    "pre-push": "pnpm if-config hooks.prePush \"pnpm checks\""
+    "pre-commit": "pnpm run if-config hooks.preCommit lint-staged",
+    "pre-push": "pnpm run if-config hooks.prePush \"pnpm checks\""
   }
 }

--- a/support/website/src/pages/playground.module.css
+++ b/support/website/src/pages/playground.module.css
@@ -1,0 +1,4 @@
+.playground :global(.remirror-editor) {
+  border: 1px solid rgb(90, 90, 90);
+  border-radius: 3px;
+}

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -6,11 +6,12 @@ import Footer from '@theme/Footer';
 import Navbar from '@theme/Navbar';
 import ThemeProvider from '@theme/ThemeProvider';
 import UserPreferencesProvider from '@theme/UserPreferencesProvider';
+import clsx from 'clsx';
 import React from 'react';
-import styles from './playground.module.css';
 
 import { Playground } from '@remirror/playground';
-import clsx from 'clsx';
+
+import styles from './playground.module.css';
 
 const PlaygroundPage = (props: any) => {
   const { siteConfig } = useDocusaurusContext();

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -7,8 +7,10 @@ import Navbar from '@theme/Navbar';
 import ThemeProvider from '@theme/ThemeProvider';
 import UserPreferencesProvider from '@theme/UserPreferencesProvider';
 import React from 'react';
+import styles from './playground.module.css';
 
 import { Playground } from '@remirror/playground';
+import clsx from 'clsx';
 
 const PlaygroundPage = (props: any) => {
   const { siteConfig } = useDocusaurusContext();
@@ -23,7 +25,7 @@ const PlaygroundPage = (props: any) => {
   const faviconUrl = useBaseUrl(favicon);
 
   return (
-    <div className='playground'>
+    <div className={clsx('playground', styles.playground)}>
       <ThemeProvider>
         <UserPreferencesProvider>
           <Head>

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -47,7 +47,14 @@ const PlaygroundPage = (props: any) => {
           <AnnouncementBar />
           <Navbar />
           <Head></Head>
-          <div className='custom-main-wrapper'>
+          <div
+            className='custom-main-wrapper'
+            style={{
+              /* TODO: move this to CSS, make sensible */
+              position: 'relative',
+              height: 'calc(100vh - 17rem + 3px)',
+            }}
+          >
             <Playground />
           </div>
           {!noFooter && <Footer />}

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -53,6 +53,7 @@ const PlaygroundPage = (props: any) => {
               /* TODO: move this to CSS, make sensible */
               position: 'relative',
               height: 'calc(100vh - 17rem + 3px)',
+              minHeight: '400px',
             }}
           >
             <Playground />


### PR DESCRIPTION
## Description

Tidies various things in the playground to make it more suitable for presenting via the website

## Checklist


- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test` .

## Screenshots

I gave the playground a loading screen, normally it shows:

![remirror-playground-loading](https://user-images.githubusercontent.com/129910/87310674-32c5d600-c516-11ea-9ea5-666157e7d36c.gif)

But on slower connection:

![remirror-playground-loading-slow](https://user-images.githubusercontent.com/129910/87311283-f6df4080-c516-11ea-9cfb-de103e11489e.gif)

And here's what the editor looks like a bit updated:

![Screenshot_20200713_143231](https://user-images.githubusercontent.com/129910/87310395-d367c600-c515-11ea-96a4-352a8a070203.png)

Advanced mode removes the sidebar:

![Screenshot_20200713_144241](https://user-images.githubusercontent.com/129910/87311447-24c48500-c517-11ea-997b-9f470b0805d6.png)
