### PR TITLE
Improve use remirror hook

### DIFF
--- a/.changeset/fast-owls-happen.md
+++ b/.changeset/fast-owls-happen.md
@@ -1,0 +1,25 @@
+---
+'@remirror/react': minor
+'remirror': patch
+'@remirror/core': major
+'@remirror/dom': patch
+---
+
+- Rename `change` event to `updated`. `updated` is called with the `EventListenerParameter`.
+- Add new manager `stateUpdate` to the `editorWrapper`
+- Add `autoUpdate` option to `useRemirror` hook from `@remirror/react` which means that the context object returned by the hook is always up to date with the latest editor state. It will also cause the component to rerender so be careful to only use it when necessary.
+
+```tsx
+const { active, commands } = useRemirror({ autoUpdate: true });
+
+return (
+  <button
+    onClick={() => commands.toggleBold}
+    style={{ fontWeight: active.bold() ? 'bold' : undefined }}
+  >
+    B
+  </button>
+);
+```
+
+- Fix broken `onChangeHandler` parameter for the use `useRemirror` hook.

--- a/.changeset/four-dryers-clap.md
+++ b/.changeset/four-dryers-clap.md
@@ -1,0 +1,6 @@
+---
+'@remirror/react': patch
+'remirror': patch
+---
+
+Fix broken SSR and add unit tests back.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: false
 
     steps:
@@ -339,7 +339,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: false
 
     steps:

--- a/docs/errors.mdx
+++ b/docs/errors.mdx
@@ -207,9 +207,7 @@ import { BoldExtension } from 'remirror/extension/bold';
 const Editor = () => {
   const [boldActive, setBoldActive] = useState(false);
 
-  const { getRootProps, commands, active } = useRemirror(() => {
-    setBoldActive(active.bold());
-  });
+  const { getRootProps, commands, active } = useRemirror({ autoUpdate: true });
 
   return (
     <div>
@@ -247,16 +245,13 @@ The fixed code could look something like this.
 
 ```tsx
 const Menu = () => {
-  const [boldActive, setBoldActive] = useState(false);
-  const { commands, active } = useRemirror(() => {
-    setBoldActive(active.bold());
-  });
+  const { commands, active } = useRemirror({ autoUpdate: true });
 
   return (
     <>
       <button
         onClick={() => commands.toggleBold()}
-        style={{ fontWeight: activeCommands.bold ? 'bold' : undefined }}
+        style={{ fontWeight: active.bold() ? 'bold' : undefined }}
       >
         B
       </button>

--- a/docs/guide/create-editor.mdx
+++ b/docs/guide/create-editor.mdx
@@ -42,37 +42,25 @@ const EditorWrapper = () => {
 import { useRemirror } from '@remirror/react';
 
 const Menu = () => {
-  const [activeCommands, setActiveCommands] = useState({
-    bold: false,
-    italic: false,
-    underline: false,
-  });
-
-  const { getRootProps, commands, active } = useRemirror(() => {
-    setActiveCommands({
-      bold: active.bold(),
-      italic: active.italic(),
-      underline: active.underline(),
-    });
-  });
+  const { getRootProps, commands, active } = useRemirror({ autoUpdate: true });
 
   return (
     <div>
       <button
         onClick={() => commands.toggleBold()}
-        style={{ fontWeight: activeCommands.bold ? 'bold' : undefined }}
+        style={{ fontWeight: active.bold() ? 'bold' : undefined }}
       >
         B
       </button>
       <button
         onClick={() => commands.toggleItalic()}
-        style={{ fontWeight: activeCommands.italic ? 'bold' : undefined }}
+        style={{ fontWeight: active.italic() ? 'bold' : undefined }}
       >
         I
       </button>
       <button
         onClick={() => commands.toggleUnderline()}
-        style={{ fontWeight: activeCommands.underline ? 'bold' : undefined }}
+        style={{ fontWeight: active.underline() ? 'bold' : undefined }}
       >
         U
       </button>
@@ -93,37 +81,25 @@ root props are added to the div.
 ```js live
 function example() {
   function Menu() {
-    const [activeCommands, setActiveCommands] = useState({
-      bold: false,
-      italic: false,
-      underline: false,
-    });
-
-    const { getRootProps, commands, active } = useRemirror(() => {
-      setActiveCommands({
-        bold: active.bold(),
-        italic: active.italic(),
-        underline: active.underline(),
-      });
-    });
+    const { getRootProps, commands, active } = useRemirror({ autoUpdate: true });
 
     return (
       <div>
         <button
           onClick={() => commands.toggleBold()}
-          style={{ fontWeight: activeCommands.bold ? 'bold' : undefined }}
+          style={{ fontWeight: active.bold() ? 'bold' : undefined }}
         >
           B
         </button>
         <button
           onClick={() => commands.toggleItalic()}
-          style={{ fontWeight: activeCommands.italic ? 'bold' : undefined }}
+          style={{ fontWeight: active.italic() ? 'bold' : undefined }}
         >
           I
         </button>
         <button
           onClick={() => commands.toggleUnderline()}
-          style={{ fontWeight: activeCommands.underline ? 'bold' : undefined }}
+          style={{ fontWeight: active.underline() ? 'bold' : undefined }}
         >
           U
         </button>

--- a/packages/@remirror/core/src/builtins/helpers-extension.ts
+++ b/packages/@remirror/core/src/builtins/helpers-extension.ts
@@ -143,7 +143,7 @@ declare global {
        * import { useRemirror } from '@remirror/react';
        *
        * const MyEditor = () => {
-       *   const { helpers } = useRemirror();
+       *   const { helpers } = useRemirror({ autoUpdate: true });
        *
        *   return helpers.beautiful.checkBeautyLevel() > 50
        *     ? (<span>😍</span>)

--- a/packages/@remirror/core/src/manager/remirror-manager.ts
+++ b/packages/@remirror/core/src/manager/remirror-manager.ts
@@ -558,7 +558,7 @@ export class RemirrorManager<Combined extends AnyCombinedUnion> {
    * Update the state of the view and trigger the `onStateUpdate` lifecyle
    * method as well.
    */
-  updateState = (state: EditorState<this['~Sch']>) => {
+  private readonly updateState = (state: EditorState<this['~Sch']>) => {
     const previousState = this.getState();
 
     this.view.updateState(state);
@@ -582,9 +582,13 @@ export class RemirrorManager<Combined extends AnyCombinedUnion> {
       this.#firstStateUpdate = false;
     }
 
+    const parameterWithUpdate = { ...parameter, firstUpdate };
+
     for (const handler of this.#handlers.update) {
-      handler({ ...parameter, firstUpdate });
+      handler(parameterWithUpdate);
     }
+
+    this.#events.emit('stateUpdate', parameterWithUpdate);
   }
 
   /**
@@ -678,12 +682,18 @@ export class RemirrorManager<Combined extends AnyCombinedUnion> {
   }
 }
 
-interface ManagerEvents {
+export interface ManagerEvents {
+  /**
+   * Called when the state is updated.
+   */
+  stateUpdate: (parameter: StateUpdateLifecycleParameter) => void;
+
   /**
    * An event listener which is called whenever the manager is destroyed.
    */
   destroy: () => void;
 }
+
 export type AnyRemirrorManager = RemirrorManager<AnyCombinedUnion>;
 
 /**

--- a/packages/@remirror/dom/src/__tests__/dom.spec.ts
+++ b/packages/@remirror/dom/src/__tests__/dom.spec.ts
@@ -9,7 +9,7 @@ test('can be added to the dom', () => {
   const editor = createDomEditor({ manager, element });
   const mock = jest.fn();
 
-  editor.addHandler('change', mock);
+  editor.addHandler('updated', mock);
   editor.commands.insertText('Hello test');
 
   // Make selected text bold.

--- a/packages/@remirror/react/src/hooks/__tests__/editor-hooks.spec.tsx
+++ b/packages/@remirror/react/src/hooks/__tests__/editor-hooks.spec.tsx
@@ -1,0 +1,114 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { RemirrorTestChain } from 'jest-remirror';
+import React, { FC } from 'react';
+
+import { BoldExtension } from '@remirror/testing';
+
+import { RemirrorProvider } from '../../components';
+import { createReactManager } from '../../react-helpers';
+import { useRemirror } from '../editor-hooks';
+
+describe('useRemirror', () => {
+  it('returns the provider context', () => {
+    const { wrapper } = createTestChain();
+    const { result } = renderHook(() => useRemirror({ autoUpdate: true }), { wrapper });
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        nodes: expect.any(Object),
+        marks: expect.any(Object),
+        schema: expect.any(Object),
+        tags: expect.any(Object),
+        plugins: expect.any(Array),
+        pluginKeys: expect.any(Object),
+        getPluginState: expect.any(Function),
+        getForcedUpdates: expect.any(Function),
+        components: expect.any(Object),
+        ssrTransformer: expect.any(Function),
+        portalContainer: expect.any(Object),
+        attributes: expect.any(Object),
+        nodeViews: expect.any(Object),
+        view: expect.any(Object),
+        commands: expect.any(Object),
+        chain: expect.any(Object),
+        active: expect.any(Object),
+        helpers: expect.any(Object),
+        addHandler: expect.any(Function),
+        uid: expect.any(String),
+        manager: expect.any(Object),
+        getState: expect.any(Function),
+        getPreviousState: expect.any(Function),
+        getExtension: expect.any(Function),
+        getPreset: expect.any(Function),
+        clearContent: expect.any(Function),
+        setContent: expect.any(Function),
+        focus: expect.any(Function),
+        blur: expect.any(Function),
+        getRootProps: expect.any(Function),
+      }),
+    );
+
+    expect(result.current.getState()).toEqual(result.current.getPreviousState());
+  });
+
+  it('can listen to updates', () => {
+    const { chain, wrapper } = createTestChain();
+    const { doc, p } = chain.nodes;
+    const { result } = renderHook(
+      () => useRemirror<BoldExtension>({ autoUpdate: true }),
+      { wrapper },
+    );
+
+    expect(result.current.active.bold()).toBe(false);
+
+    act(() => {
+      chain.overwrite(doc(p('Welcome <start>friend<end>')));
+    });
+
+    expect(result.current.active.bold()).toBe(false);
+
+    act(() => {
+      result.current.commands.toggleBold();
+    });
+
+    expect(result.current.active.bold()).toBe(true);
+  });
+
+  it('can listen to updates with handler', () => {
+    const { chain, wrapper } = createTestChain();
+    const { doc, p } = chain.nodes;
+    const mock = jest.fn();
+    renderHook(() => useRemirror<BoldExtension>(mock), { wrapper });
+
+    act(() => {
+      chain.overwrite(doc(p('Welcome <start>friend<end>')));
+    });
+
+    expect(mock).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createTestChain() {
+  const chain = RemirrorTestChain.create(createReactManager([new BoldExtension()]));
+
+  const InnerComponent: FC = ({ children }) => {
+    const { getRootProps } = useRemirror();
+
+    return (
+      <>
+        {children}
+        <div {...getRootProps()} />
+      </>
+    );
+  };
+
+  const Wrapper: FC = ({ children }) => {
+    return (
+      <RemirrorProvider manager={chain.manager}>
+        <InnerComponent>{children}</InnerComponent>
+      </RemirrorProvider>
+    );
+  };
+
+  return { chain, wrapper: Wrapper };
+}

--- a/readme.md
+++ b/readme.md
@@ -155,16 +155,15 @@ import { BoldExtension } from 'remirror/extension/bold';
 import { RemirrorProvider, useManager, useRemirror, useExtensionCreator } from 'remirror/react';
 
 const Editor = () => {
-  const { getRootProps, active, commands } = useRemirror();
-
-  const toggleBold = useCallback(() => {
-    commands.toggleBold();
-  }, [commands]);
+  const { getRootProps, active, commands } = useRemirror({ autoUpdate: true });
 
   return (
     <div>
       <div {...getRootProps()} />
-      <button onClick={toggleBold} style={{ fontWeight: active.bold() ? 'bold' : undefined }}>
+      <button
+        onClick={() => commands.toggleBold()}
+        style={{ fontWeight: active.bold() ? 'bold' : undefined }}
+      >
         Bold
       </button>
     </div>

--- a/support/e2e/src/helpers/index.ts
+++ b/support/e2e/src/helpers/index.ts
@@ -105,7 +105,6 @@ export const type = async ({ text, delay = 10 }: TypeParameter) =>
   page.keyboard.type(text, { delay });
 
 export * from './modifier-keys';
-
 export * from './images';
 
 interface HTMLObject {

--- a/support/e2e/src/positioner.e2e.test.ts
+++ b/support/e2e/src/positioner.e2e.test.ts
@@ -19,7 +19,7 @@ describe('Positioner', () => {
   describe('Bubble menu', () => {
     it('should show the bubble menu', async () => {
       await $editor.focus();
-      await $editor.type('This is text');
+      await $editor.type('This is text', { delay: 10 });
       await expect($editor.innerHTML()).resolves.toMatchSnapshot();
       const $bubbleMenu = await getByTestId($document, 'bubble-menu');
       await expect($bubbleMenu.getAttribute('style')).resolves.toBe(

--- a/support/examples/with-next/src/pages/editor/positioner.tsx
+++ b/support/examples/with-next/src/pages/editor/positioner.tsx
@@ -17,21 +17,9 @@ const EXTENSIONS = [
 ];
 
 function Menu() {
-  const [activeCommands, setActiveCommands] = useState({
-    bold: false,
-    italic: false,
-    underline: false,
+  const { commands, active } = useRemirror<BoldExtension | ItalicExtension | UnderlineExtension>({
+    autoUpdate: true,
   });
-
-  const { commands, active } = useRemirror<BoldExtension | ItalicExtension | UnderlineExtension>(
-    () => {
-      setActiveCommands({
-        bold: active.bold(),
-        italic: active.italic(),
-        underline: active.underline(),
-      });
-    },
-  );
 
   // The use positioner hook allows for tracking the current selection in the editor.
   const { bottom, left, ref } = usePositioner('bubble');
@@ -40,20 +28,20 @@ function Menu() {
     <div ref={ref} style={{ bottom, left, position: 'absolute' }} data-testid='bubble-menu'>
       <button
         onClick={() => commands.toggleBold()}
-        style={{ fontWeight: activeCommands.bold ? 'bold' : undefined }}
+        style={{ fontWeight: active.bold() ? 'bold' : undefined }}
         data-testid='bubble-menu-bold'
       >
         Bold
       </button>
       <button
         onClick={() => commands.toggleItalic()}
-        style={{ fontWeight: activeCommands.italic ? 'bold' : undefined }}
+        style={{ fontWeight: active.italic() ? 'bold' : undefined }}
       >
         Italic
       </button>
       <button
         onClick={() => commands.toggleUnderline()}
-        style={{ fontWeight: activeCommands.underline ? 'bold' : undefined }}
+        style={{ fontWeight: active.underline() ? 'bold' : undefined }}
       >
         Underline
       </button>


### PR DESCRIPTION
## Description

- Rename `change` event to `updated`. `updated` is called with the `EventListenerParameter`.
- Add new manager `stateUpdate` to the `editorWrapper`
- Add `autoUpdate` option to `useRemirror` hook from `@remirror/react` which means that the context object returned by the hook is always up to date with the latest editor state. It will also cause the component to rerender so be careful to only use it when necessary.

```tsx
const { active, commands } = useRemirror({ autoUpdate: true });

return (
  <button
    onClick={() => commands.toggleBold}
    style={{ fontWeight: active.bold() ? 'bold' : undefined }}
  >
    B
  </button>
);
```

- Fix broken `onChangeHandler` parameter for the use `useRemirror` hook.
 

Closes #372
Closes #371

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

No more delayed update of editor state

![2020-07-23 20 01 53](https://user-images.githubusercontent.com/1160934/88327943-9ecaea00-cd1f-11ea-8908-42934e21bcc6.gif)
