### PR TITLE
refactor: use method signature for class overloads

### DIFF
--- a/.changeset/cool-countries-pay.md
+++ b/.changeset/cool-countries-pay.md
@@ -5,3 +5,5 @@
 ---
 
 Switch to using method signatures for extension class methods as discussed in #360.
+
+Remove the first parameter `extensions` from method `onCreate`, `onView` and `onDestroy`.

--- a/.changeset/cool-countries-pay.md
+++ b/.changeset/cool-countries-pay.md
@@ -1,12 +1,42 @@
 ---
 '@remirror/core': minor
+'@remirror/extension-auto-link': patch
 '@remirror/extension-bidi': patch
+'@remirror/extension-blockquote': patch
+'@remirror/extension-bold': patch
+'@remirror/extension-code': patch
+'@remirror/extension-code-block': patch
+'@remirror/extension-collaboration': patch
+'@remirror/extension-diff': patch
+'@remirror/extension-drop-cursor': patch
+'@remirror/extension-emoji': patch
+'@remirror/extension-epic-mode': patch
+'@remirror/extension-gap-cursor': patch
+'@remirror/extension-heading': patch
+'@remirror/extension-history': patch
+'@remirror/extension-horizontal-rule': patch
+'@remirror/extension-image': patch
+'@remirror/extension-italic': patch
+'@remirror/extension-link': patch
+'@remirror/extension-mention': patch
+'@remirror/extension-paragraph': patch
 '@remirror/extension-placeholder': patch
+'@remirror/extension-position-tracker': patch
+'@remirror/extension-positioner': patch
+'@remirror/extension-react-ssr': patch
+'@remirror/extension-search': patch
+'@remirror/extension-strike': patch
+'@remirror/extension-trailing-node': patch
+'@remirror/extension-underline': patch
+'@remirror/extension-yjs': patch
+'@remirror/preset-embed': patch
+'@remirror/preset-list': patch
+'@remirror/preset-table': patch
 ---
 
-Remove the first parameter `extensions` from method `onCreate`, `onView` and `onDestroy`.
+Remove the first parameter `extensions` from the lifecycle methods `onCreate`, `onView` and `onDestroy`.
 
-Switch to using method signatures for extension class methods as discussed in #360. The follow methods have been affected:
+Switch to using method signatures for extension class methods as discussed in #360. The following methods have been affected:
 
 ```
 onCreate

--- a/.changeset/cool-countries-pay.md
+++ b/.changeset/cool-countries-pay.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core': minor
+'@remirror/extension-bidi': patch
+'@remirror/extension-placeholder': patch
+---
+
+Switch to using method signatures for extension class methods as discussed in #360.

--- a/.changeset/cool-countries-pay.md
+++ b/.changeset/cool-countries-pay.md
@@ -4,6 +4,21 @@
 '@remirror/extension-placeholder': patch
 ---
 
-Switch to using method signatures for extension class methods as discussed in #360.
-
 Remove the first parameter `extensions` from method `onCreate`, `onView` and `onDestroy`.
+
+Switch to using method signatures for extension class methods as discussed in #360. The follow methods have been affected:
+
+```
+onCreate
+onView
+onStateUpdate
+onDestroy
+createAttributes
+createCommands
+createPlugin
+createExternalPlugins
+createSuggestions
+createHelpers
+fromObject
+onSetOptions
+```

--- a/packages/@remirror/core/src/builtins/attributes-extension.ts
+++ b/packages/@remirror/core/src/builtins/attributes-extension.ts
@@ -2,7 +2,7 @@ import { ExtensionPriority } from '@remirror/core-constants';
 import { bool, object } from '@remirror/core-helpers';
 import { AttributesWithClass } from '@remirror/core-types';
 
-import { CreateLifecycleMethod, PlainExtension } from '../extension';
+import { PlainExtension } from '../extension';
 import { AnyCombinedUnion } from '../preset';
 
 /**
@@ -32,10 +32,10 @@ export class AttributesExtension extends PlainExtension {
    *
    * @internal
    */
-  onCreate: CreateLifecycleMethod = () => {
+  onCreate() {
     this.transformAttributes();
     this.store.setExtensionStore('updateAttributes', this.updateAttributes);
-  };
+  }
 
   private readonly updateAttributes = (triggerUpdate = true) => {
     this.transformAttributes();

--- a/packages/@remirror/core/src/builtins/attributes-extension.ts
+++ b/packages/@remirror/core/src/builtins/attributes-extension.ts
@@ -127,7 +127,7 @@ declare global {
        *
        * @alpha
        */
-      createAttributes?: () => AttributesWithClass;
+      createAttributes?(): AttributesWithClass;
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -483,7 +483,7 @@ declare global {
        * const MyExtension = ExtensionFactory.plain({
        *   name: 'myExtension',
        *   version: '1.0.0',
-       *   createCommands: () => {
+       *   createCommands() {
        *     return {
        *       haveFun() {
        *         return ({ state, dispatch }) => {

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -132,7 +132,7 @@ export class CommandsExtension extends PlainExtension {
   /**
    * Create the default commands available to all extensions.
    */
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Create a custom transaction.
@@ -230,7 +230,7 @@ export class CommandsExtension extends PlainExtension {
         };
       },
     };
-  };
+  }
 
   /**
    * This plugin is here only to keep track of the forced updates meta data.

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -235,9 +235,9 @@ export class CommandsExtension extends PlainExtension {
   /**
    * This plugin is here only to keep track of the forced updates meta data.
    */
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {};
-  };
+  }
 
   /**
    * A helper for forcing through updates in the view layer. The view layer can

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -454,6 +454,17 @@ declare global {
 
     interface ExtensionCreatorMethods {
       /**
+       * `ExtensionCommands`
+       *
+       * This pseudo property makes it easier to infer Generic types of this
+       * class.
+       * @private
+       */
+      ['~C']: this['createCommands'] extends AnyFunction
+        ? ReturnType<this['createCommands']>
+        : EmptyShape;
+
+      /**
        * Create and register commands for that can be called within the editor.
        *
        * These are typically used to create menu's actions and as a direct
@@ -497,18 +508,7 @@ declare global {
        *
        * @param parameter - schema parameter with type included
        */
-      createCommands?: () => ExtensionCommandReturn;
-
-      /**
-       * `ExtensionCommands`
-       *
-       * This pseudo property makes it easier to infer Generic types of this
-       * class.
-       * @private
-       */
-      ['~C']: this['createCommands'] extends AnyFunction
-        ? ReturnType<this['createCommands']>
-        : EmptyShape;
+      createCommands?(): ExtensionCommandReturn;
     }
 
     interface ExtensionStore {

--- a/packages/@remirror/core/src/builtins/helpers-extension.ts
+++ b/packages/@remirror/core/src/builtins/helpers-extension.ts
@@ -115,6 +115,17 @@ declare global {
 
     interface ExtensionCreatorMethods {
       /**
+       * `ExtensionHelpers`
+       *
+       * This pseudo property makes it easier to infer Generic types of this
+       * class.
+       * @private
+       */
+      ['~H']: this['createHelpers'] extends AnyFunction
+        ? ReturnType<this['createHelpers']>
+        : EmptyShape;
+
+      /**
        * A helper method is a function that takes in arguments and returns a
        * value depicting the state of the editor specific to this extension.
        *
@@ -151,17 +162,7 @@ declare global {
        * };
        * ```
        */
-      createHelpers?: () => ExtensionHelperReturn;
-      /**
-       * `ExtensionHelpers`
-       *
-       * This pseudo property makes it easier to infer Generic types of this
-       * class.
-       * @private
-       */
-      ['~H']: this['createHelpers'] extends AnyFunction
-        ? ReturnType<this['createHelpers']>
-        : EmptyShape;
+      createHelpers?(): ExtensionHelperReturn;
     }
 
     interface ExtensionStore {

--- a/packages/@remirror/core/src/builtins/helpers-extension.ts
+++ b/packages/@remirror/core/src/builtins/helpers-extension.ts
@@ -85,9 +85,9 @@ export class HelpersExtension extends PlainExtension {
     this.store.setStoreKey('helpers', helpers);
   }
 
-  createHelpers = () => {
+  createHelpers() {
     return {};
-  };
+  }
 }
 
 declare global {

--- a/packages/@remirror/core/src/builtins/helpers-extension.ts
+++ b/packages/@remirror/core/src/builtins/helpers-extension.ts
@@ -5,12 +5,10 @@ import { isMarkActive, isNodeActive } from '@remirror/core-utils';
 
 import {
   AnyExtension,
-  CreateLifecycleMethod,
   HelpersFromExtensions,
   isMarkExtension,
   isNodeExtension,
   PlainExtension,
-  ViewLifecycleMethod,
 } from '../extension';
 import { throwIfNameNotUnique } from '../helpers';
 import { ActiveFromCombined, AnyCombinedUnion, HelpersFromCombined } from '../preset';
@@ -40,25 +38,25 @@ export class HelpersExtension extends PlainExtension {
    * Provide a method with access to the helpers for use in commands and
    * helpers.
    */
-  onCreate: CreateLifecycleMethod = () => {
+  onCreate() {
     this.store.setExtensionStore('getHelpers', () => {
       const helpers = this.store.getStoreKey('helpers');
       invariant(helpers, { code: ErrorConstant.HELPERS_CALLED_IN_OUTER_SCOPE });
 
       return helpers as any;
     });
-  };
+  }
 
   /**
    * Helpers are only available once the view has been added to
    * `RemirrorManager`.
    */
-  onView: ViewLifecycleMethod = (extensions) => {
+  onView() {
     const helpers: Record<string, AnyFunction> = object();
     const active: Record<string, AnyFunction> = object();
     const names = new Set<string>();
 
-    for (const extension of extensions) {
+    for (const extension of this.store.extensions) {
       if (isNodeExtension(extension)) {
         active[extension.name] = (attrs?: ProsemirrorAttributes) => {
           return isNodeActive({ state: this.store.getState(), type: extension.type, attrs });
@@ -85,7 +83,7 @@ export class HelpersExtension extends PlainExtension {
 
     this.store.setStoreKey('active', active);
     this.store.setStoreKey('helpers', helpers);
-  };
+  }
 
   createHelpers = () => {
     return {};

--- a/packages/@remirror/core/src/builtins/input-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/input-rules-extension.ts
@@ -2,7 +2,7 @@ import { ExtensionPriority } from '@remirror/core-constants';
 import { InputRule, inputRules } from '@remirror/pm/inputrules';
 import { Plugin } from '@remirror/pm/state';
 
-import { CreateLifecycleMethod, PlainExtension } from '../extension';
+import { PlainExtension } from '../extension';
 
 /**
  * This extension allows others extension to add the `createInputRules` method
@@ -27,12 +27,12 @@ export class InputRulesExtension extends PlainExtension {
   /**
    * Ensure that all ssr transformers are run.
    */
-  onCreate: CreateLifecycleMethod = () => {
+  onCreate() {
     this.store.setExtensionStore('rebuildInputRules', this.rebuildInputRules);
     this.loopExtensions();
 
     this.store.addPlugins(this.inputRulesPlugin);
-  };
+  }
 
   private loopExtensions() {
     const rules: InputRule[] = [];

--- a/packages/@remirror/core/src/builtins/input-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/input-rules-extension.ts
@@ -103,7 +103,7 @@ declare global {
        *
        * @param parameter - schema parameter with type included
        */
-      createInputRules?: () => InputRule[];
+      createInputRules?(): InputRule[];
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/keymap-extension.ts
+++ b/packages/@remirror/core/src/builtins/keymap-extension.ts
@@ -109,7 +109,7 @@ declare global {
        *
        * @param parameter - schema parameter with type included
        */
-      createKeymap?: () => KeyBindings;
+      createKeymap?(): KeyBindings;
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/keymap-extension.ts
+++ b/packages/@remirror/core/src/builtins/keymap-extension.ts
@@ -3,7 +3,7 @@ import { KeyBindings, ProsemirrorPlugin } from '@remirror/core-types';
 import { mergeProsemirrorKeyBindings } from '@remirror/core-utils';
 import { keymap } from '@remirror/pm/keymap';
 
-import { CreateLifecycleMethod, PlainExtension } from '../extension';
+import { PlainExtension } from '../extension';
 
 /**
  * This extension allows others extension to use the `createKeymaps` method.
@@ -27,11 +27,11 @@ export class KeymapExtension extends PlainExtension {
   /**
    * This adds the `createKeymap` method functionality to all extensions.
    */
-  onCreate: CreateLifecycleMethod = () => {
+  onCreate() {
     this.store.setExtensionStore('rebuildKeymap', this.rebuildKeymap);
     this.loopExtensions();
     this.store.addPlugins(this.keymap);
-  };
+  }
 
   /**
    * Updates the stored keymap plugin on this extension.

--- a/packages/@remirror/core/src/builtins/node-views-extension.ts
+++ b/packages/@remirror/core/src/builtins/node-views-extension.ts
@@ -2,7 +2,7 @@ import { ExtensionPriority } from '@remirror/core-constants';
 import { isFunction, object } from '@remirror/core-helpers';
 import { NodeViewMethod } from '@remirror/core-types';
 
-import { CreateLifecycleMethod, PlainExtension } from '../extension';
+import { PlainExtension } from '../extension';
 import { AnyCombinedUnion } from '../preset';
 
 /**
@@ -26,7 +26,7 @@ export class NodeViewsExtension extends PlainExtension {
   /**
    * Ensure that all SSR transformers are run.
    */
-  onCreate: CreateLifecycleMethod = () => {
+  onCreate() {
     const nodeViewList: Array<Record<string, NodeViewMethod>> = [];
     const nodeViews: Record<string, NodeViewMethod> = object();
 
@@ -54,7 +54,7 @@ export class NodeViewsExtension extends PlainExtension {
     }
 
     this.store.setStoreKey('nodeViews', nodeViews);
-  };
+  }
 }
 
 declare global {

--- a/packages/@remirror/core/src/builtins/node-views-extension.ts
+++ b/packages/@remirror/core/src/builtins/node-views-extension.ts
@@ -91,7 +91,7 @@ declare global {
        *
        * @alpha
        */
-      createNodeViews?: () => NodeViewMethod | Record<string, NodeViewMethod>;
+      createNodeViews?(): NodeViewMethod | Record<string, NodeViewMethod>;
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/paste-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/paste-rules-extension.ts
@@ -62,7 +62,7 @@ declare global {
        *
        * TODO - The paste plugin is currently switched off.
        */
-      createPasteRules?: () => ProsemirrorPlugin[];
+      createPasteRules?(): ProsemirrorPlugin[];
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/paste-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/paste-rules-extension.ts
@@ -1,7 +1,7 @@
 import { ExtensionPriority } from '@remirror/core-constants';
 import { ProsemirrorPlugin } from '@remirror/core-types';
 
-import { CreateLifecycleMethod, PlainExtension } from '../extension';
+import { PlainExtension } from '../extension';
 
 /**
  * This extension allows others extension to add the `createPasteRules` method
@@ -20,10 +20,10 @@ export class PasteRulesExtension extends PlainExtension {
   /**
    * Ensure that all ssr transformers are run.
    */
-  onCreate: CreateLifecycleMethod = (extensions) => {
+  onCreate() {
     const pasteRules: ProsemirrorPlugin[] = [];
 
-    for (const extension of extensions) {
+    for (const extension of this.store.extensions) {
       if (
         // managerSettings excluded this from running
         this.store.managerSettings.exclude?.pasteRules ||
@@ -40,7 +40,7 @@ export class PasteRulesExtension extends PlainExtension {
 
     // TODO rewrite so this is all one plugin
     this.store.addPlugins(...pasteRules);
-  };
+  }
 }
 
 declare global {

--- a/packages/@remirror/core/src/builtins/plugins-extension.ts
+++ b/packages/@remirror/core/src/builtins/plugins-extension.ts
@@ -4,12 +4,7 @@ import { ProsemirrorPlugin } from '@remirror/core-types';
 import { getPluginState } from '@remirror/core-utils';
 import { EditorState, Plugin, PluginKey } from '@remirror/pm/state';
 
-import {
-  AnyExtension,
-  AnyExtensionConstructor,
-  CreateLifecycleMethod,
-  PlainExtension,
-} from '../extension';
+import { AnyExtension, AnyExtensionConstructor, PlainExtension } from '../extension';
 import { AnyCombinedUnion, InferCombinedExtensions } from '../preset';
 import { CreatePluginReturn, GetNameUnion } from '../types';
 
@@ -45,18 +40,18 @@ export class PluginsExtension extends PlainExtension {
 
   // Here set the plugins keys and state getters for retrieving plugin state.
   // These methods are later used.
-  onCreate: CreateLifecycleMethod = (extensions) => {
+  onCreate() {
     const { setStoreKey, setExtensionStore } = this.store;
     this.updateExtensionStore();
 
-    for (const extension of extensions) {
+    for (const extension of this.store.extensions) {
       this.extractExtensionPlugins(extension);
     }
 
     setStoreKey('pluginKeys', this.pluginKeys);
     setStoreKey('getPluginState', this.getStateByName);
     setExtensionStore('getPluginState', this.getStateByName);
-  };
+  }
 
   /**
    * Get all the plugins from the extension.

--- a/packages/@remirror/core/src/builtins/plugins-extension.ts
+++ b/packages/@remirror/core/src/builtins/plugins-extension.ts
@@ -330,26 +330,6 @@ declare global {
 
     interface BaseExtension {
       /**
-       * Retrieve the state of the custom plugin for this extension. This will
-       * throw an error if the extension doesn't have a valid `createPlugin`
-       * method.
-       *
-       * @remarks
-       *
-       * ```ts
-       * const pluginState = this.getPluginState();
-       * ```
-       *
-       * This is only available after the initialize stage of the editor manager
-       * lifecycle.
-       *
-       * If you would like to use it before that e.g. in the decorations prop of
-       * the `createPlugin` method, you can call it with a current state which
-       * will be used to retrieve the plugin state.
-       */
-      getPluginState: <State>(state?: EditorState) => State;
-
-      /**
        * The plugin key for custom plugin created by this extension. This only
        * exists when there is a valid `createPlugin` method on the extension.
        *
@@ -371,6 +351,26 @@ declare global {
        * The external plugins created by the `createExternalPlugins` method.
        */
       externalPlugins: Plugin[];
+
+      /**
+       * Retrieve the state of the custom plugin for this extension. This will
+       * throw an error if the extension doesn't have a valid `createPlugin`
+       * method.
+       *
+       * @remarks
+       *
+       * ```ts
+       * const pluginState = this.getPluginState();
+       * ```
+       *
+       * This is only available after the initialize stage of the editor manager
+       * lifecycle.
+       *
+       * If you would like to use it before that e.g. in the decorations prop of
+       * the `createPlugin` method, you can call it with a current state which
+       * will be used to retrieve the plugin state.
+       */
+      getPluginState: <State>(state?: EditorState) => State;
     }
 
     interface ExtensionCreatorMethods {
@@ -418,7 +418,7 @@ declare global {
        * in the outer scope of the `createPlugin` function or you will get
        * errors..
        */
-      createPlugin?: () => CreatePluginReturn;
+      createPlugin?(): CreatePluginReturn;
 
       /**
        * Register third party plugins when this extension is placed into the
@@ -430,7 +430,7 @@ declare global {
        * creator method allows you to return a list of plugins you'd like to
        * support.
        */
-      createExternalPlugins?: () => ProsemirrorPlugin[];
+      createExternalPlugins?(): ProsemirrorPlugin[];
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/plugins-extension.ts
+++ b/packages/@remirror/core/src/builtins/plugins-extension.ts
@@ -385,26 +385,28 @@ declare global {
        *     return 'me' as const;
        *   }
        *
-       *   createPlugin: (): ExtensionPluginSpec => ({
-       *     props: {
-       *       handleKeyDown: keydownHandler({
-       *         Backspace: handler,
-       *         'Mod-Backspace': handler,
-       *         Delete: handler,
-       *         'Mod-Delete': handler,
-       *         'Ctrl-h': handler,
-       *         'Alt-Backspace': handler,
-       *         'Ctrl-d': handler,
-       *         'Ctrl-Alt-Backspace': handler,
-       *         'Alt-Delete': handler,
-       *         'Alt-d': handler,
-       *       }),
-       *       decorations() {
-       *         pluginState.setDeleted(false);
-       *         return pluginState.decorationSet;
+       *   createPlugin (): ExtensionPluginSpec {
+       *     return  {
+       *       props: {
+       *         handleKeyDown: keydownHandler({
+       *           Backspace: handler,
+       *           'Mod-Backspace': handler,
+       *           Delete: handler,
+       *           'Mod-Delete': handler,
+       *           'Ctrl-h': handler,
+       *           'Alt-Backspace': handler,
+       *           'Ctrl-d': handler,
+       *           'Ctrl-Alt-Backspace': handler,
+       *           'Alt-Delete': handler,
+       *           'Alt-d': handler,
+       *         }),
+       *         decorations() {
+       *           pluginState.setDeleted(false);
+       *           return pluginState.decorationSet;
+       *         },
        *       },
-       *     },
-       *   })
+       *     }
+       *   }
        * }
        * ```
        *

--- a/packages/@remirror/core/src/builtins/schema-extension.ts
+++ b/packages/@remirror/core/src/builtins/schema-extension.ts
@@ -26,7 +26,6 @@ import { Schema } from '@remirror/pm/model';
 
 import {
   AnyExtension,
-  CreateLifecycleMethod,
   GetMarkNameUnion,
   GetNodeNameUnion,
   isMarkExtension,
@@ -52,20 +51,20 @@ export class SchemaExtension extends PlainExtension {
     return 'schema' as const;
   }
 
-  onCreate: CreateLifecycleMethod = (extensions) => {
+  onCreate() {
     const { managerSettings } = this.store;
     const nodes: Record<string, NodeExtensionSpec> = object();
     const marks: Record<string, MarkExtensionSpec> = object();
     const namedExtraAttributes = transformExtraAttributes({
       settings: managerSettings,
-      gatheredSchemaAttributes: this.gatherExtraAttributes(extensions),
+      gatheredSchemaAttributes: this.gatherExtraAttributes(this.store.extensions),
       nodeNames: this.store.nodeNames,
       markNames: this.store.markNames,
     });
 
     // Skip the for loop by setting the list to empty when extra attributes are disabled
 
-    for (const extension of extensions) {
+    for (const extension of this.store.extensions) {
       const currentAttributes = namedExtraAttributes[extension.name] ?? object();
 
       namedExtraAttributes[extension.name] = {
@@ -109,7 +108,7 @@ export class SchemaExtension extends PlainExtension {
     this.store.setStoreKey('marks', marks);
     this.store.setStoreKey('schema', schema);
     this.store.setExtensionStore('schema', schema);
-  };
+  }
 
   /**
    * Gather all the extra attributes that have been added by extensions.

--- a/packages/@remirror/core/src/builtins/schema-extension.ts
+++ b/packages/@remirror/core/src/builtins/schema-extension.ts
@@ -408,9 +408,9 @@ declare global {
        *
        * For example the `@remirror/extension-bidi` adds a `dir` attribute to
        * all node extensions which allows them to automatically infer whether
-       * the text direction should be right to left, or left to right.
+       * the text direction should be right-to-left, or left-to-right.
        */
-      createSchemaAttributes?: () => IdentifierSchemaAttributes[];
+      createSchemaAttributes?(): IdentifierSchemaAttributes[];
     }
     interface BaseExtensionOptions {
       /**

--- a/packages/@remirror/core/src/builtins/suggestions-extension.ts
+++ b/packages/@remirror/core/src/builtins/suggestions-extension.ts
@@ -71,7 +71,7 @@ declare global {
        * functionality. They can support `@` mentions, `#` tagging, `/` special
        * command keys which trigger an actions menu and much more.
        */
-      createSuggestions?: () => Suggestion[] | Suggestion;
+      createSuggestions?(): Suggestion[] | Suggestion;
     }
   }
 }

--- a/packages/@remirror/core/src/builtins/tags-extension.ts
+++ b/packages/@remirror/core/src/builtins/tags-extension.ts
@@ -3,7 +3,6 @@ import { isUndefined, object } from '@remirror/core-helpers';
 
 import {
   AnyExtension,
-  CreateLifecycleMethod,
   ExtensionTags,
   isMarkExtension,
   isNodeExtension,
@@ -37,16 +36,16 @@ export class TagsExtension extends PlainExtension {
     };
   }
 
-  onCreate: CreateLifecycleMethod = (extensions) => {
+  onCreate() {
     this.resetTags();
 
-    for (const extension of extensions) {
+    for (const extension of this.store.extensions) {
       this.updateTagForExtension(extension);
     }
 
     this.store.setStoreKey('tags', this.combinedTags);
     this.store.setExtensionStore('tags', this.combinedTags);
-  };
+  }
 
   private resetTags() {
     this.#generalTags = {

--- a/packages/@remirror/core/src/extension/__dts__/extension-types.dts.ts
+++ b/packages/@remirror/core/src/extension/__dts__/extension-types.dts.ts
@@ -11,7 +11,7 @@ class FirstExtension extends PlainExtension {
     return 'first' as const;
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       free(title?: string) {
         return () => false;
@@ -21,7 +21,7 @@ class FirstExtension extends PlainExtension {
         return () => true;
       },
     };
-  };
+  }
 }
 
 class SecondExtension extends PlainExtension<{ option: boolean }> {
@@ -29,13 +29,13 @@ class SecondExtension extends PlainExtension<{ option: boolean }> {
     return 'second' as const;
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       fun: (value: { key?: boolean }) => {
         return () => false;
       },
     };
-  };
+  }
 }
 
 class ThirdExtension extends PlainExtension {
@@ -43,13 +43,13 @@ class ThirdExtension extends PlainExtension {
     return 'third' as const;
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       notChainable: (value: string) => {
         return nonChainable(() => false);
       },
     };
-  };
+  }
 }
 
 type Chainable = ChainedFromExtensions<FirstExtension | SecondExtension | ThirdExtension>;

--- a/packages/@remirror/core/src/extension/extension-base.ts
+++ b/packages/@remirror/core/src/extension/extension-base.ts
@@ -29,7 +29,7 @@ import {
   GetNameUnion,
   MarkExtensionTags,
   NodeExtensionTags,
-  StateUpdateLifecycleMethod,
+  StateUpdateLifecycleParameter,
 } from '../types';
 import {
   AnyBaseClassOverrides,
@@ -281,23 +281,23 @@ interface ExtensionLifecycleMethods {
    * shore to check when they become available in the lifecycle. It is
    * recommende that you don't use this method unless absolutely required.
    */
-  onCreate?: CreateLifecycleMethod;
+  onCreate?(): void;
 
   /**
    * This event happens when the view is first received from the view layer
    * (e.g. React).
    */
-  onView?: ViewLifecycleMethod;
+  onView?(view: EditorView<EditorSchema>): void;
 
   /**
    * Called when a transaction successfully updates the editor state.
    */
-  onStateUpdate?: StateUpdateLifecycleMethod;
+  onStateUpdate?(parameter: StateUpdateLifecycleParameter): void;
 
   /**
    * Called when the extension is being destroyed.
    */
-  onDestroy?: DestroyLifecycleMethod;
+  onDestroy?(): void;
 }
 
 /**
@@ -705,13 +705,6 @@ export type SchemaFromExtensionUnion<ExtensionUnion extends AnyExtension> = Edit
 
 export type AnyManagerStore = Remirror.ManagerStore<any>;
 export type ManagerStoreKeys = keyof Remirror.ManagerStore<any>;
-
-export type CreateLifecycleMethod = (extensions: readonly AnyExtension[]) => void;
-export type ViewLifecycleMethod = (
-  extensions: readonly AnyExtension[],
-  view: EditorView<EditorSchema>,
-) => void;
-export type DestroyLifecycleMethod = (extensions: readonly AnyExtension[]) => void;
 
 declare global {
   /**

--- a/packages/@remirror/core/src/manager/__tests__/remirror-manager.spec.tsx
+++ b/packages/@remirror/core/src/manager/__tests__/remirror-manager.spec.tsx
@@ -4,12 +4,13 @@ import { EMPTY_PARAGRAPH_NODE, ExtensionPriority, ExtensionTag } from '@remirror
 import {
   EditorState,
   KeyBindingCommandFunction,
+  NodeExtensionSpec,
   ProsemirrorAttributes,
 } from '@remirror/core-types';
 import { EditorView } from '@remirror/pm/view';
 import { CorePreset, createCoreManager } from '@remirror/testing';
 
-import { CreateLifecycleMethod, PlainExtension } from '../../extension';
+import { CreateLifecycleMethod, NodeExtension, PlainExtension } from '../../extension';
 import { isRemirrorManager, RemirrorManager } from '../remirror-manager';
 
 describe('Manager', () => {
@@ -25,33 +26,35 @@ describe('Manager', () => {
     }
     readonly extensionTags = ['simple', ExtensionTag.LastNodeCompatible];
 
-    createCommands = () => {
+    createCommands() {
       return { dummy: mock };
-    };
+    }
 
-    createHelpers = () => {
+    createHelpers() {
       return {
         getInformation,
       };
-    };
+    }
 
-    createAttributes = () => {
+    createAttributes() {
       return {
         class: 'custom',
       };
-    };
+    }
   }
 
-  class BigExtension extends PlainExtension {
+  class BigExtension extends NodeExtension {
+    static disableExtraAttributes = true;
+
     get name() {
       return 'big' as const;
     }
 
-    createNodeSpec = () => {
+    createNodeSpec(): NodeExtensionSpec {
       return {
         toDOM: () => ['h1', 0],
       };
-    };
+    }
   }
 
   const dummyExtension = new DummyExtension({ priority: ExtensionPriority.Critical });

--- a/packages/@remirror/core/src/manager/__tests__/remirror-manager.spec.tsx
+++ b/packages/@remirror/core/src/manager/__tests__/remirror-manager.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { EditorView } from '@remirror/pm/view';
 import { CorePreset, createCoreManager } from '@remirror/testing';
 
-import { CreateLifecycleMethod, NodeExtension, PlainExtension } from '../../extension';
+import { NodeExtension, PlainExtension } from '../../extension';
 import { isRemirrorManager, RemirrorManager } from '../remirror-manager';
 
 describe('Manager', () => {
@@ -230,14 +230,14 @@ test('lifecycle', () => {
       return 'test' as const;
     }
 
-    onCreate: CreateLifecycleMethod = () => {
+    onCreate() {
       expect(this.store.setExtensionStore).toBeFunction();
       expect(this.store.setStoreKey).toBeFunction();
       expect(this.store.getStoreKey).toBeFunction();
       expect(this.store.addPlugins).toBeFunction();
       expect(this.store.tags).toBeTruthy();
       expect(this.store.schema).toBeTruthy();
-    };
+    }
   }
 
   const extension = new LifecycleExtension();

--- a/packages/@remirror/core/src/manager/remirror-manager.ts
+++ b/packages/@remirror/core/src/manager/remirror-manager.ts
@@ -761,18 +761,18 @@ interface SettingsWithPrivacy extends Remirror.ManagerSettings {
 export type GetCombined<Manager extends AnyRemirrorManager> = Manager['~EP'];
 
 interface RemirrorManagerConstructor extends Function, Remirror.RemirrorManagerConstructor {
-  fromObject: <Combined extends AnyCombinedUnion>(
+  fromObject<Combined extends AnyCombinedUnion>(
     parameter: RemirrorManagerParameter<
       InferCombinedExtensions<Combined>,
       InferCombinedPresets<Combined>
     >,
-  ) => RemirrorManager<
+  ): RemirrorManager<
     InferCombinedExtensions<Combined> | InferCombinedPresets<Combined> | BuiltinPreset
   >;
-  create: <Combined extends AnyCombinedUnion>(
+  create<Combined extends AnyCombinedUnion>(
     combined: Combined[],
     settings?: Remirror.ManagerSettings,
-  ) => RemirrorManager<Combined | BuiltinPreset>;
+  ): RemirrorManager<Combined | BuiltinPreset>;
 }
 
 export interface RemirrorManager<Combined extends AnyCombinedUnion> {
@@ -883,23 +883,6 @@ declare global {
       readonly phase: ManagerPhase;
 
       /**
-       * Return true when the editor view has been created.
-       */
-      readonly isMounted: () => boolean;
-
-      /**
-       * A helper method for retrieving the state of the editor
-       */
-      readonly getState: () => EditorState<EditorSchema>;
-
-      /**
-       * Allow extensions to trigger an update in the prosemirror state. This
-       * should only be used in rarely as it is easy to get
-       * in trouble without the necessary thought.
-       */
-      readonly updateState: (state: EditorState<EditorSchema>) => void;
-
-      /**
        * The view available to extensions once `addView` has been called on the
        * `RemirrorManager` instance.
        */
@@ -934,6 +917,23 @@ declare global {
        * The names of every plain extension.
        */
       plainNames: readonly string[];
+
+      /**
+       * Return true when the editor view has been created.
+       */
+      readonly isMounted: () => boolean;
+
+      /**
+       * A helper method for retrieving the state of the editor
+       */
+      readonly getState: () => EditorState<EditorSchema>;
+
+      /**
+       * Allow extensions to trigger an update in the prosemirror state. This
+       * should only be used in rarely as it is easy to get
+       * in trouble without the necessary thought.
+       */
+      readonly updateState: (state: EditorState<EditorSchema>) => void;
 
       /**
        * Get the value of a key from the manager store.

--- a/packages/@remirror/core/src/types.ts
+++ b/packages/@remirror/core/src/types.ts
@@ -207,7 +207,6 @@ export interface StateUpdateLifecycleParameter extends EditorStateParameter {
    */
   transactions?: Transaction[];
 }
-export type StateUpdateLifecycleMethod = (parameter: StateUpdateLifecycleParameter) => void;
 
 export interface BaseExtensionOptions extends Remirror.BaseExtensionOptions {
   /**

--- a/packages/@remirror/core/src/types.ts
+++ b/packages/@remirror/core/src/types.ts
@@ -9,7 +9,6 @@ import {
   EditorState,
   EditorStateParameter,
   GetDynamic,
-  GetFixed,
   GetFixedDynamic,
   GetPartialDynamic,
   ProsemirrorAttributes,
@@ -17,25 +16,6 @@ import {
   ValidOptions,
 } from '@remirror/core-types';
 import { PluginSpec } from '@remirror/pm/state';
-
-/**
- * This is the shape for both the preset and extension so that properties can be
- * set with an identical interface.
- *
- * @typeParam Properties - The properties used by the object.
- */
-export interface OptionsSetter<Options extends ValidOptions>
-  extends ReadonlyOptionsParameter<Options> {
-  /**
-   * Reset the options object to the initial values.
-   */
-  resetOptions: () => void;
-
-  /**
-   * Set the properties to the newly defined values.
-   */
-  setOptions: (properties: GetPartialDynamic<Options>) => void;
-}
 
 type Changes<Type> =
   | {
@@ -250,13 +230,6 @@ export interface BaseExtensionOptions extends Remirror.BaseExtensionOptions {
 }
 
 export interface ExcludeOptions extends Partial<Remirror.ExcludeOptions> {}
-
-interface ReadonlyOptionsParameter<Options extends ValidOptions> {
-  /**
-   * The readonly value for the options.
-   */
-  readonly options: GetFixed<Options>;
-}
 
 /**
  * @internal

--- a/packages/@remirror/extension-auto-link/src/auto-link-extension.ts
+++ b/packages/@remirror/extension-auto-link/src/auto-link-extension.ts
@@ -91,7 +91,7 @@ export class AutoLinkExtension extends MarkExtension<AutoLinkOptions> {
     ];
   };
 
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {
       state: {
         init: () => {
@@ -201,7 +201,7 @@ export class AutoLinkExtension extends MarkExtension<AutoLinkOptions> {
         },
       }),
     };
-  };
+  }
 }
 
 export interface UrlUpdateHandlerParameter {

--- a/packages/@remirror/extension-bidi/src/bidi-extension.ts
+++ b/packages/@remirror/extension-bidi/src/bidi-extension.ts
@@ -53,9 +53,9 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
   }
 
   /**
-   * Add the bidi property to the
+   * Add the bidi property to the editor attributes.
    */
-  createAttributes = (): AttributesWithClass => {
+  createAttributes(): AttributesWithClass {
     if (this.options.defaultDirection) {
       return {
         dir: this.options.defaultDirection,
@@ -63,7 +63,7 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
     }
 
     return {};
-  };
+  }
 
   /**
    * Add the dir to all the node types.
@@ -131,13 +131,13 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
     };
   };
 
-  protected onSetOptions = (parameter: OnSetOptionsParameter<BidiOptions>) => {
+  protected onSetOptions(parameter: OnSetOptionsParameter<BidiOptions>) {
     const { changes } = parameter;
 
     if (changes.defaultDirection.changed) {
       this.store.updateAttributes();
     }
-  };
+  }
 
   /**
    * Create the `SchemaAttributesObject`

--- a/packages/@remirror/extension-bidi/src/bidi-extension.ts
+++ b/packages/@remirror/extension-bidi/src/bidi-extension.ts
@@ -80,7 +80,7 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
    * Create the plugin that ensures the node has the correct `dir` value on each
    * state update.
    */
-  createPlugin = (): CreatePluginReturn<boolean> => {
+  createPlugin(): CreatePluginReturn<boolean> {
     return {
       state: {
         init: () => false,
@@ -129,7 +129,7 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
       }),
       props: {},
     };
-  };
+  }
 
   protected onSetOptions(parameter: OnSetOptionsParameter<BidiOptions>) {
     const { changes } = parameter;

--- a/packages/@remirror/extension-blockquote/src/blockquote-extension.ts
+++ b/packages/@remirror/extension-blockquote/src/blockquote-extension.ts
@@ -26,7 +26,7 @@ export class BlockquoteExtension extends NodeExtension {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the blockquote at the current selection.
@@ -40,7 +40,7 @@ export class BlockquoteExtension extends NodeExtension {
        */
       toggleBlockquote: (): CommandFunction => toggleWrap(this.type),
     };
-  };
+  }
 
   createKeymap = (): KeyBindings => {
     return {

--- a/packages/@remirror/extension-bold/src/bold-extension.ts
+++ b/packages/@remirror/extension-bold/src/bold-extension.ts
@@ -86,7 +86,7 @@ export class BoldExtension extends MarkExtension<BoldOptions> {
     return [markInputRule({ regexp: /(?:\*\*|__)([^*_]+)(?:\*\*|__)$/, type: this.type })];
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the bold styling on and off. Remove the formatting if any
@@ -124,5 +124,5 @@ export class BoldExtension extends MarkExtension<BoldOptions> {
         return true;
       },
     };
-  };
+  }
 }

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -341,7 +341,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
   /**
    * Create the custom code block plugin which handles the delete key amongst other things.
    */
-  createPlugin = (): CreatePluginReturn<CodeBlockState> => {
+  createPlugin(): CreatePluginReturn<CodeBlockState> {
     const pluginState = new CodeBlockState(this.type, this);
 
     /**
@@ -382,7 +382,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
         },
       },
     };
-  };
+  }
 
   /**
    * Register passed in languages.

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -98,7 +98,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Call this method to toggle the code block.
@@ -166,7 +166,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
         })(parameter);
       },
     };
-  };
+  }
 
   /**
    * Create an input rule that listens converts the code fence into a code block

--- a/packages/@remirror/extension-code/src/code-extension.ts
+++ b/packages/@remirror/extension-code/src/code-extension.ts
@@ -31,14 +31,14 @@ export class CodeExtension extends MarkExtension {
     };
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the current selection as a code mark.
        */
       toggleCode: () => convertCommand(toggleMark(this.type)),
     };
-  };
+  }
 
   createInputRules = () => {
     return [

--- a/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -14,7 +14,7 @@ import {
   PlainExtension,
   ProsemirrorAttributes,
   Shape,
-  StateUpdateLifecycleMethod,
+  StateUpdateLifecycleParameter,
   Static,
   Transaction,
   uniqueId,
@@ -88,9 +88,9 @@ export class CollaborationExtension extends PlainExtension<CollaborationOptions>
     return [plugin];
   };
 
-  onStateUpdate: StateUpdateLifecycleMethod = (parameter) => {
+  onStateUpdate(parameter: StateUpdateLifecycleParameter) {
     this.getSendableSteps(parameter.state);
-  };
+  }
 
   /**
    * This passes the sendable steps into the `onSendableReceived` handler defined in the

--- a/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -77,7 +77,7 @@ export class CollaborationExtension extends PlainExtension<CollaborationOptions>
     };
   }
 
-  createExternalPlugins = () => {
+  createExternalPlugins() {
     const { version, clientID } = this.options;
 
     const plugin = collab({
@@ -86,7 +86,7 @@ export class CollaborationExtension extends PlainExtension<CollaborationOptions>
     });
 
     return [plugin];
-  };
+  }
 
   onStateUpdate(parameter: StateUpdateLifecycleParameter) {
     this.getSendableSteps(parameter.state);

--- a/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -43,7 +43,7 @@ export class CollaborationExtension extends PlainExtension<CollaborationOptions>
     this.getSendableSteps = debounce(this.options.debounceMs, this.getSendableSteps);
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Send a collaboration update.
@@ -75,7 +75,7 @@ export class CollaborationExtension extends PlainExtension<CollaborationOptions>
         return true;
       },
     };
-  };
+  }
 
   createExternalPlugins = () => {
     const { version, clientID } = this.options;

--- a/packages/@remirror/extension-diff/src/diff-extension.ts
+++ b/packages/@remirror/extension-diff/src/diff-extension.ts
@@ -170,7 +170,7 @@ export class DiffExtension extends PlainExtension<DiffOptions> {
    * This has been adapted from the prosemirror website demo.
    * https://github.com/ProseMirror/website/blob/master/example/track/index.js
    */
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {
       state: {
         init: (_, state) => {
@@ -198,7 +198,7 @@ export class DiffExtension extends PlainExtension<DiffOptions> {
         },
       },
     };
-  };
+  }
 
   /**
    * Calls the selection handlers when the selection changes the number of

--- a/packages/@remirror/extension-diff/src/diff-extension.ts
+++ b/packages/@remirror/extension-diff/src/diff-extension.ts
@@ -87,7 +87,7 @@ export class DiffExtension extends PlainExtension<DiffOptions> {
   /**
    * Create the command for managing the commits in the document.
    */
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Attach a commit message to the recent change.
@@ -109,7 +109,7 @@ export class DiffExtension extends PlainExtension<DiffOptions> {
        */
       removeHighlightedCommit: (commit: Commit | CommitId) => this.removeHighlightedCommit(commit),
     };
-  };
+  }
 
   createHelpers = () => {
     return {

--- a/packages/@remirror/extension-diff/src/diff-extension.ts
+++ b/packages/@remirror/extension-diff/src/diff-extension.ts
@@ -111,7 +111,7 @@ export class DiffExtension extends PlainExtension<DiffOptions> {
     };
   }
 
-  createHelpers = () => {
+  createHelpers() {
     return {
       /**
        * Get the full list of commits in the history.
@@ -125,7 +125,7 @@ export class DiffExtension extends PlainExtension<DiffOptions> {
        */
       getCommit: (id: CommitId) => this.getCommit(id),
     };
-  };
+  }
 
   /**
    * Get the full list of tracked commit changes

--- a/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
+++ b/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
@@ -142,7 +142,7 @@ export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
     return 'dropCursor' as const;
   }
 
-  createHelpers = () => {
+  createHelpers() {
     return {
       /**
        * Check if the anything is currently being dragged over the editor.
@@ -151,7 +151,7 @@ export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
         return this.store.getPluginState<DropCursorState>(this.name).isDragging();
       },
     };
-  };
+  }
 
   /**
    * Use the dropCursor plugin with provided options.

--- a/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
+++ b/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
@@ -156,7 +156,7 @@ export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
   /**
    * Use the dropCursor plugin with provided options.
    */
-  createPlugin = (): CreatePluginReturn<DropCursorState> => {
+  createPlugin(): CreatePluginReturn<DropCursorState> {
     const dropCursorState = new DropCursorState(this);
 
     return {
@@ -190,7 +190,7 @@ export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
         },
       },
     };
-  };
+  }
 }
 
 /**

--- a/packages/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/packages/@remirror/extension-emoji/src/emoji-extension.ts
@@ -89,7 +89,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
     ];
   };
 
-  createCommands = () => {
+  createCommands() {
     const commands = {
       /**
        * Insert an emoji into the document at the requested location by name
@@ -153,7 +153,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
     };
 
     return commands;
-  };
+  }
 
   createHelpers = () => {
     return {

--- a/packages/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/packages/@remirror/extension-emoji/src/emoji-extension.ts
@@ -155,7 +155,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
     return commands;
   }
 
-  createHelpers = () => {
+  createHelpers() {
     return {
       /**
        * Update the emoji which are displayed to the user when the query is not
@@ -165,7 +165,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
         this.frequentlyUsed = populateFrequentlyUsed(names);
       },
     };
-  };
+  }
 
   protected onAddCustomHandler: AddCustomHandler<EmojiOptions> = (parameter) => {
     const { keyBindings: keyBindings } = parameter;

--- a/packages/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/packages/@remirror/extension-emoji/src/emoji-extension.ts
@@ -200,7 +200,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
    * Emojis can be selected via `:` the colon key (by default). This sets the
    * configuration using `prosemirror-suggest`
    */
-  createSuggestions = (): Suggestion => {
+  createSuggestions(): Suggestion {
     return {
       noDecorations: true,
       invalidPrefixCharacters: escapeStringRegex(this.options.suggestionCharacter),
@@ -235,7 +235,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
         };
       },
     };
-  };
+  }
 }
 
 export interface EmojiCommandOptions extends Partial<FromToParameter> {

--- a/packages/@remirror/extension-epic-mode/src/epic-mode-extension.ts
+++ b/packages/@remirror/extension-epic-mode/src/epic-mode-extension.ts
@@ -26,7 +26,7 @@ export class EpicModeExtension extends PlainExtension<EpicModeOptions> {
     return 'epicMode' as const;
   }
 
-  createPlugin = (): CreatePluginReturn<EpicModePluginState> => {
+  createPlugin(): CreatePluginReturn<EpicModePluginState> {
     const pluginState = new EpicModePluginState(this);
 
     return {
@@ -56,7 +56,7 @@ export class EpicModeExtension extends PlainExtension<EpicModeOptions> {
         };
       },
     };
-  };
+  }
 }
 
 function getRGBComponents(node: Element) {

--- a/packages/@remirror/extension-gap-cursor/src/gap-cursor-extension.ts
+++ b/packages/@remirror/extension-gap-cursor/src/gap-cursor-extension.ts
@@ -22,9 +22,9 @@ export class GapCursorExtension extends PlainExtension {
     return 'gapCursor' as const;
   }
 
-  createExternalPlugins = () => {
+  createExternalPlugins() {
     return [gapCursor()];
-  };
+  }
 }
 
 /**

--- a/packages/@remirror/extension-heading/src/heading-extension.ts
+++ b/packages/@remirror/extension-heading/src/heading-extension.ts
@@ -84,7 +84,7 @@ export class HeadingExtension extends NodeExtension<HeadingOptions> {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the heading for the current block. If you don't provide the
@@ -97,7 +97,7 @@ export class HeadingExtension extends NodeExtension<HeadingOptions> {
           attrs,
         }),
     };
-  };
+  }
 
   createKeymap = (): KeyBindings => {
     const keys: KeyBindings = object();

--- a/packages/@remirror/extension-history/src/history-extension.ts
+++ b/packages/@remirror/extension-history/src/history-extension.ts
@@ -140,7 +140,7 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
   /**
    * Provide the undo and redo commands.
    */
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Undo the last action that occurred. This can be overridden by
@@ -165,5 +165,5 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
        */
       redo: () => this.wrapMethod(redo),
     };
-  };
+  }
 }

--- a/packages/@remirror/extension-history/src/history-extension.ts
+++ b/packages/@remirror/extension-history/src/history-extension.ts
@@ -131,11 +131,11 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
   /**
    * Bring the `prosemirror-history` plugin with options set on this extension.
    */
-  createExternalPlugins = () => {
+  createExternalPlugins() {
     const { depth, newGroupDelay } = this.options;
 
     return [history({ depth, newGroupDelay })];
-  };
+  }
 
   /**
    * Provide the undo and redo commands.

--- a/packages/@remirror/extension-horizontal-rule/src/horizontal-rule-extension.ts
+++ b/packages/@remirror/extension-horizontal-rule/src/horizontal-rule-extension.ts
@@ -25,7 +25,7 @@ export class HorizontalRuleExtension extends NodeExtension {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       horizontalRule: (): CommandFunction => ({ state, dispatch }) => {
         if (dispatch) {
@@ -35,7 +35,7 @@ export class HorizontalRuleExtension extends NodeExtension {
         return true;
       },
     };
-  };
+  }
 
   createInputRules = (): InputRule[] => {
     return [nodeInputRule({ regexp: /^(?:---|___\s|\*\*\*\s)$/, type: this.type })];

--- a/packages/@remirror/extension-image/src/image-extension.ts
+++ b/packages/@remirror/extension-image/src/image-extension.ts
@@ -54,7 +54,7 @@ export class ImageExtension extends NodeExtension {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       insertImage: (
         attributes: ProsemirrorAttributes<ImageExtensionAttributes>,
@@ -71,7 +71,7 @@ export class ImageExtension extends NodeExtension {
         return true;
       },
     };
-  };
+  }
 
   createPlugin = (): CreatePluginReturn => {
     return {

--- a/packages/@remirror/extension-image/src/image-extension.ts
+++ b/packages/@remirror/extension-image/src/image-extension.ts
@@ -73,7 +73,7 @@ export class ImageExtension extends NodeExtension {
     };
   }
 
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {
       props: {
         handleDOMEvents: {
@@ -118,7 +118,7 @@ export class ImageExtension extends NodeExtension {
         },
       },
     };
-  };
+  }
 }
 
 export interface ImageExtensionAttributes {

--- a/packages/@remirror/extension-italic/src/italic-extension.ts
+++ b/packages/@remirror/extension-italic/src/italic-extension.ts
@@ -35,14 +35,14 @@ export class ItalicExtension extends MarkExtension {
     };
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the italic formatting on the selected text.
        */
       toggleItalic: () => convertCommand(toggleMark(this.type)),
     };
-  };
+  }
 
   createInputRules = () => {
     return [markInputRule({ regexp: /(?:^|[^*_])[*_]([^*_]+)[*_]$/, type: this.type })];

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -145,7 +145,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     ];
   };
 
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {
       props: {
         handleClick: (view, pos) => {
@@ -165,5 +165,5 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
         },
       },
     };
-  };
+  }
 }

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -92,7 +92,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     };
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Create or update the link if it doesn't currently exist at the current selection.
@@ -133,7 +133,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
         };
       },
     };
-  };
+  }
 
   createPasteRules = () => {
     return [

--- a/packages/@remirror/extension-mention/src/mention-extension.ts
+++ b/packages/@remirror/extension-mention/src/mention-extension.ts
@@ -185,7 +185,7 @@ export class MentionExtension extends MarkExtension<MentionOptions> {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Create a new mention
@@ -203,7 +203,7 @@ export class MentionExtension extends MarkExtension<MentionOptions> {
       removeMention: ({ range }: Partial<RangeParameter> = object()) =>
         removeMark({ type: this.type, expand: true, range }),
     };
-  };
+  }
 
   createPasteRules = () => {
     return this.options.matchers.map((matcher) => {

--- a/packages/@remirror/extension-mention/src/mention-extension.ts
+++ b/packages/@remirror/extension-mention/src/mention-extension.ts
@@ -229,7 +229,7 @@ export class MentionExtension extends MarkExtension<MentionOptions> {
     });
   };
 
-  createSuggestions = () => {
+  createSuggestions() {
     return this.options.matchers.map<Suggestion<MentionExtensionSuggestCommand>>((matcher) => {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const extension = this;
@@ -312,7 +312,7 @@ export class MentionExtension extends MarkExtension<MentionOptions> {
         },
       };
     });
-  };
+  }
 
   /**
    * The factory method for mention commands to update and create new mentions.

--- a/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
+++ b/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
@@ -60,13 +60,13 @@ export class ParagraphExtension extends NodeExtension<ParagraphOptions> {
   /**
    * Provides the commands that this extension uses.
    */
-  createCommands = () => {
+  createCommands() {
     return {
       createParagraph: (attributes: ParagraphExtensionAttributes) => {
         return convertCommand(setBlockType(this.type, attributes));
       },
     };
-  };
+  }
 }
 
 export interface ParagraphOptions {

--- a/packages/@remirror/extension-placeholder/src/placeholder-extension.ts
+++ b/packages/@remirror/extension-placeholder/src/placeholder-extension.ts
@@ -70,11 +70,11 @@ export class PlaceholderExtension extends PlainExtension<PlaceholderOptions> {
     return 'placeholder' as const;
   }
 
-  createAttributes = () => {
+  createAttributes() {
     return { 'aria-placeholder': this.options.placeholder };
-  };
+  }
 
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {
       state: {
         init: (_, state): PlaceholderPluginState => ({
@@ -91,7 +91,7 @@ export class PlaceholderExtension extends PlainExtension<PlaceholderOptions> {
         },
       },
     };
-  };
+  }
 
   onSetOptions(parameter: OnSetOptionsParameter<PlaceholderOptions>) {
     const { changes } = parameter;

--- a/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
+++ b/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
@@ -181,7 +181,7 @@ export class PositionTrackerExtension extends PlainExtension<PositionTrackerOpti
     };
   }
 
-  createPlugin = (): CreatePluginReturn<DecorationSet> => {
+  createPlugin(): CreatePluginReturn<DecorationSet> {
     const name = this.name;
 
     return {
@@ -235,7 +235,7 @@ export class PositionTrackerExtension extends PlainExtension<PositionTrackerOpti
         },
       },
     };
-  };
+  }
 }
 
 export interface PositionTrackerExtensionMeta {

--- a/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
+++ b/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
@@ -52,7 +52,7 @@ export class PositionTrackerExtension extends PlainExtension<PositionTrackerOpti
     return 'positionTracker' as const;
   }
 
-  createHelpers = () => {
+  createHelpers() {
     const helpers = {
       /**
        * Add a tracker position with the specified params to the transaction and return the transaction.
@@ -140,7 +140,7 @@ export class PositionTrackerExtension extends PlainExtension<PositionTrackerOpti
     };
 
     return helpers;
-  };
+  }
 
   #commandFactory = <Parameter>(helperName: string) => {
     return (parameter: Parameter): CommandFunction => ({ dispatch }) => {

--- a/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
+++ b/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
@@ -159,7 +159,7 @@ export class PositionTrackerExtension extends PlainExtension<PositionTrackerOpti
     };
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Command to dispatch a transaction adding the tracker position to be tracked.
@@ -179,7 +179,7 @@ export class PositionTrackerExtension extends PlainExtension<PositionTrackerOpti
        */
       clearPositionTrackers: this.#commandFactory<void>('clearPositionTrackers'),
     };
-  };
+  }
 
   createPlugin = (): CreatePluginReturn<DecorationSet> => {
     const name = this.name;

--- a/packages/@remirror/extension-positioner/src/positioner-extension.ts
+++ b/packages/@remirror/extension-positioner/src/positioner-extension.ts
@@ -5,7 +5,6 @@ import {
   isString,
   PlainExtension,
   Position,
-  StateUpdateLifecycleMethod,
   StateUpdateLifecycleParameter,
 } from '@remirror/core';
 
@@ -56,9 +55,9 @@ export class PositionerExtension extends PlainExtension<PositionerOptions> {
     };
   };
 
-  onStateUpdate: StateUpdateLifecycleMethod = (update) => {
+  onStateUpdate(update: StateUpdateLifecycleParameter) {
     this.positionerHandler(update);
-  };
+  }
 
   private positionerHandler(update: StateUpdateLifecycleParameter) {
     for (const handler of this.#positionerHandlerList) {

--- a/packages/@remirror/extension-react-ssr/src/react-ssr-extension.ts
+++ b/packages/@remirror/extension-react-ssr/src/react-ssr-extension.ts
@@ -2,7 +2,6 @@ import { Children, cloneElement, ComponentType, createElement, JSXElementConstru
 
 import {
   AnyCombinedUnion,
-  CreateLifecycleMethod,
   EditorState,
   ExtensionPriority,
   isArray,
@@ -54,7 +53,7 @@ export class ReactSSRExtension extends PlainExtension<ReactSSROptions> {
     return 'reactSSR' as const;
   }
 
-  onCreate: CreateLifecycleMethod = (extensions) => {
+  onCreate() {
     const components: Record<string, ManagerStoreReactComponent> = object();
     const ssrTransformers: Array<() => SSRTransformer> = [];
 
@@ -68,7 +67,7 @@ export class ReactSSRExtension extends PlainExtension<ReactSSROptions> {
       return element;
     };
 
-    for (const extension of extensions) {
+    for (const extension of this.store.extensions) {
       if (
         !this.store.managerSettings.exclude?.reactSSR &&
         extension.ReactComponent &&
@@ -96,7 +95,7 @@ export class ReactSSRExtension extends PlainExtension<ReactSSROptions> {
 
     this.store.setStoreKey('components', components);
     this.store.setStoreKey('ssrTransformer', ssrTransformer);
-  };
+  }
 
   /**
    * A function that takes in the initial automatically produced JSX by the

--- a/packages/@remirror/extension-search/src/search-extension.ts
+++ b/packages/@remirror/extension-search/src/search-extension.ts
@@ -160,7 +160,7 @@ export class SearchExtension extends PlainExtension<SearchOptions> {
   /**
    * This plugin is responsible for adding something decorations to the
    */
-  createPlugin = (): CreatePluginReturn => {
+  createPlugin(): CreatePluginReturn {
     return {
       state: {
         init() {
@@ -189,7 +189,7 @@ export class SearchExtension extends PlainExtension<SearchOptions> {
         },
       },
     };
-  };
+  }
 
   /**
    * Create the keymap for this extension.

--- a/packages/@remirror/extension-search/src/search-extension.ts
+++ b/packages/@remirror/extension-search/src/search-extension.ts
@@ -122,7 +122,7 @@ export class SearchExtension extends PlainExtension<SearchOptions> {
     return 'search' as const;
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Find a search term in the editor. If no search term is provided it
@@ -155,7 +155,7 @@ export class SearchExtension extends PlainExtension<SearchOptions> {
        */
       clearSearch: () => this.clear(),
     };
-  };
+  }
 
   /**
    * This plugin is responsible for adding something decorations to the

--- a/packages/@remirror/extension-strike/src/strike-extension.ts
+++ b/packages/@remirror/extension-strike/src/strike-extension.ts
@@ -47,14 +47,14 @@ export class StrikeExtension extends MarkExtension {
     };
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the strike through formatting annotation.
        */
       toggleStrike: () => convertCommand(toggleMark(this.type)),
     };
-  };
+  }
 
   createInputRules = () => {
     return [markInputRule({ regexp: /~([^~]+)~$/, type: this.type })];

--- a/packages/@remirror/extension-trailing-node/src/trailing-node-extension.ts
+++ b/packages/@remirror/extension-trailing-node/src/trailing-node-extension.ts
@@ -77,7 +77,7 @@ export class TrailingNodeExtension extends PlainExtension<TrailingNodeOptions> {
    * Create the paragraph plugin which can check the end of the document and
    * insert a new node.
    */
-  createPlugin = (): CreatePluginReturn<boolean> => {
+  createPlugin(): CreatePluginReturn<boolean> {
     const { tags, schema } = this.store;
     const { disableTags, ignoredNodes, nodeName } = this.options;
 
@@ -127,5 +127,5 @@ export class TrailingNodeExtension extends PlainExtension<TrailingNodeOptions> {
         },
       },
     };
-  };
+  }
 }

--- a/packages/@remirror/extension-underline/src/underline-extension.ts
+++ b/packages/@remirror/extension-underline/src/underline-extension.ts
@@ -36,12 +36,12 @@ export class UnderlineExtension extends MarkExtension {
     };
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the underline formatting of the selected text.
        */
       toggleUnderline: () => convertCommand(toggleMark(this.type)),
     };
-  };
+  }
 }

--- a/packages/@remirror/extension-yjs/src/yjs-extension.ts
+++ b/packages/@remirror/extension-yjs/src/yjs-extension.ts
@@ -99,7 +99,7 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
     return [ySyncPlugin(type), yCursorPlugin(this.provider.awareness), yUndoPlugin()];
   };
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Undo within a collaborative editor.
@@ -111,7 +111,7 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
        */
       yRedo: (): CommandFunction => nonChainable(convertCommand(redo)),
     };
-  };
+  }
 
   /**
    * This managers the updates of the collaboration provider.

--- a/packages/@remirror/extension-yjs/src/yjs-extension.ts
+++ b/packages/@remirror/extension-yjs/src/yjs-extension.ts
@@ -132,13 +132,13 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
   /**
    * Remove the provider from the manager.
    */
-  onDestroy = () => {
+  onDestroy() {
     if (!this.#provider) {
       return;
     }
 
     this.options.destroyProvider(this.#provider);
-  };
+  }
 }
 
 /**

--- a/packages/@remirror/extension-yjs/src/yjs-extension.ts
+++ b/packages/@remirror/extension-yjs/src/yjs-extension.ts
@@ -93,11 +93,11 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
   /**
    * Create the yjs plugins.
    */
-  createExternalPlugins = () => {
+  createExternalPlugins() {
     const yDoc = this.provider.doc;
     const type = yDoc.getXmlFragment('prosemirror');
     return [ySyncPlugin(type), yCursorPlugin(this.provider.awareness), yUndoPlugin()];
-  };
+  }
 
   createCommands() {
     return {

--- a/packages/@remirror/preset-embed/src/iframe-extension.ts
+++ b/packages/@remirror/preset-embed/src/iframe-extension.ts
@@ -114,7 +114,7 @@ export class IframeExtension extends NodeExtension<IframeOptions> {
   /**
    * Provides the commands for the iFrame extension.
    */
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Add a custom iFrame to the editor.
@@ -136,7 +136,7 @@ export class IframeExtension extends NodeExtension<IframeOptions> {
        */
       updateYouTubeVideo: this.updateYouTubeVideo,
     };
-  };
+  }
 
   /**
    * Creates the command for adding an iFrame to the editor.

--- a/packages/@remirror/preset-list/src/bullet-list-extension.ts
+++ b/packages/@remirror/preset-list/src/bullet-list-extension.ts
@@ -26,14 +26,14 @@ export class BulletListExtension extends NodeExtension {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the bullet list.
        */
       toggleBulletList: () => toggleList(this.type, this.store.schema.nodes.listItem),
     };
-  };
+  }
 
   createKeymap = (): KeyBindings => {
     return {

--- a/packages/@remirror/preset-list/src/ordered-list-extension.ts
+++ b/packages/@remirror/preset-list/src/ordered-list-extension.ts
@@ -52,14 +52,14 @@ export class OrderedListExtension extends NodeExtension {
     };
   }
 
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Toggle the ordered list for the current selection.
        */
       toggleOrderedList: () => toggleList(this.type, this.store.schema.nodes.listItem),
     };
-  };
+  }
 
   createKeymap = (): KeyBindings => {
     return {

--- a/packages/@remirror/preset-table/src/table-extensions.ts
+++ b/packages/@remirror/preset-table/src/table-extensions.ts
@@ -170,7 +170,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
     };
   }
 
-  createHelpers = () => {
+  createHelpers() {
     return {
       /**
        * Enable table usage within the editor. This depends on the editor.
@@ -185,7 +185,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
         tablesEnabled = true;
       },
     };
-  };
+  }
 
   /**
    * This managers the updates of the collaboration provider.

--- a/packages/@remirror/preset-table/src/table-extensions.ts
+++ b/packages/@remirror/preset-table/src/table-extensions.ts
@@ -61,9 +61,9 @@ export class TableExtension extends NodeExtension<TableOptions> {
   /**
    * Add the table plugins to the editor.
    */
-  createExternalPlugins = () => {
+  createExternalPlugins() {
     return [tableEditing(), columnResizing({})];
-  };
+  }
 
   /**
    * Create the commands that can be used for the table.

--- a/packages/@remirror/preset-table/src/table-extensions.ts
+++ b/packages/@remirror/preset-table/src/table-extensions.ts
@@ -68,7 +68,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
   /**
    * Create the commands that can be used for the table.
    */
-  createCommands = () => {
+  createCommands() {
     return {
       /**
        * Create a table in the editor at the current selection point.
@@ -168,7 +168,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
        */
       fixTables: () => fixTablesCommand,
     };
-  };
+  }
 
   createHelpers = () => {
     return {

--- a/packages/@remirror/react/src/components/__tests__/react-editor-controlled.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/react-editor-controlled.spec.tsx
@@ -7,7 +7,7 @@ import {
   fromHtml,
   PlainExtension,
   SchemaFromCombined,
-  StateUpdateLifecycleMethod,
+  StateUpdateLifecycleParameter,
 } from '@remirror/core';
 import { act, render } from '@remirror/testing/react';
 
@@ -258,7 +258,7 @@ describe('Remirror Controlled Component', () => {
         return 'update' as const;
       }
 
-      onStateUpdate: StateUpdateLifecycleMethod = mock;
+      onStateUpdate: (update: StateUpdateLifecycleParameter) => void = mock;
     }
 
     const { manager, props, chain, doc, p } = create([new UpdateExtension()]);

--- a/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
@@ -99,7 +99,7 @@ class CustomExtension extends PlainExtension {
     return 'custom' as const;
   }
 
-  createPlugin = () => {
+  createPlugin() {
     return {
       props: {
         handleTripleClick: tripleClickMock,
@@ -107,7 +107,7 @@ class CustomExtension extends PlainExtension {
         handleClick: clickMock,
       },
     };
-  };
+  }
 }
 
 function create() {

--- a/support/root/.eslintrc.js
+++ b/support/root/.eslintrc.js
@@ -199,7 +199,7 @@ module.exports = {
       'warn',
       { default: ['signature', 'static-field', 'static-method', 'field', 'constructor', 'method'] },
     ],
-    '@typescript-eslint/method-signature-style': 'error',
+    '@typescript-eslint/method-signature-style': 'warn',
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/no-unused-vars-experimental': [
       'error',
@@ -340,6 +340,15 @@ module.exports = {
     {
       files: ['packages/@remirror/playground/**', 'support/e2e/**'],
       rules: { '@typescript-eslint/no-var-requires': 'off' },
+    },
+    {
+      files: [
+        '**/*extension.ts',
+        '**/*extension.tsx',
+        'packages/@remirror/core/src/manager/remirror-manager.ts',
+        'packages/@remirror/core/src/extension/extension-base.ts',
+      ],
+      rules: { '@typescript-eslint/method-signature-style': 'off' },
     },
   ],
 };


### PR DESCRIPTION
## Description

Switch to using method signatures for extension class methods as discussed in #360.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
