### PR TITLE
fix(react): correct `previousState` for controlled editors

### DIFF
--- a/.changeset/olive-rockets-shout.md
+++ b/.changeset/olive-rockets-shout.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react': patch
+---
+
+Fix a bug where the previous state was always equal to the updated state for controlled editors. This caused problems with functionality that relies on comparing state values e.g. `PositionerExtension`.

--- a/packages/@remirror/core/src/editor-wrapper.ts
+++ b/packages/@remirror/core/src/editor-wrapper.ts
@@ -60,6 +60,11 @@ export abstract class EditorWrapper<
   #previousState: EditorState<SchemaFromCombined<Combined>> | undefined;
 
   /**
+   * A previous state that can be overridden by the framework implementation.
+   */
+  protected previousStateOverride?: EditorState<SchemaFromCombined<Combined>>;
+
+  /**
    * True when this is the first render.
    */
   #firstRender = true;
@@ -84,7 +89,7 @@ export abstract class EditorWrapper<
   /**
    * The props passed in when creating or updating the `EditorWrapper` instance.
    */
-  protected get props(): Props {
+  get props(): Props {
     return this.#getProps();
   }
 
@@ -94,7 +99,7 @@ export abstract class EditorWrapper<
    * current state will always be equal.
    */
   protected get previousState(): EditorState<SchemaFromCombined<Combined>> {
-    return this.#previousState ?? this.view.state;
+    return this.previousStateOverride ?? this.#previousState ?? this.view.state;
   }
 
   /**
@@ -168,7 +173,7 @@ export abstract class EditorWrapper<
   }
 
   /**
-   * Retrieve the editor state. This is passed through to the extension manager.
+   * Retrieve the editor state.
    */
   protected readonly getState = () => this.view.state;
 

--- a/packages/@remirror/react/src/components/__tests__/__snapshots__/react-editor-controlled.spec.tsx.snap
+++ b/packages/@remirror/react/src/components/__tests__/__snapshots__/react-editor-controlled.spec.tsx.snap
@@ -67,6 +67,22 @@ exports[`Remirror Controlled Component should set the initial value 1`] = `
 </div>
 `;
 
+exports[`Remirror Controlled Component throws when switching from controlled to non-controlled 1`] = `
+"There is a problem with your controlled editor setup.
+
+You have attempted to switch from a controlled to an uncontrolled editor. Once you set up an editor as a controlled editor it must always provide a \`value\` prop.
+
+For more information visit https://remirror.io/docs/errors#rmr0203"
+`;
+
+exports[`Remirror Controlled Component throws when switching from non-controlled to controlled 1`] = `
+"There is a problem with your controlled editor setup.
+
+You have provided a \`value\` prop to an uncontrolled editor. In order to set up your editor as controlled you must provide the \`value\` prop from the very first render.
+
+For more information visit https://remirror.io/docs/errors#rmr0203"
+`;
+
 exports[`Remirror Controlled Component throws when using  \`setContent\` updates 1`] = `
 "There is a problem with your controlled editor setup.
 

--- a/packages/@remirror/react/src/components/__tests__/remirror-provider.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/remirror-provider.spec.tsx
@@ -32,6 +32,7 @@ test('`RemirrorProvider`', () => {
 test('multiple `getRootProps` applied to dom throw an error', () => {
   const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
   const manager = createReactManager([]);
+
   const TestComponent: FC = () => {
     const { getRootProps } = useRemirror();
 

--- a/packages/@remirror/react/src/hooks/editor-hooks.ts
+++ b/packages/@remirror/react/src/hooks/editor-hooks.ts
@@ -335,7 +335,7 @@ export function useManager<Combined extends AnyCombinedUnion>(
 
   useEffect(() => {
     return manager.addHandler('destroy', () => {
-      setManager(nextManager);
+      setManager(nextManager.clone());
     });
   }, [manager, nextManager]);
 

--- a/support/e2e/server.config.js
+++ b/support/e2e/server.config.js
@@ -51,6 +51,11 @@ const servers = (exports.servers = {
 });
 
 const editors = (exports.editors = {
+  positioner: {
+    next: {
+      empty: 'http://localhost:3030/editor/positioner',
+    },
+  },
   social: {
     next: {
       empty: 'http://localhost:3030/editor/social',

--- a/support/e2e/src/__snapshots__/positioner.e2e.test.ts.snap
+++ b/support/e2e/src/__snapshots__/positioner.e2e.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Positioner Bubble menu should show the bubble menu 1`] = `
+<p class>
+  This is text
+</p>
+`;
+
+exports[`Positioner Bubble menu should show the bubble menu 2`] = `
+<p class>
+  <strong>
+    This is text
+  </strong>
+</p>
+`;

--- a/support/e2e/src/helpers/test-environment.ts
+++ b/support/e2e/src/helpers/test-environment.ts
@@ -32,7 +32,7 @@ declare global {
   }
 
   type RemirrorTestServers = 'next' | 'docs';
-  type RemirrorTestEditors = 'social' | 'wysiwyg' | 'epic';
+  type RemirrorTestEditors = 'social' | 'wysiwyg' | 'epic' | 'positioner';
   type SupportedBrowserName = 'firefox' | 'chromium' | 'webkit';
 }
 

--- a/support/e2e/src/positioner.e2e.test.ts
+++ b/support/e2e/src/positioner.e2e.test.ts
@@ -1,0 +1,40 @@
+import { getDocument, queries } from 'playwright-testing-library';
+import { ElementHandle } from 'playwright-testing-library/dist/typedefs';
+
+import { selectAll } from './helpers';
+
+const { getByRole, getByTestId, getByText } = queries;
+const path = __SERVER__.urls.positioner.empty;
+
+describe('Positioner', () => {
+  let $document: ElementHandle;
+  let $editor: ElementHandle;
+
+  beforeEach(async () => {
+    await page.goto(path);
+    $document = await getDocument(page);
+    $editor = await getByRole($document, 'textbox');
+  });
+
+  describe('Bubble menu', () => {
+    it('should show the bubble menu', async () => {
+      await $editor.focus();
+      await $editor.type('This is text');
+      await expect($editor.innerHTML()).resolves.toMatchSnapshot();
+      const $bubbleMenu = await getByTestId($document, 'bubble-menu');
+      await expect($bubbleMenu.getAttribute('style')).resolves.toBe(
+        'bottom:99999px;left:-99999px;position:absolute',
+      );
+
+      await selectAll();
+      const $visibleBubbleMenu = await getByTestId($document, 'bubble-menu');
+      const newStyles = await $visibleBubbleMenu.getAttribute('style');
+      expect(newStyles).not.toInclude('99999px');
+
+      const $boldButton = await getByText($document, 'Bold');
+      await $boldButton.click();
+
+      await expect($editor.innerHTML()).resolves.toMatchSnapshot();
+    });
+  });
+});

--- a/support/examples/with-next/src/pages/editor/positioner.tsx
+++ b/support/examples/with-next/src/pages/editor/positioner.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useState } from 'react';
+
+import { EMPTY_PARAGRAPH_NODE } from 'remirror/core';
+import { BoldExtension } from 'remirror/extension/bold';
+import { HeadingExtension } from 'remirror/extension/heading';
+import { ItalicExtension } from 'remirror/extension/italic';
+import { UnderlineExtension } from 'remirror/extension/underline';
+import { ListPreset } from 'remirror/preset/list';
+import { RemirrorProvider, useManager, usePositioner, useRemirror } from 'remirror/react';
+
+const EXTENSIONS = [
+  new HeadingExtension(),
+  new BoldExtension(),
+  new ItalicExtension(),
+  new UnderlineExtension(),
+  new ListPreset(),
+];
+
+function Menu() {
+  const [activeCommands, setActiveCommands] = useState({
+    bold: false,
+    italic: false,
+    underline: false,
+  });
+
+  const { commands, active } = useRemirror<BoldExtension | ItalicExtension | UnderlineExtension>(
+    () => {
+      setActiveCommands({
+        bold: active.bold(),
+        italic: active.italic(),
+        underline: active.underline(),
+      });
+    },
+  );
+
+  // The use positioner hook allows for tracking the current selection in the editor.
+  const { bottom, left, ref } = usePositioner('bubble');
+
+  return (
+    <div ref={ref} style={{ bottom, left, position: 'absolute' }} data-testid='bubble-menu'>
+      <button
+        onClick={() => commands.toggleBold()}
+        style={{ fontWeight: activeCommands.bold ? 'bold' : undefined }}
+        data-testid='bubble-menu-bold'
+      >
+        Bold
+      </button>
+      <button
+        onClick={() => commands.toggleItalic()}
+        style={{ fontWeight: activeCommands.italic ? 'bold' : undefined }}
+      >
+        Italic
+      </button>
+      <button
+        onClick={() => commands.toggleUnderline()}
+        style={{ fontWeight: activeCommands.underline ? 'bold' : undefined }}
+      >
+        Underline
+      </button>
+    </div>
+  );
+}
+
+/**
+ * This component contains the editor and any toolbars/chrome it requires.
+ */
+const SmallEditor = () => {
+  const { getRootProps } = useRemirror();
+  return (
+    <div>
+      <div {...getRootProps()} />
+      <Menu />
+    </div>
+  );
+};
+const SmallEditorWrapper = () => {
+  const extensionManager = useManager(EXTENSIONS);
+  const [value, setValue] = useState(
+    extensionManager.createState({ content: EMPTY_PARAGRAPH_NODE }),
+  );
+
+  const onChange = useCallback((event) => {
+    setValue(event.state);
+  }, []);
+
+  return (
+    <RemirrorProvider manager={extensionManager} value={value} onChange={onChange}>
+      <SmallEditor />
+    </RemirrorProvider>
+  );
+};
+
+export default SmallEditorWrapper;

--- a/support/examples/with-next/src/pages/editor/social/content.tsx
+++ b/support/examples/with-next/src/pages/editor/social/content.tsx
@@ -9,6 +9,5 @@ const SocialEditorWithContent: FC = () => (
     characterLimit={280}
   />
 );
-SocialEditorWithContent.displayName = 'SocialEditorWithContent';
 
 export default SocialEditorWithContent;

--- a/support/examples/with-next/src/pages/editor/social/index.tsx
+++ b/support/examples/with-next/src/pages/editor/social/index.tsx
@@ -3,6 +3,5 @@ import React, { FC } from 'react';
 import { ExampleSocialEditor } from '@remirror/showcase';
 
 const SocialEditor: FC = () => <ExampleSocialEditor suppressHydrationWarning={true} />;
-SocialEditor.displayName = 'SocialEditor';
 
 export default SocialEditor;


### PR DESCRIPTION
## Description

Closes #365
Closes #364

<!-- Describe your changes in detail and reference any issues it addresses-->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

<!-- Delete this section if not applicable -->
