### PR TITLE
Enable the Playground on the website

### DIFF
--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -127,8 +127,8 @@ export const SimplePanel: FC<SimplePanelProps> = function (props) {
     <div style={{ padding: '1rem' }}>
       {/* REMIRROR CORE */}
       <p style={{ fontSize: '0.8rem' }}>
-        ⚠️ Remirror Playground is <em>highly experimental;</em> we've released it in this very early
-        state because it's a useful tool... when it works.{' '}
+        ⚠️ Remirror Playground is <em>highly experimental;</em> we&rsquo;ve released it in this very
+        early state because it&rsquo;s a useful tool... when it works.{' '}
         <a href='https://github.com/remirror/remirror/issues/new?template=bug_report.md'>
           Report a bug.
         </a>

--- a/packages/@remirror/playground/src/simple-panel.tsx
+++ b/packages/@remirror/playground/src/simple-panel.tsx
@@ -126,6 +126,13 @@ export const SimplePanel: FC<SimplePanelProps> = function (props) {
   return (
     <div style={{ padding: '1rem' }}>
       {/* REMIRROR CORE */}
+      <p style={{ fontSize: '0.8rem' }}>
+        ⚠️ Remirror Playground is <em>highly experimental;</em> we've released it in this very early
+        state because it's a useful tool... when it works.{' '}
+        <a href='https://github.com/remirror/remirror/issues/new?template=bug_report.md'>
+          Report a bug.
+        </a>
+      </p>
       <p>
         <strong>Remirror core</strong>{' '}
       </p>

--- a/support/website/docusaurus.config.js
+++ b/support/website/docusaurus.config.js
@@ -25,7 +25,7 @@ module.exports = {
           label: 'Docs',
           position: 'right',
         },
-        // { to: 'playground', label: 'Playground', position: 'right' },
+        { to: 'playground', label: 'Playground', position: 'right' },
         { to: 'blog', label: 'Blog', position: 'right' },
         {
           href: 'https://github.com/remirror/remirror',


### PR DESCRIPTION
## Description

This PR adds a notice to the playground so that we can feel more comfortable enabling it on the public website.

This is built on #333 and #334.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test` .

## Screenshots

![Screenshot_20200713_171751](https://user-images.githubusercontent.com/129910/87328188-05d0ed80-c52d-11ea-8245-cb4e34bd4699.png)

