### PR TITLE
perf: prevent creating extensions on every render

### DIFF
--- a/.changeset/fuzzy-pandas-tan.md
+++ b/.changeset/fuzzy-pandas-tan.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+`RemirrorManager.create` can now accept a function to which returns an array of extensions and presets. This lazy creation allows for optimizations to be made elsewhere in the codebase.

--- a/.changeset/lazy-shrimps-promise.md
+++ b/.changeset/lazy-shrimps-promise.md
@@ -1,0 +1,7 @@
+---
+'@remirror/react': patch
+---
+
+- Prevent `createReactManager` being called on every render.
+- Accept a `manager` as a parameter for ``createReactManager`
+- Improve internal performance of components by caching the `ReactEditorWrapper` after the first render.

--- a/.changeset/purple-pants-yell.md
+++ b/.changeset/purple-pants-yell.md
@@ -1,0 +1,9 @@
+---
+'@remirror/preset-core': minor
+'@remirror/react': minor
+---
+
+Remove requirement for `readonly` arrays when passing a list of extensions / presets to manager creators.
+
+- **`@remirror/react`** - Add support for a function as the first parameter to the `useManager` hook and `createReactManager` function.
+- **`@remirror/preset-core`** - Add support for a function as the first parameter to the `createCoreManager` function.

--- a/.changeset/violet-doors-pull.md
+++ b/.changeset/violet-doors-pull.md
@@ -1,0 +1,7 @@
+---
+'@remirror/react-social': major
+---
+
+Reduce the number of rerenders for the social manager.
+
+BREAKING CHANGE: The package no longer exports a `createSocialManager` and instead provides a `socialManagerArgs` which can be passed into the `useManager` hook.

--- a/packages/@remirror/core-helpers/src/core-helpers.ts
+++ b/packages/@remirror/core-helpers/src/core-helpers.ts
@@ -1013,6 +1013,18 @@ export function hasOwnProperty<Obj extends object, Property extends string | num
   return Object.prototype.hasOwnProperty.call(object_, key);
 }
 
+/**
+ * Helper for getting an array which can be passed in as a argument-less
+ * function.
+ */
+export function getArray<Type>(value: Type[] | (() => Type[])): Type[] {
+  if (isFunction(value)) {
+    return value();
+  }
+
+  return value;
+}
+
 // Forwarded exports
 
 export {

--- a/packages/@remirror/preset-core/src/core-preset-methods.ts
+++ b/packages/@remirror/preset-core/src/core-preset-methods.ts
@@ -1,4 +1,4 @@
-import { AnyCombinedUnion, RemirrorManager } from '@remirror/core';
+import { AnyCombinedUnion, getArray, RemirrorManager } from '@remirror/core';
 
 import { CorePreset, CorePresetOptions } from './core-preset';
 
@@ -18,9 +18,13 @@ export interface CreateCoreManagerOptions {
  * Create a manager with the core preset already applied.
  */
 export function createCoreManager<Combined extends AnyCombinedUnion>(
-  combined: readonly Combined[],
+  combined: Combined[] | (() => Combined[]),
   options: CreateCoreManagerOptions = {},
 ) {
   const { core, managerSettings } = options;
-  return RemirrorManager.create([...combined, new CorePreset(core)], managerSettings);
+
+  return RemirrorManager.create(
+    () => [...getArray(combined), new CorePreset(core)],
+    managerSettings,
+  );
 }

--- a/packages/@remirror/react-social/src/components/__tests__/social-editor.spec.tsx
+++ b/packages/@remirror/react-social/src/components/__tests__/social-editor.spec.tsx
@@ -2,9 +2,9 @@ import { RemirrorTestChain } from 'jest-remirror';
 import React from 'react';
 
 import { docNodeBasicJSON } from '@remirror/testing';
-import { act, render } from '@remirror/testing/react';
+import { act, createReactManager, render } from '@remirror/testing/react';
 
-import { createSocialManager, SocialEditor } from '../..';
+import { SocialEditor, socialManagerArgs } from '../..';
 
 describe('social editor', () => {
   it('should place the editor within the correct element', () => {
@@ -24,7 +24,7 @@ describe('social editor', () => {
   });
 
   it('should support content', () => {
-    const manager = createSocialManager([]);
+    const manager = createReactManager(...socialManagerArgs([]));
     const chain = RemirrorTestChain.create(manager);
 
     render(

--- a/packages/@remirror/react-social/src/hooks/__tests__/use-social-emoji.spec.tsx
+++ b/packages/@remirror/react-social/src/hooks/__tests__/use-social-emoji.spec.tsx
@@ -2,13 +2,15 @@ import { act, renderHook } from '@testing-library/react-hooks';
 import { RemirrorTestChain } from 'jest-remirror';
 import React, { FC } from 'react';
 
+import { createReactManager } from '@remirror/testing/react';
+
 import { SocialProvider } from '../../components/social-provider';
-import { createSocialManager } from '../../social-utils';
+import { socialManagerArgs } from '../../social-utils';
 import { useSocialRemirror } from '../use-social';
 import { useSocialEmoji } from '../use-social-emoji';
 
 function createChain() {
-  const manager = createSocialManager([]);
+  const manager = createReactManager(...socialManagerArgs([]));
   const chain = RemirrorTestChain.create(manager);
   const { doc, p } = chain.nodes;
 

--- a/packages/@remirror/react-social/src/hooks/__tests__/use-social-mention.spec.tsx
+++ b/packages/@remirror/react-social/src/hooks/__tests__/use-social-mention.spec.tsx
@@ -3,10 +3,11 @@ import { RemirrorTestChain } from 'jest-remirror';
 import React, { FC } from 'react';
 
 import { NON_BREAKING_SPACE_CHAR } from '@remirror/core';
+import { createReactManager } from '@remirror/react';
 
 import { SocialProvider } from '../../components/social-provider';
 import { MentionChangeParameter, TagData, UserData } from '../../social-types';
-import { createSocialManager } from '../../social-utils';
+import { socialManagerArgs } from '../../social-utils';
 import { useSocialRemirror } from '../use-social';
 import { useSocialMention } from '../use-social-mention';
 
@@ -200,7 +201,7 @@ describe('useSocialMention', () => {
 });
 
 function createChain() {
-  const manager = createSocialManager([]);
+  const manager = createReactManager(...socialManagerArgs([]));
   const chain = RemirrorTestChain.create(manager);
   const { doc, p } = chain.nodes;
 

--- a/packages/@remirror/react-social/src/hooks/use-social.ts
+++ b/packages/@remirror/react-social/src/hooks/use-social.ts
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { useMemo } from 'react';
 
-import { AnyCombinedUnion, isRemirrorManager, RemirrorManager } from '@remirror/core';
-import { useRemirror, UseRemirrorType } from '@remirror/react';
+import { AnyCombinedUnion, RemirrorManager } from '@remirror/core';
+import { useManager, useRemirror, UseRemirrorType } from '@remirror/react';
 
 import { CreateSocialManagerOptions, SocialCombinedUnion } from '../social-types';
-import { createSocialManager } from '../social-utils';
+import { socialManagerArgs } from '../social-utils';
 
 /**
  * A wrapper around the `createSocialManager` function for creating a manager
@@ -20,22 +20,14 @@ import { createSocialManager } from '../social-utils';
  * configuration and then ignores everything else.
  */
 export function useSocialManager<Combined extends AnyCombinedUnion>(
-  managerOrCombined: readonly Combined[] | RemirrorManager<Combined | SocialCombinedUnion>,
+  combined: Combined[] | (() => Combined[]) | RemirrorManager<Combined | SocialCombinedUnion>,
   options: CreateSocialManagerOptions = {},
 ): RemirrorManager<SocialCombinedUnion | Combined> {
-  const manager = useRef(
-    isRemirrorManager<Combined | SocialCombinedUnion>(managerOrCombined)
-      ? managerOrCombined
-      : createSocialManager(managerOrCombined, options),
-  ).current;
+  const args = useMemo(() => {
+    return socialManagerArgs(combined, options);
+  }, [combined, options]);
 
-  useEffect(() => {
-    return () => {
-      manager.destroy();
-    };
-  }, [manager]);
-
-  return manager;
+  return useManager(...args);
 }
 
 /**

--- a/packages/@remirror/react/src/components/providers.tsx
+++ b/packages/@remirror/react/src/components/providers.tsx
@@ -45,7 +45,7 @@ export interface RemirrorProviderProps<Combined extends AnyCombinedUnion>
    * should not change they during the component lifecycle as they are created
    * once at the very start and never recreated.
    */
-  combined?: readonly Combined[];
+  combined?: Combined[];
 
   /**
    * The settings to provide to the `RemirrorManager`. This is only applied when

--- a/packages/@remirror/react/src/components/react-editor.tsx
+++ b/packages/@remirror/react/src/components/react-editor.tsx
@@ -576,7 +576,17 @@ type SetShouldRenderClient = Dispatch<SetStateAction<boolean | undefined>>;
 function useEditorWrapper<Combined extends AnyCombinedUnion>(
   parameter: ReactEditorWrapperParameter<Combined>,
 ) {
-  return useRef(new ReactEditorWrapper<Combined>(parameter)).current.update(parameter);
+  const isFirstMount = useFirstMountState();
+  const reactEditorWrapper = useRef(
+    isFirstMount ? new ReactEditorWrapper<Combined>(parameter) : null,
+  ).current?.update(parameter);
+
+  invariant(reactEditorWrapper, {
+    message: 'Problem with `useEditorWrapper` hook.',
+    code: ErrorConstant.INTERNAL,
+  });
+
+  return reactEditorWrapper;
 }
 
 /**

--- a/packages/@remirror/react/src/hooks/editor-hooks.ts
+++ b/packages/@remirror/react/src/hooks/editor-hooks.ts
@@ -384,7 +384,7 @@ type UsePresetCallback<Type extends AnyPresetConstructor> = (
  * ```
  */
 export function useManager<Combined extends AnyCombinedUnion>(
-  combined: readonly Combined[] | RemirrorManager<ReactCombinedUnion<Combined>>,
+  combined: Combined[] | (() => Combined[]) | RemirrorManager<ReactCombinedUnion<Combined>>,
   options: CreateReactManagerOptions = {},
 ): RemirrorManager<ReactCombinedUnion<Combined>> {
   const combinedRef = useRef(combined);

--- a/packages/@remirror/react/src/react-helpers.tsx
+++ b/packages/@remirror/react/src/react-helpers.tsx
@@ -1,4 +1,9 @@
-import { AnyCombinedUnion, BuiltinPreset, RemirrorManager } from '@remirror/core';
+import {
+  AnyCombinedUnion,
+  BuiltinPreset,
+  isRemirrorManager,
+  RemirrorManager,
+} from '@remirror/core';
 import { CorePreset } from '@remirror/preset-core';
 import { ReactPreset } from '@remirror/preset-react';
 
@@ -8,10 +13,16 @@ import { CreateReactManagerOptions } from './react-types';
  * Create a react manager with all the default react presets and extensions.
  */
 export function createReactManager<Combined extends AnyCombinedUnion>(
-  combined: readonly Combined[],
+  combined:
+    | readonly Combined[]
+    | RemirrorManager<Combined | BuiltinPreset | ReactPreset | CorePreset>,
   options: CreateReactManagerOptions = {},
 ): RemirrorManager<Combined | BuiltinPreset | ReactPreset | CorePreset> {
   const { managerSettings: settings, core, react } = options;
+
+  if (isRemirrorManager<Combined | BuiltinPreset | ReactPreset | CorePreset>(combined)) {
+    return combined;
+  }
 
   return RemirrorManager.create(
     [...combined, new ReactPreset(react), new CorePreset(core)],

--- a/packages/@remirror/react/src/react-helpers.tsx
+++ b/packages/@remirror/react/src/react-helpers.tsx
@@ -1,6 +1,7 @@
 import {
   AnyCombinedUnion,
   BuiltinPreset,
+  getArray,
   isRemirrorManager,
   RemirrorManager,
 } from '@remirror/core';
@@ -14,7 +15,8 @@ import { CreateReactManagerOptions } from './react-types';
  */
 export function createReactManager<Combined extends AnyCombinedUnion>(
   combined:
-    | readonly Combined[]
+    | Combined[]
+    | (() => Combined[])
     | RemirrorManager<Combined | BuiltinPreset | ReactPreset | CorePreset>,
   options: CreateReactManagerOptions = {},
 ): RemirrorManager<Combined | BuiltinPreset | ReactPreset | CorePreset> {
@@ -25,7 +27,7 @@ export function createReactManager<Combined extends AnyCombinedUnion>(
   }
 
   return RemirrorManager.create(
-    [...combined, new ReactPreset(react), new CorePreset(core)],
+    () => [...getArray(combined), new ReactPreset(react), new CorePreset(core)],
     settings,
   );
 }

--- a/packages/@remirror/testing/src/react.tsx
+++ b/packages/@remirror/testing/src/react.tsx
@@ -8,7 +8,7 @@ export function render(
   return originalRender(<StrictMode>{ui}</StrictMode>, options);
 }
 
-export { cleanup, act, fireEvent } from '@testing-library/react';
+export { cleanup, act, fireEvent, render as nonStrictRender } from '@testing-library/react';
 export type { RenderResult };
 export {
   useRemirror,


### PR DESCRIPTION
## Description

#### `@remirror/core`

- `RemirrorManager.create` can now accept a function to which returns an array of extensions and presets. This lazy creation allows for optimizations to be made elsewhere in the codebase.

#### `@remirror/react`

- Prevent `createReactManager` being called on every render.
- Accept a `manager` as a parameter for `createReactManager`.
- Improve internal performance of components by caching the `ReactEditorWrapper` after the first render.

Remove requirement for `readonly` arrays when passing a list of extensions / presets to manager creators.

- **`@remirror/react`** - Add support for a function as the first parameter to the `useManager` hook and `createReactManager` function.
- **`@remirror/preset-core`** - Add support for a function as the first parameter to the `createCoreManager` function.

#### `@remirror/react-social`

Reduce the number of rerenders for the social manager.

**BREAKING CHANGE:** The package no longer exports a `createSocialManager` and instead provides a `socialManagerArgs` which can be passed into the `useManager` hook.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Other

Closes #370