### PR TITLE
Playground serialization/deserialization

### DIFF
--- a/packages/@remirror/extension-trailing-node/src/trailing-node-extension.ts
+++ b/packages/@remirror/extension-trailing-node/src/trailing-node-extension.ts
@@ -101,7 +101,7 @@ export class TrailingNodeExtension extends PlainExtension<TrailingNodeOptions> {
           update: (view) => {
             const { state, dispatch } = view;
             const { doc } = state;
-            const shouldInsertNodeAtEnd = this.getPluginState<boolean>();
+            const shouldInsertNodeAtEnd = this.getPluginState<boolean>(state);
             const endPosition = doc.content.size;
 
             if (!shouldInsertNodeAtEnd) {

--- a/packages/@remirror/playground/scripts/import-remirror.ts
+++ b/packages/@remirror/playground/scripts/import-remirror.ts
@@ -72,9 +72,6 @@ function template({ extensions, presets }: Everything) {
 *                                                                              *
 \\******************************************************************************/
 
-// Remirror custom imports
-import { RemirrorProvider, useExtension, useManager, useRemirror } from '@remirror/react';
-
 import { useRemirrorPlayground } from './use-remirror-playground';
 
 export const IMPORT_CACHE: { [moduleName: string]: any } = {
@@ -83,11 +80,13 @@ export const IMPORT_CACHE: { [moduleName: string]: any } = {
 
   // Manual-imported
   remirror: require('remirror'),
-  'remirror/react': { RemirrorProvider, useManager, useExtension, useRemirror },
+  'remirror/react': require('remirror/react'),
   '@remirror/playground': { useRemirrorPlayground },
 
   // External dependencies
   '@babel/runtime/helpers/interopRequireDefault': require('@babel/runtime/helpers/interopRequireDefault'),
+  '@babel/runtime/helpers/interopRequireWildcard': require('@babel/runtime/helpers/interopRequireWildcard'),
+  '@babel/runtime/helpers/slicedToArray': require('@babel/runtime/helpers/slicedToArray'),
   react: require('react'),
 };
 

--- a/packages/@remirror/playground/src/_remirror.tsx
+++ b/packages/@remirror/playground/src/_remirror.tsx
@@ -54,11 +54,13 @@ export const IMPORT_CACHE: { [moduleName: string]: any } = {
 
   // Manual-imported
   remirror: require('remirror'),
-  'remirror/react': { RemirrorProvider, useManager, useExtension, useRemirror },
+  'remirror/react': require('remirror/react'),
   '@remirror/playground': { useRemirrorPlayground },
 
   // External dependencies
   '@babel/runtime/helpers/interopRequireDefault': require('@babel/runtime/helpers/interopRequireDefault'),
+  '@babel/runtime/helpers/interopRequireWildcard': require('@babel/runtime/helpers/interopRequireWildcard'),
+  '@babel/runtime/helpers/slicedToArray': require('@babel/runtime/helpers/slicedToArray'),
   react: require('react'),
 };
 

--- a/packages/@remirror/playground/src/_remirror.tsx
+++ b/packages/@remirror/playground/src/_remirror.tsx
@@ -6,9 +6,6 @@
 *                                                                              *
 \******************************************************************************/
 
-// Remirror custom imports
-import { RemirrorProvider, useExtension, useManager, useRemirror } from '@remirror/react';
-
 import { useRemirrorPlayground } from './use-remirror-playground';
 
 export const IMPORT_CACHE: { [moduleName: string]: any } = {

--- a/packages/@remirror/playground/src/context.tsx
+++ b/packages/@remirror/playground/src/context.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { EditorSchema, EditorState, RemirrorJSON } from 'remirror/core';
+
+export interface PlaygroundContextObject {
+  setContent: (state: Readonly<EditorState>) => void;
+  onContentChange: (callback: (state: RemirrorJSON) => void) => void;
+}
+
+export const PlaygroundContext = React.createContext<PlaygroundContextObject>({
+  setContent: () => {
+    console.warn('No playground context found, setContent ignored');
+  },
+  onContentChange: () => {
+    return () => {};
+  },
+});

--- a/packages/@remirror/playground/src/context.tsx
+++ b/packages/@remirror/playground/src/context.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { EditorSchema, EditorState, RemirrorJSON } from 'remirror/core';
+import { EditorState, RemirrorJSON } from 'remirror/core';
 
 export interface PlaygroundContextObject {
   setContent: (state: Readonly<EditorState>) => void;

--- a/packages/@remirror/playground/src/execute.tsx
+++ b/packages/@remirror/playground/src/execute.tsx
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 import { languages } from 'monaco-editor';
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
+import React, { FC, useEffect, useMemo, useRef, useState, useContext } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
 // addImport('@remirror/react', 'RemirrorProvider');
@@ -14,6 +14,7 @@ import { IMPORT_CACHE, INTERNAL_MODULES } from './_remirror';
 //import * as remirror from 'remirror';
 import { ErrorBoundary } from './error-boundary';
 import { acquiredTypeDefs, dtsCache } from './vendor/type-acquisition';
+import { PlaygroundContext, PlaygroundContextObject } from './context';
 
 // Start with these and cannot remove them
 export const REQUIRED_MODULES = INTERNAL_MODULES.map((mod) => mod.moduleName);
@@ -150,7 +151,11 @@ function runCode(code: string, requireFn: (mod: string) => any) {
 
 function runCodeInDiv(
   div: HTMLDivElement,
-  { code, requires }: { code: string; requires: string[] },
+  {
+    code,
+    requires,
+    playground,
+  }: { code: string; requires: string[]; playground: PlaygroundContextObject },
 ) {
   let active = true;
   (async function doIt() {
@@ -169,7 +174,9 @@ function runCodeInDiv(
       // Then mount the React element into the div
       render(
         <ErrorBoundary>
-          <Component />
+          <PlaygroundContext.Provider value={playground}>
+            <Component />
+          </PlaygroundContext.Provider>
         </ErrorBoundary>,
         div,
       );
@@ -223,16 +230,17 @@ export const Execute: FC<ExecuteProps> = function (props) {
   const { code: rawCode, requires: rawRequires } = props;
   const ref = useRef<HTMLDivElement | null>(null);
   const [code, requires] = useDebouncedValue([rawCode, rawRequires]);
+  const playground = useContext(PlaygroundContext);
   useEffect(() => {
     if (!ref.current) {
       return;
     }
 
-    const release = runCodeInDiv(ref.current, { code, requires });
+    const release = runCodeInDiv(ref.current, { code, requires, playground });
     return () => {
       release();
     };
-  }, [code, requires]);
+  }, [code, requires, playground]);
 
   return <div ref={ref} style={{ height: '100%' }} />;
 };

--- a/packages/@remirror/playground/src/execute.tsx
+++ b/packages/@remirror/playground/src/execute.tsx
@@ -1,6 +1,6 @@
 import * as crypto from 'crypto';
 import { languages } from 'monaco-editor';
-import React, { FC, useEffect, useMemo, useRef, useState, useContext } from 'react';
+import React, { FC, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 
 // addImport('@remirror/react', 'RemirrorProvider');
@@ -9,12 +9,12 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { debounce } from '@remirror/core-helpers';
 
 import { IMPORT_CACHE, INTERNAL_MODULES } from './_remirror';
+import { PlaygroundContext, PlaygroundContextObject } from './context';
 // import * as remirrorCoreExtensions from '@remirror/core-extensions';
 //import * as remirrorReact from '@remirror/react';
 //import * as remirror from 'remirror';
 import { ErrorBoundary } from './error-boundary';
 import { acquiredTypeDefs, dtsCache } from './vendor/type-acquisition';
-import { PlaygroundContext, PlaygroundContextObject } from './context';
 
 // Start with these and cannot remove them
 export const REQUIRED_MODULES = INTERNAL_MODULES.map((mod) => mod.moduleName);

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
 import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { EditorSchema, EditorState } from 'remirror/core';
+import { EditorState } from 'remirror/core';
 
 import CodeEditor from './code-editor';
 import { PlaygroundContext, PlaygroundContextObject } from './context';
@@ -250,7 +250,7 @@ export const Playground: FC = () => {
         // TODO: indicate JSON error
       }
     },
-    [eventEmitter],
+    [eventEmitter, setPlaygroundState],
   );
 
   const [textareaIsFocussed, setTextareaIsFocussed] = useState(false);

--- a/packages/@remirror/playground/src/playground.tsx
+++ b/packages/@remirror/playground/src/playground.tsx
@@ -1,9 +1,12 @@
 import assert from 'assert';
-import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
-import React, { FC, useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import { EventEmitter } from 'events';
+import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { EditorSchema, EditorState } from 'remirror/core';
 
 import CodeEditor from './code-editor';
+import { PlaygroundContext, PlaygroundContextObject } from './context';
 import { ErrorBoundary } from './error-boundary';
 import { makeRequire, REQUIRED_MODULES } from './execute';
 import { CodeOptions, Exports, RemirrorModules } from './interfaces';
@@ -11,8 +14,6 @@ import { makeCode } from './make-code';
 import { Container, Divide, Main, Panel } from './primitives';
 import { SimplePanel } from './simple-panel';
 import { Viewer } from './viewer';
-import { PlaygroundContext, PlaygroundContextObject } from './context';
-import { EditorState, EditorSchema } from 'remirror/core';
 
 export { useRemirrorPlayground } from './use-remirror-playground';
 
@@ -43,9 +44,7 @@ function cleanse(moduleName: string, moduleExports: Exports): Exports {
 
 export const Playground: FC = () => {
   const [value, setValue] = useState('// Add some code here\n');
-  const [contentValue, setContentValue] = useState<Readonly<EditorState<EditorSchema>> | null>(
-    null,
-  );
+  const [contentValue, setContentValue] = useState<Readonly<EditorState> | null>(null);
   const [advanced, setAdvanced] = useState(false);
   const [modules, setModules] = useState<RemirrorModules>({});
   const addModule = useCallback((moduleName: string) => {
@@ -199,6 +198,7 @@ export const Playground: FC = () => {
         c: value,
       };
     }
+
     return state;
   }, [advanced, value, options, modules]);
 
@@ -225,7 +225,7 @@ export const Playground: FC = () => {
   } => {
     const eventEmitter = new EventEmitter();
     const playground: PlaygroundContextObject = {
-      setContent: (state: Readonly<EditorState<EditorSchema>>) => {
+      setContent: (state: Readonly<EditorState>) => {
         setContentValue(state);
       },
       onContentChange: (callback) => {
@@ -246,7 +246,7 @@ export const Playground: FC = () => {
         const json = JSON.parse(text);
         setPlaygroundState(json.playground);
         eventEmitter.emit('change', json.doc);
-      } catch (e) {
+      } catch {
         // TODO: indicate JSON error
       }
     },

--- a/packages/@remirror/playground/src/use-remirror-playground.tsx
+++ b/packages/@remirror/playground/src/use-remirror-playground.tsx
@@ -50,7 +50,16 @@ export function useRemirrorPlayground(
 
   useEffect(() => {
     playground.setContent(value);
-  }, [value]);
+  }, [playground, value]);
+  useEffect(() => {
+    const unlisten = playground.onContentChange((json) => {
+      const state = extensionManager.createState({
+        content: json,
+      });
+      setValue(state);
+    });
+    return unlisten;
+  }, [playground]);
 
   return { value, onChange };
 }

--- a/packages/@remirror/playground/src/use-remirror-playground.tsx
+++ b/packages/@remirror/playground/src/use-remirror-playground.tsx
@@ -61,7 +61,7 @@ export function useRemirrorPlayground(
       setValue(state);
     });
     return unlisten;
-  }, [playground]);
+  }, [playground, extensionManager]);
 
   return { value, onChange };
 }

--- a/packages/@remirror/playground/src/use-remirror-playground.tsx
+++ b/packages/@remirror/playground/src/use-remirror-playground.tsx
@@ -56,6 +56,7 @@ export function useRemirrorPlayground(
       const state = extensionManager.createState({
         content: json,
       });
+      PERSIST.lastKnownGoodState = state;
       setValue(state);
     });
     return unlisten;

--- a/packages/@remirror/playground/src/use-remirror-playground.tsx
+++ b/packages/@remirror/playground/src/use-remirror-playground.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect, useContext } from 'react';
 
 import {
   AnyCombinedUnion,
@@ -9,6 +9,7 @@ import {
   RemirrorJSON,
   RemirrorManager,
 } from 'remirror/core';
+import { PlaygroundContext } from './context';
 
 declare global {
   interface Window {
@@ -34,6 +35,7 @@ export function useRemirrorPlayground(
   value: EditorState;
   onChange: RemirrorEventListener<AnyCombinedUnion>;
 } {
+  const playground = useContext(PlaygroundContext);
   const [value, setValue] = useState<EditorState>(
     extensionManager.createState({
       content: PERSIST.lastKnownGoodState
@@ -45,6 +47,10 @@ export function useRemirrorPlayground(
     PERSIST.lastKnownGoodState = event.state;
     setValue(event.state);
   }, []);
+
+  useEffect(() => {
+    playground.setContent(value);
+  }, [value]);
 
   return { value, onChange };
 }

--- a/packages/@remirror/playground/src/use-remirror-playground.tsx
+++ b/packages/@remirror/playground/src/use-remirror-playground.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useContext } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 
 import {
   AnyCombinedUnion,
@@ -9,6 +9,7 @@ import {
   RemirrorJSON,
   RemirrorManager,
 } from 'remirror/core';
+
 import { PlaygroundContext } from './context';
 
 declare global {


### PR DESCRIPTION
## Description

Adds a textarea to the bottom of the playground showing the full state of the playground, including the document itself. This textarea is editable, so you can save reproduction cases and share them with others (e.g. to demonstrate configs, or to help reproduce bugs).

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test` .

## Screenshots

![Screenshot_20200716_154446](https://user-images.githubusercontent.com/129910/87685650-8dac3700-c77b-11ea-8da9-82cc97520aba.png)

- note
  - note
  - note
- note
