### PR TITLE
Playground persistence via URL hash

### DIFF
--- a/packages/@remirror/playground/package.json
+++ b/packages/@remirror/playground/package.json
@@ -29,6 +29,8 @@
     "@remirror/react": "^1.0.0-next.1",
     "@types/babel__core": "^7.1.9",
     "@types/babel__standalone": "^7.1.2",
+    "@types/lz-string": "^1.3.34",
+    "lz-string": "^1.4.4",
     "monaco-editor": "^0.20.0",
     "monaco-editor-webpack-plugin": "^1.9.0",
     "regenerator-runtime": "^0.13.5",

--- a/packages/@remirror/playground/src/code-editor.tsx
+++ b/packages/@remirror/playground/src/code-editor.tsx
@@ -86,7 +86,7 @@ const CodeEditor: FC<CodeEditorProps> = function (props) {
     });
   }, [model, onChange]);
 
-  return <div style={{ flex: '1', overflow: 'hidden', backgroundColor: '#f3f' }} ref={ref} />;
+  return <div style={{ flex: '1', overflow: 'hidden', backgroundColor: 'white' }} ref={ref} />;
 };
 
 export default CodeEditor;

--- a/packages/@remirror/playground/src/compile.tsx
+++ b/packages/@remirror/playground/src/compile.tsx
@@ -51,7 +51,7 @@ export function compile(
        * **MUST NOT** have their `@babel/preset-` or `@babel/plugin-` prefixes
        * otherwise they WILL NOT WORK.
        */
-      presets: ['react', 'env', 'typescript'],
+      presets: ['react', ['env', { useBuiltIns: false }], 'typescript'],
       plugins: [
         ['transform-runtime'],
         ['proposal-object-rest-spread'],

--- a/packages/@remirror/playground/src/execute.tsx
+++ b/packages/@remirror/playground/src/execute.tsx
@@ -234,5 +234,5 @@ export const Execute: FC<ExecuteProps> = function (props) {
     };
   }, [code, requires]);
 
-  return <div ref={ref} />;
+  return <div ref={ref} style={{ height: '100%' }} />;
 };

--- a/packages/@remirror/playground/src/index.tsx
+++ b/packages/@remirror/playground/src/index.tsx
@@ -66,6 +66,7 @@ const Loading: FC<{ hasBabel: boolean }> = ({ hasBabel }) => {
   return (
     <div
       style={{
+        height: '100%',
         display: 'flex',
         maxWidth: '50rem',
         margin: '0 auto',

--- a/packages/@remirror/playground/src/index.tsx
+++ b/packages/@remirror/playground/src/index.tsx
@@ -33,12 +33,62 @@ export const Playground: FC = () => {
     });
   }, [hasBabel]);
 
-  return Component ? (
-    <Component />
-  ) : hasBabel ? (
-    <p>Loading monaco editor...</p>
-  ) : (
-    <p>Waiting for babel...</p>
+  return Component ? <Component /> : <Loading hasBabel={hasBabel} />;
+};
+
+const Loading: FC<{ hasBabel: boolean }> = ({ hasBabel }) => {
+  const [numberOfDots, setNumberOfDots] = useState(3);
+  useEffect(() => {
+    const dotsPlusPlus = () => {
+      setNumberOfDots((dots) => (dots > 2 ? 0 : dots + 1));
+    };
+    const interval = setInterval(dotsPlusPlus, 300);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  const show = {};
+  const hide = { visibility: 'hidden' };
+
+  const dots = [
+    <span key={1} style={numberOfDots >= 1 ? show : hide}>
+      .
+    </span>,
+    <span key={2} style={numberOfDots >= 2 ? show : hide}>
+      .
+    </span>,
+    <span key={3} style={numberOfDots >= 3 ? show : hide}>
+      .
+    </span>,
+  ];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        maxWidth: '50rem',
+        margin: '0 auto',
+        padding: '2rem',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <div style={{ flex: '0 0 300px' }}>
+        <img
+          width='300'
+          height='300'
+          src='https://raw.githubusercontent.com/remirror/remirror/next/support/assets/logo-animated-light.svg?sanitize=true'
+          alt='animated remirror logo'
+        />
+      </div>
+      <div style={{ flex: '1 0 16rem', padding: '0 0 0 2rem', textAlign: 'center' }}>
+        Loading {!hasBabel ? 'babel' : 'monaco'}
+        {dots}
+      </div>
+    </div>
   );
 };
 

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -249,10 +249,10 @@ const copy = (text: string) => {
   textarea.style.top = '0';
   textarea.style.left = '-10000px';
   textarea.style.opacity = '0.0001';
-  document.body.appendChild(textarea);
+  document.body.append(textarea);
   textarea.value = text;
   textarea.select();
   textarea.setSelectionRange(0, 999999);
   document.execCommand('copy');
-  document.body.removeChild(textarea);
+  textarea.remove();
 };

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -249,7 +249,7 @@ export const Playground: FC = () => {
       };
     }
     const encoded = encode(state);
-    const hash = `o/${encoded}`;
+    const hash = `#o/${encoded}`;
     if (hash !== ourHash.current) {
       ourHash.current = hash;
       window.location.hash = hash;

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -181,26 +181,41 @@ export const Playground: FC = () => {
   return (
     <Container>
       <Main>
-        <Panel flex='0 0 16rem' overflow>
-          {advanced ? (
-            <div>
-              <button onClick={handleToggleAdvanced}>Enter simple mode</button>
-            </div>
-          ) : (
-            <SimplePanel
-              options={options}
-              setOptions={setOptions}
-              modules={modules}
-              addModule={addModule}
-              removeModule={removeModule}
-              onAdvanced={handleToggleAdvanced}
-            />
-          )}
-        </Panel>
-        <Divide />
+        {advanced ? null : (
+          <>
+            <Panel flex='0 0 18rem' overflow>
+              <SimplePanel
+                options={options}
+                setOptions={setOptions}
+                modules={modules}
+                addModule={addModule}
+                removeModule={removeModule}
+                onAdvanced={handleToggleAdvanced}
+              />
+            </Panel>
+            <Divide />
+          </>
+        )}
         <Panel vertical>
           <ErrorBoundary>
-            <CodeEditor value={code} onChange={setValue} readOnly={!advanced} />
+            <div
+              style={{
+                flex: '1',
+                overflow: 'hidden',
+                backgroundColor: 'white',
+                display: 'flex',
+                position: 'relative',
+              }}
+            >
+              <CodeEditor value={code} onChange={setValue} readOnly={!advanced} />
+              <div style={{ position: 'absolute', bottom: '1rem', right: '2rem' }}>
+                {advanced ? (
+                  <button onClick={handleToggleAdvanced}>Enter simple mode</button>
+                ) : (
+                  <button onClick={handleToggleAdvanced}>Enter advanced mode</button>
+                )}
+              </div>
+            </div>
           </ErrorBoundary>
           <Divide />
           <ErrorBoundary>

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -232,7 +232,9 @@ export const Playground: FC = () => {
           </ErrorBoundary>
           <Divide />
           <ErrorBoundary>
-            <Viewer options={options} code={code} />
+            <div style={{ padding: '1rem', flex: '0 0 10rem', overflow: 'auto' }}>
+              <Viewer options={options} code={code} />
+            </div>
           </ErrorBoundary>
         </Panel>
       </Main>

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -178,6 +178,16 @@ export const Playground: FC = () => {
   }, [advanced, options]);
 
   const code = advanced ? value : makeCode(options);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    copy(code);
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  }, [code]);
+
   return (
     <Container>
       <Main>
@@ -210,10 +220,13 @@ export const Playground: FC = () => {
               <CodeEditor value={code} onChange={setValue} readOnly={!advanced} />
               <div style={{ position: 'absolute', bottom: '1rem', right: '2rem' }}>
                 {advanced ? (
-                  <button onClick={handleToggleAdvanced}>Enter simple mode</button>
+                  <button onClick={handleToggleAdvanced}>☑️ Enter simple mode</button>
                 ) : (
-                  <button onClick={handleToggleAdvanced}>Enter advanced mode</button>
+                  <button onClick={handleToggleAdvanced}>🤓 Enter advanced mode</button>
                 )}
+                <button onClick={handleCopy} style={{ marginLeft: '0.5rem' }}>
+                  📋 {copied ? 'Copied code!' : 'Copy code'}
+                </button>
               </div>
             </div>
           </ErrorBoundary>
@@ -225,4 +238,19 @@ export const Playground: FC = () => {
       </Main>
     </Container>
   );
+};
+
+/** Copies text to the clipboard */
+const copy = (text: string) => {
+  const textarea = document.createElement('textarea');
+  textarea.style.position = 'absolute';
+  textarea.style.top = '0';
+  textarea.style.left = '-10000px';
+  textarea.style.opacity = '0.0001';
+  document.body.appendChild(textarea);
+  textarea.value = text;
+  textarea.select();
+  textarea.setSelectionRange(0, 999999);
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
 };

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -5,7 +5,7 @@ import { ErrorBoundary } from './error-boundary';
 import { makeRequire, REQUIRED_MODULES } from './execute';
 import { CodeOptions, Exports, RemirrorModules } from './interfaces';
 import { makeCode } from './make-code';
-import { Container, Divide, Header, Main, Panel } from './primitives';
+import { Container, Divide, Main, Panel } from './primitives';
 import { SimplePanel } from './simple-panel';
 import { Viewer } from './viewer';
 
@@ -42,11 +42,9 @@ const PRETTIER_SCRIPTS = [
 ];
 
 export const Playground: FC = () => {
-  console.log('Playground pre hooks');
   const [value, setValue] = useState('// Add some code here\n');
   const [advanced, setAdvanced] = useState(false);
   const [modules, setModules] = useState<RemirrorModules>({});
-  console.log('Playground post hooks');
   const addModule = useCallback((moduleName: string) => {
     setModules((oldModules) => ({
       ...oldModules,
@@ -182,9 +180,8 @@ export const Playground: FC = () => {
   const code = advanced ? value : makeCode(options);
   return (
     <Container>
-      <Header>Playground</Header>
       <Main>
-        <Panel flex='0 0 16rem'>
+        <Panel flex='0 0 16rem' overflow>
           {advanced ? (
             <div>
               <button onClick={handleToggleAdvanced}>Enter simple mode</button>

--- a/packages/@remirror/playground/src/primitives.tsx
+++ b/packages/@remirror/playground/src/primitives.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+
 const BG_COLOR = '#e0dbf5';
 
 export const Container: FC = function ({ children }) {

--- a/packages/@remirror/playground/src/primitives.tsx
+++ b/packages/@remirror/playground/src/primitives.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+const BG_COLOR = '#e0dbf5';
 
 export const Container: FC = function ({ children }) {
   return (
@@ -17,26 +18,19 @@ export const Container: FC = function ({ children }) {
   );
 };
 
-export const Header: FC = function ({ children }) {
-  return (
-    <div style={{ flex: '0 0 3rem', borderBottom: '1px solid black', background: '#aaa' }}>
-      {children}
-    </div>
-  );
-};
-
 export const Main: FC = function ({ children }) {
   return (
-    <div style={{ flex: '1', display: 'flex', backgroundColor: '#ddd', overflow: 'hidden' }}>
+    <div style={{ flex: '1', display: 'flex', backgroundColor: BG_COLOR, overflow: 'hidden' }}>
       {children}
     </div>
   );
 };
 
-export const Panel: FC<{ flex?: string; vertical?: boolean }> = function ({
+export const Panel: FC<{ flex?: string; vertical?: boolean; overflow?: boolean }> = function ({
   children,
   flex = '1 0 0',
   vertical,
+  overflow = false,
 }) {
   return (
     <div
@@ -45,7 +39,7 @@ export const Panel: FC<{ flex?: string; vertical?: boolean }> = function ({
         flex,
         display: 'flex',
         flexDirection: vertical ? 'column' : 'row',
-        overflow: 'hidden',
+        overflow: overflow ? 'auto' : 'hidden',
       }}
     >
       {children}

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -62,10 +62,10 @@ const ExtensionOrPresetCheckbox: FC<ExtensionCheckboxProps> = function (props) {
 };
 
 export const SimplePanel: FC<SimplePanelProps> = function (props) {
-  const { options, setOptions, onAdvanced, modules, addModule, removeModule } = props;
+  const { options, setOptions, modules, addModule, removeModule } = props;
 
   const onAddModule = useCallback(() => {
-    const moduleName = prompt('What module name do you wish to add?');
+    const moduleName = prompt('Enter the name of the npm module you want to import:');
 
     if (moduleName) {
       addModule(moduleName);

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -124,9 +124,7 @@ export const SimplePanel: FC<SimplePanelProps> = function (props) {
   externalModules.sort((a, b) => a[0].localeCompare(b[0]));
 
   return (
-    <div>
-      <button onClick={onAdvanced}>Switch to advanced mode</button>
-
+    <div style={{ padding: '1rem' }}>
       {/* REMIRROR CORE */}
       <p>
         <strong>Remirror core</strong>{' '}

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -125,7 +125,7 @@ export const SimplePanel: FC<SimplePanelProps> = function (props) {
 
   return (
     <div>
-      <button onClick={onAdvanced}>Enter advanced mode</button>
+      <button onClick={onAdvanced}>Switch to advanced mode</button>
 
       {/* REMIRROR CORE */}
       <p>

--- a/packages/@remirror/playground/src/viewer.tsx
+++ b/packages/@remirror/playground/src/viewer.tsx
@@ -16,7 +16,7 @@ export const Viewer: FC<ViewerProps> = function (props) {
   const { code: compiledCode, error, requires } = result;
 
   return (
-    <div style={{ flex: '1 0 0', overflow: 'auto' }}>
+    <div>
       {!error && typeof compiledCode === 'string' ? (
         <Execute code={compiledCode} requires={requires} />
       ) : (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,6 +800,8 @@ importers:
       '@remirror/react': 'link:../react'
       '@types/babel__core': 7.1.9
       '@types/babel__standalone': 7.1.2
+      '@types/lz-string': 1.3.34
+      lz-string: 1.4.4
       monaco-editor: 0.20.0
       monaco-editor-webpack-plugin: 1.9.0_monaco-editor@0.20.0
       regenerator-runtime: 0.13.5
@@ -821,9 +823,11 @@ importers:
       '@remirror/react': ^1.0.0-next.1
       '@types/babel__core': ^7.1.9
       '@types/babel__standalone': ^7.1.2
+      '@types/lz-string': ^1.3.34
       '@types/prettier': ^2.0.2
       '@types/react': ^16.9.43
       '@types/react-dom': ^16.9.8
+      lz-string: ^1.4.4
       monaco-editor: ^0.20.0
       monaco-editor-webpack-plugin: ^1.9.0
       prettier: ^2.0.5
@@ -6808,6 +6812,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
+  /@types/lz-string/1.3.34:
+    dev: false
+    resolution:
+      integrity: sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==
   /@types/match-sorter/4.0.0:
     dev: false
     resolution:
@@ -17249,6 +17257,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  /lz-string/1.4.4:
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
   /macos-release/2.4.0:
     dev: false
     engines:

--- a/support/root/.huskyrc
+++ b/support/root/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "pnpm if-config hooks.preCommit lint-staged",
-    "pre-push": "pnpm if-config hooks.prePush \"pnpm checks\""
+    "pre-commit": "pnpm run if-config hooks.preCommit lint-staged",
+    "pre-push": "pnpm run if-config hooks.prePush \"pnpm checks\""
   }
 }

--- a/support/website/src/pages/playground.module.css
+++ b/support/website/src/pages/playground.module.css
@@ -1,0 +1,4 @@
+.playground :global(.remirror-editor) {
+  border: 1px solid rgb(90, 90, 90);
+  border-radius: 3px;
+}

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -6,11 +6,12 @@ import Footer from '@theme/Footer';
 import Navbar from '@theme/Navbar';
 import ThemeProvider from '@theme/ThemeProvider';
 import UserPreferencesProvider from '@theme/UserPreferencesProvider';
+import clsx from 'clsx';
 import React from 'react';
-import styles from './playground.module.css';
 
 import { Playground } from '@remirror/playground';
-import clsx from 'clsx';
+
+import styles from './playground.module.css';
 
 const PlaygroundPage = (props: any) => {
   const { siteConfig } = useDocusaurusContext();

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -7,8 +7,10 @@ import Navbar from '@theme/Navbar';
 import ThemeProvider from '@theme/ThemeProvider';
 import UserPreferencesProvider from '@theme/UserPreferencesProvider';
 import React from 'react';
+import styles from './playground.module.css';
 
 import { Playground } from '@remirror/playground';
+import clsx from 'clsx';
 
 const PlaygroundPage = (props: any) => {
   const { siteConfig } = useDocusaurusContext();
@@ -23,7 +25,7 @@ const PlaygroundPage = (props: any) => {
   const faviconUrl = useBaseUrl(favicon);
 
   return (
-    <div className='playground'>
+    <div className={clsx('playground', styles.playground)}>
       <ThemeProvider>
         <UserPreferencesProvider>
           <Head>

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -47,7 +47,14 @@ const PlaygroundPage = (props: any) => {
           <AnnouncementBar />
           <Navbar />
           <Head></Head>
-          <div className='custom-main-wrapper'>
+          <div
+            className='custom-main-wrapper'
+            style={{
+              /* TODO: move this to CSS, make sensible */
+              position: 'relative',
+              height: 'calc(100vh - 17rem + 3px)',
+            }}
+          >
             <Playground />
           </div>
           {!noFooter && <Footer />}

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -53,6 +53,7 @@ const PlaygroundPage = (props: any) => {
               /* TODO: move this to CSS, make sensible */
               position: 'relative',
               height: 'calc(100vh - 17rem + 3px)',
+              minHeight: '400px',
             }}
           >
             <Playground />


### PR DESCRIPTION
## Description

Stores the currently playground state into the URL hash (like TypeScript playground), allowing sharing preconfigured playgrounds.

Built on top of #333 (hence that's the base branch).

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test` .

## Screenshots
![Screenshot_20200713_165942](https://user-images.githubusercontent.com/129910/87326253-6579c980-c52a-11ea-9805-97bed72ed0b1.png)

