### PR TITLE
Require Node 14 for development

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "typescript-styled-plugin": "^0.15.0"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "pnpm": "^5.3.0"
   },
   "manypkg": {


### PR DESCRIPTION
## Description

Node 12 doesn't support `??`, and to be honest developing on Node 14 is fine, it doesn't affect what versions the actual project supports.

```
$ yarn docs
yarn run v1.22.4
warning root@: The engine "pnpm" appears to be invalid.
$ cd support/website && pnpm start

> @remirror/website@0.0.0 start /home/benjie/Dev/Sprout/remirror/support/website
> docusaurus start

Starting the development server...
/home/benjie/Dev/Sprout/remirror/support/website/plugins/monaco-editor.js:28
        for (const item of rule.use ?? []) {
                                     ^

SyntaxError: Unexpected token '?'
    at wrapSafe (internal/modules/cjs/loader.js:1070:16)
    at Module._compile (internal/modules/cjs/loader.js:1120:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1176:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Module.require (internal/modules/cjs/loader.js:1042:19)
    at Object.module.exports [as default] (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/import-fresh@3.2.1/node_modules/import-fresh/index.js:31:59)
    at /home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/lib/server/plugins/init.js:42:52
    at Array.map (<anonymous>)
    at Object.initPlugins (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/lib/server/plugins/init.js:24:10)
    at Object.loadPlugins (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/lib/server/plugins/index.js:47:28)
    at Object.load (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/lib/server/index.js:57:62)
    at start (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/lib/commands/start.js:45:34)
    at /home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/bin/docusaurus.js:29:5
    at Command.<anonymous> (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/@docusaurus/core@2.0.0-alpha.58_react-dom@16.13.1+react@16.13.1/node_modules/@docusaurus/core/bin/docusaurus.js:97:23)
    at Command.listener (/home/benjie/Dev/Sprout/remirror/node_modules/.pnpm/commander@4.1.1/node_modules/commander/index.js:370:29)
 ERROR  Command failed with exit code 1.
error Command failed with exit code 1.
```

## Checklist


- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test` .

