### PR TITLE
fix: Readme refers to non-existant preset-formatting

### DIFF
--- a/packages/@remirror/extension-auto-link/readme.md
+++ b/packages/@remirror/extension-auto-link/readme.md
@@ -51,13 +51,6 @@ document.body.appendChild(element);
 manager.addView(element);
 ```
 
-### Alternatives
-
-There are presets which contain this extension and can help make setup process for you editor less
-verbose.
-
-- `@remirror/preset-formatting`
-
 <br />
 
 ## Credits

--- a/packages/@remirror/extension-bold/readme.md
+++ b/packages/@remirror/extension-bold/readme.md
@@ -57,13 +57,6 @@ manager.commands.toggleBold();
 manager.commands.toggleBold({ from: 1, to: 7 });
 ```
 
-### Alternatives
-
-There are presets which contain this extension and can help make setup process for you editor less
-verbose.
-
-- `@remirror/preset-formatting`
-
 <br />
 
 ## Credits

--- a/packages/@remirror/extension-paragraph/readme.md
+++ b/packages/@remirror/extension-paragraph/readme.md
@@ -62,7 +62,6 @@ There are several presets which contain this extension and make the installation
 verbose. AS a result you probably won't ever need to manage it directly.
 
 - `@remirror/preset-core`
-- `@remirror/preset-formatting`
 
 <br />
 


### PR DESCRIPTION
## Description

Various points of the documentation refer to a preset "formatting", which doesn't exists.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

Fixes https://github.com/remirror/remirror/issues/393
