### PR TITLE
fix(react-social): trapped cursor in mentions

### DIFF
--- a/.changeset/warm-sloths-admire.md
+++ b/.changeset/warm-sloths-admire.md
@@ -1,0 +1,14 @@
+---
+'@remirror/core-utils': minor
+'prosemirror-suggest': minor
+'@remirror/extension-auto-link': patch
+'@remirror/extension-mention': patch
+'@remirror/preset-social': patch
+'@remirror/react-social': patch
+---
+
+- Add `keepSelection` property to the `replaceText` command function.
+- Prevent mentions from trapping the cursor when arrowing left and right through the mention.
+- Set low priority for `AutoLinkExtension` to prevent `appendTransaction` interfering with mentions.
+- Update extension order in the `SocialPreset`
+- `prosemirror-suggest` - New export `isSelectionExitReason` which let's the user know if the exit was due to a selection change or a character entry.

--- a/docs/showcase/social.mdx
+++ b/docs/showcase/social.mdx
@@ -3,10 +3,13 @@ title: Social
 ---
 
 import { ExampleSocialEditor } from '@remirror/showcase';
+import { ProsemirrorDevTools } from '@remirror/dev';
 
 Below is an example of a social editor using the `@remirror/react-social` package.
 
 To test it out try adding an **`@`** mention or a **`#`** mention. Also typing **`:`** will activate
 the emoji search extension.
 
-<ExampleSocialEditor autoFocus={true} placeholder='Start typing...' />
+<ExampleSocialEditor autoFocus={true} placeholder='Start typing...'>
+  <ProsemirrorDevTools />
+</ExampleSocialEditor>

--- a/packages/@remirror/extension-auto-link/src/auto-link-extension.ts
+++ b/packages/@remirror/extension-auto-link/src/auto-link-extension.ts
@@ -6,6 +6,7 @@ import {
   EditorState,
   EditorStateParameter,
   EditorView,
+  ExtensionPriority,
   findMatches,
   FromToParameter,
   getMatchString,
@@ -32,11 +33,11 @@ import { ReplaceStep } from '@remirror/pm/transform';
  * It's inspired by the behavior of several social sites like `twitter`.
  */
 export class AutoLinkExtension extends MarkExtension<AutoLinkOptions> {
+  static readonly defaultPriority = ExtensionPriority.Low;
   static readonly defaultOptions: DefaultExtensionOptions<AutoLinkOptions> = {
     urlRegex: /((http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/.*)?)/gi,
     defaultProtocol: '',
   };
-
   static readonly handlerKeys: HandlerKeyList<AutoLinkOptions> = ['onUrlUpdate'];
 
   get name() {

--- a/packages/@remirror/preset-social/src/social-preset.ts
+++ b/packages/@remirror/preset-social/src/social-preset.ts
@@ -149,6 +149,6 @@ export class SocialPreset extends Preset<SocialOptions> {
     mentionExtension.addHandler('onChange', this.options.onChange);
     mentionExtension.addHandler('onExit', this.options.onExit);
 
-    return [autoLinkExtension, emojiExtension, mentionExtension];
+    return [emojiExtension, mentionExtension, autoLinkExtension];
   }
 }

--- a/packages/@remirror/react-social/src/hooks/__tests__/use-social-mention.spec.tsx
+++ b/packages/@remirror/react-social/src/hooks/__tests__/use-social-mention.spec.tsx
@@ -70,6 +70,37 @@ describe('useSocialMention', () => {
     `);
   });
 
+  it('should not trap the cursor in the mention', () => {
+    const { chain, Wrapper, getTags, getUsers, onChange } = createChain();
+
+    renderHook(
+      () => useSocialMention({ users: getUsers(), tags: getTags(), onMentionChange: onChange }),
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    acts([
+      () => {
+        chain.insertText('@a').selectText(1).insertText('ab ');
+      },
+    ]);
+
+    expect(chain.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        ab Initial content
+        <a role="presentation"
+           href="/a"
+           class="mention mention-at"
+           data-mention-id="a"
+           data-mention-name="at"
+        >
+          @a
+        </a>
+      </p>
+    `);
+  });
+
   it('should clear suggestions when the `Escape` key is pressed', () => {
     const { chain, Wrapper, getTags, getUsers, onChange } = createChain();
 

--- a/packages/prosemirror-suggest/src/suggest-predicates.ts
+++ b/packages/prosemirror-suggest/src/suggest-predicates.ts
@@ -1,4 +1,4 @@
-import { bool, isString } from '@remirror/core-helpers';
+import { bool, includes, isString } from '@remirror/core-helpers';
 import { SelectionParameter } from '@remirror/core-types';
 
 import { ChangeReason, ExitReason } from './suggest-constants';
@@ -51,6 +51,22 @@ export const isExitReason = (value: unknown): value is ExitReason =>
   isString(value) && Object.values(ExitReason).includes(value as ExitReason);
 export const isChangeReason = (value: unknown): value is ChangeReason =>
   isString(value) && Object.values(ChangeReason).includes(value as ChangeReason);
+
+/**
+ * An exit which is caused by a changed in the selection and no other change in the document.
+ */
+export function isSelectionExitReason(value: unknown) {
+  return includes(
+    [
+      ExitReason.MoveEnd,
+      ExitReason.MoveStart,
+      ExitReason.SelectionOutside,
+      ExitReason.JumpForward,
+      ExitReason.JumpBackward,
+    ],
+    value,
+  );
+}
 
 /**
  * Checks that the reason passed is a split reason. This typically means that we

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1777,6 +1777,7 @@ importers:
       '@docusaurus/preset-classic': 2.0.0-alpha.58_7ba835cdfcd941260fa6ae402e96cd88
       '@docusaurus/theme-live-codeblock': 2.0.0-alpha.58_7ba835cdfcd941260fa6ae402e96cd88
       '@mdx-js/react': 1.6.11_react@16.13.1
+      '@remirror/dev': 'link:../../packages/@remirror/dev'
       '@remirror/playground': 'link:../../packages/@remirror/playground'
       '@remirror/showcase': 'link:../../packages/@remirror/showcase'
       clsx: 1.1.1
@@ -1804,6 +1805,7 @@ importers:
       '@docusaurus/theme-live-codeblock': ^2.0.0-alpha.58
       '@docusaurus/types': ^2.0.0-alpha.58
       '@mdx-js/react': ^1.6.11
+      '@remirror/dev': ^1.0.0-next.4
       '@remirror/playground': ^1.0.0-next.4
       '@remirror/showcase': ^1.0.0-next.4
       '@types/react': ^16.9.43

--- a/support/e2e/src/__snapshots__/social.e2e.test.ts.snap
+++ b/support/e2e/src/__snapshots__/social.e2e.test.ts.snap
@@ -76,3 +76,17 @@ exports[`Social Showcase Links should parse simple urls 3`] = `
   url.co.uk
 </a>
 `;
+
+exports[`Social Showcase Mentions @ should not trap the arrow keys 1`] = `
+<p class>
+  12
+  <a role="presentation"
+     href="/a"
+     class="mention mention-at"
+     data-mention-id="a"
+     data-mention-name="at"
+  >
+    @a
+  </a>
+</p>
+`;

--- a/support/e2e/src/social.e2e.test.ts
+++ b/support/e2e/src/social.e2e.test.ts
@@ -96,6 +96,23 @@ describe('Social Showcase', () => {
         );
       });
 
+      it('should not trap the arrow keys', async () => {
+        await $editor.type('@a');
+        await press({ key: 'ArrowLeft', count: 2 });
+
+        await $editor.type('12 ');
+        await expect($editor.innerHTML()).resolves.toMatchSnapshot();
+      });
+
+      it('should not revert the mention', async () => {
+        const selector = sel(EDITOR_CLASS_SELECTOR, '.mention-at');
+        await $editor.type('@a ');
+        await press({ key: 'ArrowLeft' });
+
+        await $editor.type(' ');
+        await expect(textContent(selector)).resolves.toBe('@a');
+      });
+
       it('should accept selections onEnter', async () => {
         const selector = sel(EDITOR_CLASS_SELECTOR, '.mention-at');
 

--- a/support/website/package.json
+++ b/support/website/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/preset-classic": "^2.0.0-alpha.58",
     "@docusaurus/theme-live-codeblock": "^2.0.0-alpha.58",
     "@mdx-js/react": "^1.6.11",
+    "@remirror/dev": "^1.0.0-next.4",
     "@remirror/playground": "^1.0.0-next.4",
     "@remirror/showcase": "^1.0.0-next.4",
     "clsx": "^1.1.1",


### PR DESCRIPTION
## Description

Mentions trap the cursor when arrowing left and right through the mention.

Also fixed another bug where mentions were being blocked by the `@remirror/extension-auto-link`. This was fixed by giving the `AutoLinkExtension` a lower priority.

Closes #352

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

![2020-07-21 13 01 28](https://user-images.githubusercontent.com/1160934/88052605-64602200-cb52-11ea-9ad0-0b84b0e5061e.gif)