### PR TITLE
Add new `extensionDecorator` and `presetDecorator`

### DIFF
--- a/.changeset/few-numbers-joke.md
+++ b/.changeset/few-numbers-joke.md
@@ -1,0 +1,44 @@
+---
+'@remirror/extension-auto-link': patch
+'@remirror/extension-bidi': patch
+'@remirror/extension-bold': patch
+'@remirror/extension-code': patch
+'@remirror/extension-code-block': patch
+'@remirror/extension-collaboration': patch
+'@remirror/extension-diff': patch
+'@remirror/extension-doc': patch
+'@remirror/extension-drop-cursor': patch
+'@remirror/extension-emoji': patch
+'@remirror/extension-epic-mode': patch
+'@remirror/extension-gap-cursor': patch
+'@remirror/extension-hard-break': patch
+'@remirror/extension-heading': patch
+'@remirror/extension-history': patch
+'@remirror/extension-horizontal-rule': patch
+'@remirror/extension-image': patch
+'@remirror/extension-italic': patch
+'@remirror/extension-link': patch
+'@remirror/extension-mention': patch
+'@remirror/extension-paragraph': patch
+'@remirror/extension-placeholder': patch
+'@remirror/extension-position-tracker': patch
+'@remirror/extension-positioner': patch
+'@remirror/extension-react-component': patch
+'@remirror/extension-react-ssr': patch
+'@remirror/extension-search': patch
+'@remirror/extension-strike': patch
+'@remirror/extension-text': patch
+'@remirror/extension-trailing-node': patch
+'@remirror/extension-underline': patch
+'@remirror/extension-yjs': patch
+'@remirror/preset-core': patch
+'@remirror/preset-embed': patch
+'@remirror/preset-list': patch
+'@remirror/preset-react': patch
+'@remirror/preset-react-checkbox': patch
+'@remirror/preset-social': patch
+'@remirror/preset-table': patch
+'@remirror/preset-wysiwyg': patch
+---
+
+Switch from static properties to using the `@extensionDecorator` and `@presetDecorator` instead.

--- a/.changeset/gold-kings-glow.md
+++ b/.changeset/gold-kings-glow.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Remove static properties and use the `@extensionDecorator` instead.

--- a/.changeset/happy-gifts-turn.md
+++ b/.changeset/happy-gifts-turn.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-position-tracker': patch
+---
+
+Make `class` and `element` options `Static`.

--- a/.changeset/happy-llamas-reflect.md
+++ b/.changeset/happy-llamas-reflect.md
@@ -1,0 +1,38 @@
+---
+'@remirror/core': minor
+'@remirror/core-types': patch
+---
+
+Add new `extensionDecorator` function which augments the static properties of an `Extension` constructor when used as a decorator.
+
+The following code will add a decorator to the extension.
+
+```ts
+import { PlainExtension, ExtensionPriority, extensionDecorator } from 'remirror/core';
+
+interface ExampleOptions {
+  color?: string;
+
+  /**
+   * This option is annotated as a handler and needs a static property.
+   **/
+  onChange?: Handler<() => void>;
+}
+
+@extensionDecorator<ExampleOptions>({
+  defaultOptions: { color: 'red' },
+  defaultPriority: ExtensionPriority.Lowest,
+  handlerKeys: ['onChange'],
+})
+class ExampleExtension extends PlainExtension<ExampleOptions> {
+  get name() {
+    return 'example' as const;
+  }
+}
+```
+
+The extension decorator updates the static properties of the extension. If you prefer not to use decorators it can also be called as a function. The `Extension` constructor is mutated by the function call and does not need to be returned.
+
+```ts
+extensionDecorator({ defaultSettings: { color: 'red' } })(ExampleExtension);
+```

--- a/.changeset/happy-paws-wait.md
+++ b/.changeset/happy-paws-wait.md
@@ -1,0 +1,5 @@
+---
+'@remirror/preset-list': patch
+---
+
+Change name of `ListPreset` from `template` to `list`.

--- a/.changeset/polite-eagles-try.md
+++ b/.changeset/polite-eagles-try.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-placeholder': minor
+---
+
+Allow `PlaceholderExtension` `emptyNodeClass` option to be updated at runtime.

--- a/.changeset/sharp-singers-repeat.md
+++ b/.changeset/sharp-singers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-paragraph': major
+---
+
+Remove `ParagraphOptions` and all formatting specific attributes.

--- a/.changeset/smart-peaches-mate.md
+++ b/.changeset/smart-peaches-mate.md
@@ -1,0 +1,36 @@
+---
+'@remirror/core': minor
+---
+
+Add new `presetDecorator` function which augments the static properties of an `Preset` constructor when used as a decorator.
+
+The following code will add a decorator to the preset.
+
+```ts
+import { Preset presetDecorator } from 'remirror/core';
+
+interface ExampleOptions {
+  color?: string;
+
+  /**
+   * This option is annotated as a handler and needs a static property.
+   **/
+  onChange?: Handler<() => void>;
+}
+
+@presetDecorator<ExampleOptions>({
+  defaultOptions: { color: 'red' },
+  handlerKeys: ['onChange'],
+})
+class ExamplePreset extends Preset<ExampleOptions> {
+  get name() {
+    return 'example' as const;
+  }
+}
+```
+
+The preset decorator updates the static properties of the preset. If you prefer not to use decorators it can also be called as a function. The `Preset` constructor is mutated by the function call and does not need to be returned.
+
+```ts
+presetDecorator({ defaultSettings: { color: 'red' }, handlerKeys: ['onChange'] })(ExamplePreset);
+```

--- a/.changeset/witty-ducks-end.md
+++ b/.changeset/witty-ducks-end.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core': major
+'@remirror/core-constants': patch
+'@remirror/core-helpers': patch
+---
+
+Throw error in `Preset` and `Extension` when attempting to update a non-dynamic option at runtime.

--- a/docs/concepts/extension.mdx
+++ b/docs/concepts/extension.mdx
@@ -62,3 +62,166 @@ onDestroy(extensions: readonly AnyExtension[]): void
 ```
 
 This is called when the `RemirrorManager` is being destroyed.
+
+## Options
+
+Options are used to configure the extension at runtime. They come in four different flavours via the
+option annotations.
+
+```ts
+import {
+  Static,
+  Dynamic,
+  Handler,
+  CustomHandler,
+  extensionDecoration,
+  PlainExtension,
+  ExtensionPriority,
+} from 'remirror/core';
+
+interface ExampleOptions {
+  // `Static` types can only be provided at instantiation.
+  type: Static<'awesome' | 'not-awesome'>;
+
+  // Options are `Dynamic` by default.
+  color?: string;
+
+  // `Dynamic` properties can also be set with the annotation, although it's unnecessary.
+  backgroundColor?: Dynamic<string>;
+
+  // `Handlers` are used to represent event handlers.
+  onChange?: Handler<() => void>;
+
+  // `CustomHandler` options are for customised handlers and it's completely up
+  // to you to integrate them properly.
+  keyBindings: CustomHandler<Record<string, () => boolean>>;
+}
+
+@extensionDecorator<ExampleOptions>({
+  defaultOptions: { color: 'red', backgroundColor: 'green' },
+  defaultPriority: ExtensionPriority.High,
+
+  // Let's the extension know that these are the static keys
+  staticKeys: ['type'],
+
+  // Provides the keys which should be converted into handlers.
+  handlerKeys: ['onChange'],
+
+  // Provides the keys which should be created treated as custom handlers.
+  customHandlerKeys: ['keyBindings'],
+})
+class ExampleExtension extends PlainExtension<ExampleOptions> {
+  get name() {
+    return 'example' as const;
+  }
+}
+```
+
+These annotations can be used to provide better intelli-sense support for the end user.
+
+### `extensionDecorator`
+
+The extension decorator updates the static properties of the extension. If you prefer not to use
+decorators it can also be called as a function. The `Extension` constructor is mutated by the
+function call.
+
+```ts
+extensionDecorator({ defaultSettings: { color: 'red' } })(ExampleExtension);
+```
+
+### `Dynamic` options
+
+`Dynamic` options can be passed in at instantiation and also during runtime. When no annotation
+exists the option is assumed to be dynamic.
+
+```ts
+const exampleExtension = new ExampleExtension({
+  type: 'awesome',
+  color: 'blue',
+  backgroundColor: 'yellow',
+});
+
+// Runtime update
+exampleExtension.setOptions({ color: 'pink', backgroundColor: 'purple' });
+```
+
+### `Static` options
+
+`Static` options should be used when it is not possible to update an option during runtime.
+Typically this is reserved for options that affect the schema, since the schema is created at
+initialization. They will throw an error if an error if updated during runtime.
+
+```ts
+const exampleExtension = new ExampleExtension({
+  type: 'awesome',
+});
+
+// Will throw an error.
+exampleExtension.setOptions({ type: 'not-awesome' });
+```
+
+### `Handler` options
+
+`Handler` options are a pseudo option in that they are completely handled by the underlying remirror
+extension.
+
+To get them to work we would change the above example extension implentation to look like the
+following.
+
+```ts
+import { StateUpdateLifecycleParameter, hasTransactionChanged } from 'remirror/core';
+import { hasStateChanged } from 'remirror/extension-positioner';
+
+@extensionDecorator<ExampleOptions>({
+  defaultOptions: { color: 'red', backgroundColor: 'green' },
+  defaultPriority: ExtensionPriority.High,
+  staticKeys: ['type'],
+  handlerKeys: ['onChange'],
+  customHandlerKeys: ['keyBindings'],
+})
+class ExampleExtension extends PlainExtension<ExampleOptions> {
+  get name() {
+    return 'example' as const;
+  }
+
+  onTransaction(parameter: StateUpdateLifecycleParameter) {
+    const { state } = parameter;
+    const { tr, state, previousState } = parameter;
+
+    const hasChanged = tr
+      ? hasTransactionChanged(tr)
+      : !state.doc.eq(previousState.doc) || !state.selection.eq(previousState.selection);
+
+    if (!hasChanged) {
+      return;
+    }
+
+    if (state.doc.textContent.includes('example')) {
+      // Call the handler when certain text is matched
+      this.options.onChange();
+    }
+  }
+}
+```
+
+Now that the extension is wired to respond to `onChange` handlers we can add a new handler.
+
+```ts
+const exampleExtension = new ExampleExtension({
+  type: 'awesome',
+});
+
+const disposeChangeHandler = exampleExtension.addHandler('onChange', () => {
+  console.log('example was found');
+});
+
+// Later
+disposeChangeHandler();
+```
+
+The onChange handler is automatically managed for you.
+
+### `CustomHandler` options
+
+`CustomHandler` options are like `Handler` options except it's up to you to wire up the handler.
+More examples will be added later.

--- a/docs/concepts/keymap.mdx
+++ b/docs/concepts/keymap.mdx
@@ -21,17 +21,14 @@ The `next` method allows full control beyond the return value. It allows both ca
 priority key bindings regardless of whether true or false has been called.
 
 ```tsx
-import { BaseExtensionOptions, Extension, KeyBindings } from '@remirror/core';
+import { BaseExtensionOptions, Extension, KeyBindings, extensionDecorator } from '@remirror/core';
 
 interface CustomKeymapExtensionOptions {
   override?: boolean;
 }
 
+@extensionDecorator({ defaultOptions: { override: false } })
 export class CustomKeymapExtension extends Extension<CustomKeymapExtensionOptions> {
-  static readonly defaultOptions = {
-    override: false,
-  };
-
   get name() {
     return 'customKeymap' as const;
   }

--- a/docs/concepts/priority.mdx
+++ b/docs/concepts/priority.mdx
@@ -28,15 +28,16 @@ Now your customExtension will have a priority level that's higher than other ext
 run prior to other extensions.
 
 If you have full control of the extension you can also set the `defaultPriority` as a static
-property to achieve the same effect.
+property with the `extension.
 
 ```ts
-import { Extension, ExtensionPriority } from 'remirror/core';
+import { Extension, ExtensionPriority, extensionDecorator } from 'remirror/core';
 
-class CustomExtension extends Extension {
+@extensionDecorator({
   // Now every custom extension created will have a `High` priority than default.
-  static readonly defaultPriority = ExtensionPriority.High;
-
+  defaultPriority: ExtensionPriority.High,
+})
+class CustomExtension extends Extension {
   get name() {
     return 'custom' as const;
   }

--- a/docs/errors.mdx
+++ b/docs/errors.mdx
@@ -6,6 +6,8 @@ This page contains the documented errors that occur while using `remirror`. Curr
 descriptions are very short and if you'd like to contribute to make them more comprehensive, then
 that would be very much appreciated. Edit this page to get started.
 
+<br />
+
 ## Core
 
 <br />
@@ -170,6 +172,14 @@ The spec was defined without calling the `defaults`, `parse` or `dom` methods.
 
 Extra attributes must either be a string or an object.
 
+### RMR0103
+
+> Invalid Set Extension Options
+
+A call to `extension.setOptions()` was made with invalid keys.
+
+<br />
+
 ## React
 
 <br />
@@ -298,6 +308,8 @@ There is a problem with your controlled editor setup.
 > React Node View
 
 Something went wrong with your custom ReactNodeView Component.
+
+<br />
 
 ## Other
 

--- a/packages/@remirror/core-constants/src/error-constants.ts
+++ b/packages/@remirror/core-constants/src/error-constants.ts
@@ -110,6 +110,9 @@ export enum ErrorConstant {
   /** Extra attributes must either be a string or an object. */
   EXTENSION_EXTRA_ATTRIBUTES = 'RMR0102',
 
+  /** A call to `extension.setOptions` was made with invalid keys. */
+  INVALID_SET_EXTENSION_OPTIONS = 'RMR0103',
+
   /**
    * `useRemirror` was called outside of the remirror context. It can only be used
    * within an active remirror context created by the `<RemirrorProvider />`.

--- a/packages/@remirror/core-helpers/src/core-errors.ts
+++ b/packages/@remirror/core-helpers/src/core-errors.ts
@@ -55,6 +55,8 @@ if (process.env.NODE_ENV !== 'production') {
       'The spec was defined without calling the `defaults`, `parse` or `dom` methods.',
     [ErrorConstant.EXTENSION_EXTRA_ATTRIBUTES]:
       'Extra attributes must either be a string or an object.',
+    [ErrorConstant.INVALID_SET_EXTENSION_OPTIONS]:
+      'A call to `extension.setOptions` was made with invalid keys.',
     [ErrorConstant.REACT_PROVIDER_CONTEXT]:
       '`useRemirror` was called outside of the `remirror` context. It can only be used within an active remirror context created by the `<RemirrorProvider />`.',
     [ErrorConstant.REACT_GET_ROOT_PROPS]:

--- a/packages/@remirror/core-types/src/annotation-types.ts
+++ b/packages/@remirror/core-types/src/annotation-types.ts
@@ -7,6 +7,7 @@ import {
   PickPartial,
   RemoveFlavoring,
   Shape,
+  StringKey,
 } from './base-types';
 
 type StaticAnnotation = Flavoring<'StaticAnnotation'>;
@@ -216,10 +217,10 @@ export type GetConstructorParameter<Options extends ValidOptions> = GetStatic<Op
  */
 export type Dispose = () => void;
 
-export type HandlerKey<Options extends ValidOptions> = keyof GetHandler<Options>;
-export type StaticKey<Options extends ValidOptions> = keyof GetStatic<Options>;
-export type DynamicKey<Options extends ValidOptions> = keyof GetDynamic<Options>;
-export type CustomHandlerKey<Options extends ValidOptions> = keyof GetCustomHandler<Options>;
+export type HandlerKey<Options extends ValidOptions> = StringKey<GetHandler<Options>>;
+export type StaticKey<Options extends ValidOptions> = StringKey<GetStatic<Options>>;
+export type DynamicKey<Options extends ValidOptions> = StringKey<GetDynamic<Options>>;
+export type CustomHandlerKey<Options extends ValidOptions> = StringKey<GetCustomHandler<Options>>;
 export type HandlerKeyList<Options extends ValidOptions> = Array<HandlerKey<Options>>;
 export type StaticKeyList<Options extends ValidOptions> = Array<StaticKey<Options>>;
 export type DynamicKeyList<Options extends ValidOptions> = Array<DynamicKey<Options>>;

--- a/packages/@remirror/core-types/src/annotation-types.ts
+++ b/packages/@remirror/core-types/src/annotation-types.ts
@@ -91,14 +91,17 @@ export type Dynamic<Type> = Type & DynamicAnnotation;
  * to automate this.
  *
  * ```ts
- * import { PlainExtension } from 'remirror/core';
+ * import { PlainExtension, extensionDecorator } from 'remirror/core';
  * interface CustomOptions {
  *   simple: boolean; // Automatically a dynamic property
  *   onChange: Handler<(value: string) => void>;
  * }
  *
+ * @extensionDecorator({ handlerKeys: ['onChange'] })
  * class CustomExtension extends PlainExtension<CustomOptions> {
- *   static readonly handlerKeys = ['onChange'];
+ *   get name() {
+ *     return 'custom' as const;
+ *   }
  * }
  *
  * // No prompt to include the `onChange` handler due to the annotation.

--- a/packages/@remirror/core-types/src/base-types.ts
+++ b/packages/@remirror/core-types/src/base-types.ts
@@ -126,6 +126,11 @@ export type PartialWithRequiredKeys<Type extends object, Keys extends keyof Type
   Required<Pick<Type, Keys>>;
 
 /**
+ * Remove all readonly modifiers from the provided type.
+ */
+export type Writeable<Type> = { -readonly [Key in keyof Type]: Type[Key] };
+
+/**
  * Makes specified keys of an interface optional while the rest stay the same.
  */
 export type MakeOptional<Type extends object, Keys extends keyof Type> = Omit<Type, Keys> &

--- a/packages/@remirror/core/src/__tests__/decorators.spec.ts
+++ b/packages/@remirror/core/src/__tests__/decorators.spec.ts
@@ -1,0 +1,53 @@
+import { CustomHandler, Dynamic, Handler, Static } from '@remirror/core-types';
+
+import { extensionDecorator } from '..';
+import { PlainExtension } from '../extension';
+
+interface GeneralOptions {
+  type: Static<'awesome' | 'not-awesome'>;
+  color?: string;
+  backgroundColor?: Dynamic<string>;
+  onChange?: Handler<() => void>;
+  keyBindings: CustomHandler<Record<string, () => boolean>>;
+}
+
+describe('@extensionDecorator', () => {
+  it('can decorate an extension', () => {
+    @extensionDecorator<GeneralOptions>({
+      defaultOptions: { backgroundColor: 'red', color: 'pink' },
+      staticKeys: ['type'],
+      handlerKeys: ['onChange'],
+      customHandlerKeys: ['keyBindings'],
+    })
+    class TestExtension extends PlainExtension<GeneralOptions> {
+      get name() {
+        return 'test' as const;
+      }
+    }
+
+    expect(TestExtension.staticKeys).toEqual(['type']);
+    expect(TestExtension.handlerKeys).toEqual(['onChange']);
+    expect(TestExtension.customHandlerKeys).toEqual(['keyBindings']);
+    expect(TestExtension.defaultOptions).toEqual({ backgroundColor: 'red', color: 'pink' });
+  });
+
+  it('can decorate an extension as a function call', () => {
+    const TestExtension = extensionDecorator<GeneralOptions>({
+      defaultOptions: { backgroundColor: 'red', color: 'pink' },
+      staticKeys: ['type'],
+      handlerKeys: ['onChange'],
+      customHandlerKeys: ['keyBindings'],
+    })(
+      class TestExtension extends PlainExtension<GeneralOptions> {
+        get name() {
+          return 'test' as const;
+        }
+      },
+    );
+
+    expect(TestExtension.staticKeys).toEqual(['type']);
+    expect(TestExtension.handlerKeys).toEqual(['onChange']);
+    expect(TestExtension.customHandlerKeys).toEqual(['keyBindings']);
+    expect(TestExtension.defaultOptions).toEqual({ backgroundColor: 'red', color: 'pink' });
+  });
+});

--- a/packages/@remirror/core/src/__tests__/decorators.spec.ts
+++ b/packages/@remirror/core/src/__tests__/decorators.spec.ts
@@ -1,7 +1,10 @@
 import { CustomHandler, Dynamic, Handler, Static } from '@remirror/core-types';
 
 import { extensionDecorator } from '..';
+import { presetDecorator } from '../decorators';
 import { PlainExtension } from '../extension';
+import { Preset } from '../preset';
+import { OnSetOptionsParameter } from '../types';
 
 interface GeneralOptions {
   type: Static<'awesome' | 'not-awesome'>;
@@ -59,5 +62,72 @@ describe('@extensionDecorator', () => {
 
     // @ts-expect-error
     expect(() => testExtension.setOptions({ type: 'not-awesome' })).toThrowError();
+  });
+});
+
+describe('@presetDecorator', () => {
+  it('can decorate a preset', () => {
+    @presetDecorator<GeneralOptions>({
+      defaultOptions: { backgroundColor: 'red', color: 'pink' },
+      staticKeys: ['type'],
+      handlerKeys: ['onChange'],
+      customHandlerKeys: ['keyBindings'],
+    })
+    class TestPreset extends Preset<GeneralOptions> {
+      get name() {
+        return 'test' as const;
+      }
+
+      createExtensions() {
+        return [];
+      }
+
+      protected onSetOptions(_: OnSetOptionsParameter<GeneralOptions>): void {
+        return;
+      }
+    }
+
+    expect(TestPreset.staticKeys).toEqual(['type']);
+    expect(TestPreset.handlerKeys).toEqual(['onChange']);
+    expect(TestPreset.customHandlerKeys).toEqual(['keyBindings']);
+    expect(TestPreset.defaultOptions).toEqual({ backgroundColor: 'red', color: 'pink' });
+
+    const testPreset = new TestPreset({ type: 'awesome' });
+
+    // @ts-expect-error
+    expect(() => testPreset.setOptions({ type: 'not-awesome' })).toThrowError();
+  });
+
+  it('can decorate a preset as a function call', () => {
+    const TestPreset = presetDecorator<GeneralOptions>({
+      defaultOptions: { backgroundColor: 'red', color: 'pink' },
+      staticKeys: ['type'],
+      handlerKeys: ['onChange'],
+      customHandlerKeys: ['keyBindings'],
+    })(
+      class TestPreset extends Preset<GeneralOptions> {
+        get name() {
+          return 'test' as const;
+        }
+
+        createExtensions() {
+          return [];
+        }
+
+        protected onSetOptions(_: OnSetOptionsParameter<GeneralOptions>): void {
+          return;
+        }
+      },
+    );
+
+    expect(TestPreset.staticKeys).toEqual(['type']);
+    expect(TestPreset.handlerKeys).toEqual(['onChange']);
+    expect(TestPreset.customHandlerKeys).toEqual(['keyBindings']);
+    expect(TestPreset.defaultOptions).toEqual({ backgroundColor: 'red', color: 'pink' });
+
+    const testPreset = new TestPreset({ type: 'awesome' });
+
+    // @ts-expect-error
+    expect(() => testPreset.setOptions({ type: 'not-awesome' })).toThrowError();
   });
 });

--- a/packages/@remirror/core/src/__tests__/decorators.spec.ts
+++ b/packages/@remirror/core/src/__tests__/decorators.spec.ts
@@ -29,6 +29,11 @@ describe('@extensionDecorator', () => {
     expect(TestExtension.handlerKeys).toEqual(['onChange']);
     expect(TestExtension.customHandlerKeys).toEqual(['keyBindings']);
     expect(TestExtension.defaultOptions).toEqual({ backgroundColor: 'red', color: 'pink' });
+
+    const testExtension = new TestExtension({ type: 'awesome' });
+
+    // @ts-expect-error
+    expect(() => testExtension.setOptions({ type: 'not-awesome' })).toThrowError();
   });
 
   it('can decorate an extension as a function call', () => {
@@ -49,5 +54,10 @@ describe('@extensionDecorator', () => {
     expect(TestExtension.handlerKeys).toEqual(['onChange']);
     expect(TestExtension.customHandlerKeys).toEqual(['keyBindings']);
     expect(TestExtension.defaultOptions).toEqual({ backgroundColor: 'red', color: 'pink' });
+
+    const testExtension = new TestExtension({ type: 'awesome' });
+
+    // @ts-expect-error
+    expect(() => testExtension.setOptions({ type: 'not-awesome' })).toThrowError();
   });
 });

--- a/packages/@remirror/core/src/builtins/attributes-extension.ts
+++ b/packages/@remirror/core/src/builtins/attributes-extension.ts
@@ -1,4 +1,3 @@
-import { ExtensionPriority } from '@remirror/core-constants';
 import { bool, object } from '@remirror/core-helpers';
 import { AttributesWithClass } from '@remirror/core-types';
 
@@ -18,8 +17,6 @@ import { AnyCombinedUnion } from '../preset';
  * @builtin
  */
 export class AttributesExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Default;
-
   get name() {
     return 'attributes' as const;
   }

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -12,6 +12,7 @@ import {
 } from '@remirror/core-types';
 import { EditorView } from '@remirror/pm/view';
 
+import { extensionDecorator } from '../decorators';
 import {
   AnyExtension,
   ChainedCommandRunParameter,
@@ -39,9 +40,8 @@ import {
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.Highest })
 export class CommandsExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Highest;
-
   get name() {
     return 'commands' as const;
   }

--- a/packages/@remirror/core/src/builtins/helpers-extension.ts
+++ b/packages/@remirror/core/src/builtins/helpers-extension.ts
@@ -3,6 +3,7 @@ import { entries, invariant, object } from '@remirror/core-helpers';
 import { AnyFunction, EmptyShape, ProsemirrorAttributes } from '@remirror/core-types';
 import { isMarkActive, isNodeActive } from '@remirror/core-utils';
 
+import { extensionDecorator } from '../decorators';
 import {
   AnyExtension,
   HelpersFromExtensions,
@@ -27,9 +28,8 @@ import { ExtensionHelperReturn } from '../types';
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.High })
 export class HelpersExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.High;
-
   get name() {
     return 'helpers' as const;
   }

--- a/packages/@remirror/core/src/builtins/input-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/input-rules-extension.ts
@@ -2,6 +2,7 @@ import { ExtensionPriority } from '@remirror/core-constants';
 import { InputRule, inputRules } from '@remirror/pm/inputrules';
 import { Plugin } from '@remirror/pm/state';
 
+import { extensionDecorator } from '../decorators';
 import { PlainExtension } from '../extension';
 
 /**
@@ -15,9 +16,8 @@ import { PlainExtension } from '../extension';
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.High })
 export class InputRulesExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.High;
-
   get name() {
     return 'inputRules' as const;
   }

--- a/packages/@remirror/core/src/builtins/keymap-extension.ts
+++ b/packages/@remirror/core/src/builtins/keymap-extension.ts
@@ -3,6 +3,7 @@ import { KeyBindings, ProsemirrorPlugin } from '@remirror/core-types';
 import { mergeProsemirrorKeyBindings } from '@remirror/core-utils';
 import { keymap } from '@remirror/pm/keymap';
 
+import { extensionDecorator } from '../decorators';
 import { PlainExtension } from '../extension';
 
 /**
@@ -15,9 +16,8 @@ import { PlainExtension } from '../extension';
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.Low })
 export class KeymapExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Low;
-
   get name() {
     return 'keymap' as const;
   }

--- a/packages/@remirror/core/src/builtins/node-views-extension.ts
+++ b/packages/@remirror/core/src/builtins/node-views-extension.ts
@@ -1,4 +1,3 @@
-import { ExtensionPriority } from '@remirror/core-constants';
 import { isFunction, object } from '@remirror/core-helpers';
 import { NodeViewMethod } from '@remirror/core-types';
 
@@ -17,8 +16,6 @@ import { AnyCombinedUnion } from '../preset';
  * @builtin
  */
 export class NodeViewsExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Default;
-
   get name() {
     return 'nodeView' as const;
   }

--- a/packages/@remirror/core/src/builtins/paste-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/paste-rules-extension.ts
@@ -1,4 +1,3 @@
-import { ExtensionPriority } from '@remirror/core-constants';
 import { ProsemirrorPlugin } from '@remirror/core-types';
 
 import { PlainExtension } from '../extension';
@@ -11,8 +10,6 @@ import { PlainExtension } from '../extension';
  * @builtin
  */
 export class PasteRulesExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Default;
-
   get name() {
     return 'pasteRules' as const;
   }

--- a/packages/@remirror/core/src/builtins/plugins-extension.ts
+++ b/packages/@remirror/core/src/builtins/plugins-extension.ts
@@ -4,6 +4,7 @@ import { ProsemirrorPlugin } from '@remirror/core-types';
 import { getPluginState } from '@remirror/core-utils';
 import { EditorState, Plugin, PluginKey } from '@remirror/pm/state';
 
+import { extensionDecorator } from '../decorators';
 import { AnyExtension, AnyExtensionConstructor, PlainExtension } from '../extension';
 import { AnyCombinedUnion, InferCombinedExtensions } from '../preset';
 import { CreatePluginReturn, GetNameUnion } from '../types';
@@ -19,9 +20,8 @@ import { CreatePluginReturn, GetNameUnion } from '../types';
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.Highest })
 export class PluginsExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Highest;
-
   get name() {
     return 'plugins' as const;
   }

--- a/packages/@remirror/core/src/builtins/schema-extension.ts
+++ b/packages/@remirror/core/src/builtins/schema-extension.ts
@@ -518,5 +518,14 @@ declare global {
        */
       schema: EditorSchema;
     }
+
+    interface StaticExtensionOptions {
+      /**
+       * When true will disable extra attributes for all instances of this extension.
+       *
+       * @defaultValue `false`
+       */
+      readonly disableExtraAttributes?: boolean;
+    }
   }
 }

--- a/packages/@remirror/core/src/builtins/schema-extension.ts
+++ b/packages/@remirror/core/src/builtins/schema-extension.ts
@@ -24,6 +24,7 @@ import {
 import { isElementDomNode, isProsemirrorMark, isProsemirrorNode } from '@remirror/core-utils';
 import { Schema } from '@remirror/pm/model';
 
+import { extensionDecorator } from '../decorators';
 import {
   AnyExtension,
   GetMarkNameUnion,
@@ -41,12 +42,8 @@ import { AnyCombinedUnion, InferCombinedExtensions } from '../preset';
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.Highest })
 export class SchemaExtension extends PlainExtension {
-  /**
-   * Really this always needs to be the first extension to run.
-   */
-  static defaultPriority: ExtensionPriority = ExtensionPriority.Highest;
-
   get name() {
     return 'schema' as const;
   }

--- a/packages/@remirror/core/src/builtins/suggestions-extension.ts
+++ b/packages/@remirror/core/src/builtins/suggestions-extension.ts
@@ -1,4 +1,3 @@
-import { ExtensionPriority } from '@remirror/core-constants';
 import { isArray } from '@remirror/core-helpers';
 import { suggest, Suggestion } from '@remirror/pm/suggest';
 
@@ -16,8 +15,6 @@ import { PlainExtension } from '../extension';
  * @builtin
  */
 export class SuggestionsExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Default;
-
   get name() {
     return 'suggestions' as const;
   }

--- a/packages/@remirror/core/src/builtins/tags-extension.ts
+++ b/packages/@remirror/core/src/builtins/tags-extension.ts
@@ -1,6 +1,7 @@
 import { ExtensionPriority, ExtensionTag, MarkGroup, NodeGroup } from '@remirror/core-constants';
 import { isUndefined, object } from '@remirror/core-helpers';
 
+import { extensionDecorator } from '../decorators';
 import {
   AnyExtension,
   ExtensionTags,
@@ -17,9 +18,8 @@ import { GeneralExtensionTags, MarkExtensionTags, NodeExtensionTags } from '../t
  *
  * @builtin
  */
+@extensionDecorator({ defaultPriority: ExtensionPriority.Highest })
 export class TagsExtension extends PlainExtension {
-  static readonly defaultPriority = ExtensionPriority.Highest;
-
   get name() {
     return 'tags' as const;
   }

--- a/packages/@remirror/core/src/decorators.ts
+++ b/packages/@remirror/core/src/decorators.ts
@@ -1,0 +1,128 @@
+import { ExtensionPriority } from '@remirror/core-constants';
+import { Cast, entries } from '@remirror/core-helpers';
+import {
+  CustomHandlerKeyList,
+  EmptyShape,
+  GetCustomHandler,
+  GetHandler,
+  GetStatic,
+  HandlerKeyList,
+  IfEmpty,
+  IfHasRequiredProperties,
+  Shape,
+  StaticKeyList,
+  Writeable,
+} from '@remirror/core-types';
+
+import {
+  AnyExtensionConstructor,
+  DefaultExtensionOptions,
+  ExtensionConstructor,
+} from './extension';
+
+interface DefaultOptionsParameter<Options extends Shape = EmptyShape> {
+  /**
+   * The default options.
+   *
+   * All non required options must have a default value provided.
+   *
+   * @defaultValue `{}`
+   */
+  defaultOptions: DefaultExtensionOptions<Options>;
+
+  /**
+   * The default priority for this extension.
+   *
+   * @defaultValue `{}`
+   */
+  defaultPriority?: ExtensionPriority;
+}
+
+interface StaticKeysParameter<Options extends Shape = EmptyShape> {
+  /**
+   * The list of all keys which are static and can only be set at the start.
+   */
+  staticKeys: StaticKeyList<Options>;
+}
+
+interface HandlerKeysParameter<Options extends Shape = EmptyShape> {
+  /**
+   * The list of all keys which are event handlers.
+   */
+  handlerKeys: HandlerKeyList<Options>;
+}
+
+interface CustomHandlerKeysParameter<Options extends Shape = EmptyShape> {
+  customHandlerKeys: CustomHandlerKeyList<Options>;
+}
+
+export type ExtensionDecoratorOptions<Options extends Shape = EmptyShape> = IfHasRequiredProperties<
+  DefaultExtensionOptions<Options>,
+  DefaultOptionsParameter<Options>,
+  Partial<DefaultOptionsParameter<Options>>
+> &
+  IfEmpty<GetStatic<Options>, Partial<StaticKeysParameter<Options>>, StaticKeysParameter<Options>> &
+  IfEmpty<
+    GetHandler<Options>,
+    Partial<HandlerKeysParameter<Options>>,
+    HandlerKeysParameter<Options>
+  > &
+  IfEmpty<
+    GetCustomHandler<Options>,
+    Partial<CustomHandlerKeysParameter<Options>>,
+    CustomHandlerKeysParameter<Options>
+  > &
+  Partial<Remirror.StaticExtensionOptions> & { defaultPriority?: ExtensionPriority };
+
+/**
+ * A decorator for the remirror extension.
+ *
+ * This adds the static properties required for the running of the app.
+ */
+export function extensionDecorator<Options extends Shape = EmptyShape>(
+  options: ExtensionDecoratorOptions<Options>,
+) {
+  return <Type extends AnyExtensionConstructor>(ReadonlyConstructor: Type) => {
+    const {
+      defaultOptions,
+      customHandlerKeys,
+      handlerKeys,
+      staticKeys,
+      defaultPriority,
+      ...rest
+    } = options;
+
+    const Constructor = Cast<Writeable<ExtensionConstructor<Options>> & Shape>(ReadonlyConstructor);
+
+    if (defaultOptions) {
+      Constructor.defaultOptions = defaultOptions;
+    }
+
+    if (defaultPriority) {
+      Constructor.defaultPriority = defaultPriority;
+    }
+
+    Constructor.staticKeys = staticKeys ?? [];
+    Constructor.handlerKeys = handlerKeys ?? [];
+    Constructor.customHandlerKeys = customHandlerKeys ?? [];
+
+    for (const [key, value] of entries(rest as Shape)) {
+      if (Constructor[key]) {
+        continue;
+      }
+
+      Constructor[key] = value;
+    }
+
+    return Cast<Type>(Constructor);
+  };
+}
+
+declare global {
+  namespace Remirror {
+    /**
+     * An interface for declaring static options for the extension.
+     */
+    interface StaticExtensionOptions {}
+  }
+}

--- a/packages/@remirror/core/src/extension/base-class.ts
+++ b/packages/@remirror/core/src/extension/base-class.ts
@@ -51,8 +51,10 @@ export abstract class BaseClass<
 > {
   /**
    * The default options for this extension.
+   *
+   * TODO see if this can be cast to something other than any and allow composition.
    */
-  static readonly defaultOptions = {};
+  static readonly defaultOptions: any = {};
 
   /**
    * The static keys for this class.

--- a/packages/@remirror/core/src/extension/extension-base.ts
+++ b/packages/@remirror/core/src/extension/extension-base.ts
@@ -631,8 +631,9 @@ export function isMarkExtension<Type extends AnyMarkExtension = AnyMarkExtension
   return isRemirrorType(value) && isIdentifierOfType(value, RemirrorIdentifier.MarkExtension);
 }
 
-interface ExtensionConstructor<Options extends ValidOptions = EmptyShape>
-  extends BaseClassConstructor<Options, BaseExtensionOptions> {
+export interface ExtensionConstructor<Options extends ValidOptions = EmptyShape>
+  extends BaseClassConstructor<Options, BaseExtensionOptions>,
+    Partial<Remirror.StaticExtensionOptions> {
   new (...parameters: ExtensionConstructorParameter<Options>): Extension<Options>;
 
   /**
@@ -641,13 +642,6 @@ interface ExtensionConstructor<Options extends ValidOptions = EmptyShape>
    * @defaultValue `ExtensionPriority.Default`
    */
   readonly defaultPriority: ExtensionPriority;
-
-  /**
-   * When true will disable extra attributes for all instances of this extension.
-   *
-   * @defaultValue `false`
-   */
-  readonly disableExtraAttributes?: boolean;
 }
 
 /**

--- a/packages/@remirror/core/src/extension/extension-base.ts
+++ b/packages/@remirror/core/src/extension/extension-base.ts
@@ -279,7 +279,7 @@ interface ExtensionLifecycleMethods {
    * Since it is called as soon as the manager is some methods may not be
    * available in the extension store. When accessing methods on `this.store` be
    * shore to check when they become available in the lifecycle. It is
-   * recommende that you don't use this method unless absolutely required.
+   * recommended that you don't use this method unless absolutely required.
    */
   onCreate?(): void;
 

--- a/packages/@remirror/core/src/index.ts
+++ b/packages/@remirror/core/src/index.ts
@@ -16,8 +16,8 @@ export * from './types';
 // TODO move to a new package.
 export * from './commands';
 
-export { extensionDecorator } from './decorators';
-export type { ExtensionDecoratorOptions } from './decorators';
+export { extensionDecorator, presetDecorator } from './decorators';
+export type { ExtensionDecoratorOptions, PresetDecoratorOptions } from './decorators';
 
 export type {
   BaseClass,

--- a/packages/@remirror/core/src/index.ts
+++ b/packages/@remirror/core/src/index.ts
@@ -16,6 +16,9 @@ export * from './types';
 // TODO move to a new package.
 export * from './commands';
 
+export { extensionDecorator } from './decorators';
+export type { ExtensionDecoratorOptions } from './decorators';
+
 export type {
   BaseClass,
   BaseClassConstructor,

--- a/packages/@remirror/extension-auto-link/src/auto-link-extension.ts
+++ b/packages/@remirror/extension-auto-link/src/auto-link-extension.ts
@@ -2,16 +2,15 @@ import {
   ApplySchemaAttributes,
   Cast,
   CreatePluginReturn,
-  DefaultExtensionOptions,
   EditorState,
   EditorStateParameter,
   EditorView,
+  extensionDecorator,
   ExtensionPriority,
   findMatches,
   FromToParameter,
   getMatchString,
   Handler,
-  HandlerKeyList,
   LEAF_NODE_REPLACING_CHARACTER,
   Mark,
   markEqualsType,
@@ -30,16 +29,18 @@ import { ReplaceStep } from '@remirror/pm/transform';
  * An auto complete auto decorated linker. This is more aggressive than the
  * `@remirror/extension-link` in that it wraps any url like string as a mark.
  *
- * It's inspired by the behavior of several social sites like `twitter`.
+ * It's inspired by the behavior of social sites like `twitter`.
  */
-export class AutoLinkExtension extends MarkExtension<AutoLinkOptions> {
-  static readonly defaultPriority = ExtensionPriority.Low;
-  static readonly defaultOptions: DefaultExtensionOptions<AutoLinkOptions> = {
+@extensionDecorator<AutoLinkOptions>({
+  defaultOptions: {
     urlRegex: /((http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/.*)?)/gi,
     defaultProtocol: '',
-  };
-  static readonly handlerKeys: HandlerKeyList<AutoLinkOptions> = ['onUrlUpdate'];
-
+  },
+  defaultPriority: ExtensionPriority.Low,
+  handlerKeys: ['onUrlUpdate'],
+  staticKeys: ['urlRegex'],
+})
+export class AutoLinkExtension extends MarkExtension<AutoLinkOptions> {
   get name() {
     return 'autoLink' as const;
   }

--- a/packages/@remirror/extension-bidi/src/bidi-extension.ts
+++ b/packages/@remirror/extension-bidi/src/bidi-extension.ts
@@ -4,7 +4,7 @@ import {
   AttributesWithClass,
   bool,
   CreatePluginReturn,
-  DefaultExtensionOptions,
+  extensionDecorator,
   findParentNode,
   hasTransactionChanged,
   IdentifierSchemaAttributes,
@@ -37,20 +37,21 @@ export interface BidiOptions {
 }
 
 /**
- * An extension which adds bidirectional text support to your editor.
+ * An extension which adds bi-directional text support to your editor.
  */
+@extensionDecorator<BidiOptions>({
+  defaultOptions: { defaultDirection: null, autoUpdate: true, excludeNodes: [] },
+  staticKeys: ['excludeNodes'],
+})
 export class BidiExtension extends PlainExtension<BidiOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<BidiOptions> = {
-    defaultDirection: null,
-    autoUpdate: true,
-    excludeNodes: [],
-  };
-
-  #ignoreNextUpdate = false;
-
   get name() {
     return 'bidi' as const;
   }
+
+  /**
+   * Whether to ignore next updated.
+   */
+  #ignoreNextUpdate = false;
 
   /**
    * Add the bidi property to the editor attributes.
@@ -66,7 +67,7 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
   }
 
   /**
-   * Add the dir to all the node types.
+   * Add the `dir` to all the node types.
    */
   createSchemaAttributes = (): IdentifierSchemaAttributes[] => {
     const identifiers = this.store.nodeNames.filter(

--- a/packages/@remirror/extension-blockquote/src/blockquote-extension.ts
+++ b/packages/@remirror/extension-blockquote/src/blockquote-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   CommandFunction,
+  extensionDecorator,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
@@ -9,6 +10,10 @@ import {
 } from '@remirror/core';
 import { wrappingInputRule } from '@remirror/pm/inputrules';
 
+/**
+ * Adds a blockquote to the editor.
+ */
+@extensionDecorator({})
 export class BlockquoteExtension extends NodeExtension {
   get name() {
     return 'blockquote' as const;

--- a/packages/@remirror/extension-bold/src/bold-extension.ts
+++ b/packages/@remirror/extension-bold/src/bold-extension.ts
@@ -3,7 +3,7 @@ import { FontWeightProperty } from 'csstype';
 import {
   ApplySchemaAttributes,
   CommandFunction,
-  DefaultExtensionOptions,
+  extensionDecorator,
   ExtensionTag,
   FromToParameter,
   InputRule,
@@ -28,11 +28,11 @@ export interface BoldOptions {
  * When added to your editor it will provide the `bold` command which makes the text under the cursor /
  * or at the provided position range bold.
  */
+@extensionDecorator<BoldOptions>({
+  defaultOptions: { weight: undefined },
+  staticKeys: ['weight'],
+})
 export class BoldExtension extends MarkExtension<BoldOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<BoldOptions> = {
-    weight: undefined,
-  };
-
   get name() {
     return 'bold' as const;
   }

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -4,7 +4,7 @@ import {
   ApplySchemaAttributes,
   convertCommand,
   CreatePluginReturn,
-  DefaultExtensionOptions,
+  extensionDecorator,
   findNodeAtSelection,
   findParentNodeOfType,
   GetAttributes,
@@ -39,8 +39,8 @@ import {
   updateNodeAttributes,
 } from './code-block-utils';
 
-export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<CodeBlockOptions> = {
+@extensionDecorator<CodeBlockOptions>({
+  defaultOptions: {
     supportedLanguages: [],
     keyboardShortcut: mod('ShiftAlt', 'f'),
     toggleName: 'paragraph',
@@ -48,8 +48,9 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
     formatter: () => undefined,
     syntaxTheme: 'atomDark',
     defaultLanguage: 'markup',
-  };
-
+  },
+})
+export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
   get name() {
     return 'codeBlock' as const;
   }

--- a/packages/@remirror/extension-code/src/code-extension.ts
+++ b/packages/@remirror/extension-code/src/code-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
+  extensionDecorator,
   KeyBindings,
   LEAF_NODE_REPLACING_CHARACTER,
   MarkExtension,
@@ -11,6 +12,10 @@ import {
 } from '@remirror/core';
 import { toggleMark } from '@remirror/pm/commands';
 
+/**
+ * Add a `code` mark to the editor. This is used to mark inline text as a code snippet.
+ */
+@extensionDecorator({})
 export class CodeExtension extends MarkExtension {
   get name() {
     return 'code' as const;

--- a/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -3,9 +3,9 @@ import { collab, getVersion, receiveTransaction, sendableSteps } from 'prosemirr
 import {
   CommandFunction,
   debounce,
-  DefaultExtensionOptions,
   EditorSchema,
   EditorState,
+  extensionDecorator,
   Handler,
   HandlerKeyList,
   invariant,
@@ -26,13 +26,16 @@ import { Step } from '@remirror/pm/transform';
  *
  * Once a central server is created the collaboration extension is good.
  */
-export class CollaborationExtension extends PlainExtension<CollaborationOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<CollaborationOptions> = {
+@extensionDecorator<CollaborationOptions>({
+  defaultOptions: {
     version: 0,
     clientID: uniqueId(),
     debounceMs: 250,
-  };
-
+  },
+  staticKeys: ['clientID', 'debounceMs', 'version'],
+  handlerKeys: ['onSendableReceived'],
+})
+export class CollaborationExtension extends PlainExtension<CollaborationOptions> {
   static readonly handlerKeys: HandlerKeyList<CollaborationOptions> = ['onSendableReceived'];
 
   get name() {

--- a/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
+++ b/packages/@remirror/extension-collaboration/src/collaboration-extension.ts
@@ -7,7 +7,6 @@ import {
   EditorState,
   extensionDecorator,
   Handler,
-  HandlerKeyList,
   invariant,
   isArray,
   isNumber,
@@ -36,8 +35,6 @@ import { Step } from '@remirror/pm/transform';
   handlerKeys: ['onSendableReceived'],
 })
 export class CollaborationExtension extends PlainExtension<CollaborationOptions> {
-  static readonly handlerKeys: HandlerKeyList<CollaborationOptions> = ['onSendableReceived'];
-
   get name() {
     return 'collaboration';
   }

--- a/packages/@remirror/extension-diff/src/diff-extension.ts
+++ b/packages/@remirror/extension-diff/src/diff-extension.ts
@@ -1,12 +1,11 @@
 import {
   CommandFunction,
   CreatePluginReturn,
-  DefaultExtensionOptions,
   EditorState,
   EditorView,
+  extensionDecorator,
   FromToParameter,
   Handler,
-  HandlerKeyList,
   hasTransactionChanged,
   isDomNode,
   isEmptyArray,
@@ -15,7 +14,6 @@ import {
   isString,
   PlainExtension,
   Static,
-  StaticKeyList,
   Transaction,
 } from '@remirror/core';
 import { Mapping, StepMap } from '@remirror/pm/transform';
@@ -63,20 +61,15 @@ export interface DiffOptions {
 /**
  * An extension for the remirror editor. CHANGE ME.
  */
-export class DiffExtension extends PlainExtension<DiffOptions> {
-  static readonly staticKeys: StaticKeyList<DiffOptions> = ['blameMarkerClass'];
-  static readonly handlerKeys: HandlerKeyList<DiffOptions> = [
-    'onMouseOverCommit',
-    'onMouseLeaveCommit',
-    'onSelectCommits',
-    'onDeselectCommits',
-  ];
-
-  static readonly defaultOptions: DefaultExtensionOptions<DiffOptions> = {
+@extensionDecorator<DiffOptions>({
+  defaultOptions: {
     blameMarkerClass: 'blame-marker',
     revertMessage: (message: string) => `Revert: '${message}'`,
-  };
-
+  },
+  staticKeys: ['blameMarkerClass'],
+  handlerKeys: ['onMouseOverCommit', 'onMouseLeaveCommit', 'onSelectCommits', 'onDeselectCommits'],
+})
+export class DiffExtension extends PlainExtension<DiffOptions> {
   get name() {
     return 'diff' as const;
   }

--- a/packages/@remirror/extension-doc/src/doc-extension.ts
+++ b/packages/@remirror/extension-doc/src/doc-extension.ts
@@ -58,12 +58,9 @@ export interface DocOptions {
   },
   defaultPriority: ExtensionPriority.Medium,
   staticKeys: ['content'],
+  disableExtraAttributes: true,
 })
 export class DocExtension extends NodeExtension<DocOptions> {
-  static readonly defaultPriority = ExtensionPriority.Medium;
-
-  static readonly disableExtraAttributes = true;
-
   get name() {
     return 'doc' as const;
   }

--- a/packages/@remirror/extension-doc/src/doc-extension.ts
+++ b/packages/@remirror/extension-doc/src/doc-extension.ts
@@ -1,6 +1,6 @@
 import {
   ApplySchemaAttributes,
-  DefaultExtensionOptions,
+  extensionDecorator,
   ExtensionPriority,
   NodeExtension,
   Static,
@@ -52,10 +52,14 @@ export interface DocOptions {
  * @required
  * @core
  */
-export class DocExtension extends NodeExtension<DocOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<DocOptions> = {
+@extensionDecorator<DocOptions>({
+  defaultOptions: {
     content: 'block+',
-  };
+  },
+  defaultPriority: ExtensionPriority.Medium,
+  staticKeys: ['content'],
+})
+export class DocExtension extends NodeExtension<DocOptions> {
   static readonly defaultPriority = ExtensionPriority.Medium;
 
   static readonly disableExtraAttributes = true;

--- a/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
+++ b/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
@@ -1,8 +1,8 @@
 import {
   bool,
   CreatePluginReturn,
-  DefaultExtensionOptions,
   EditorView,
+  extensionDecorator,
   findPositionOfNodeAfter,
   findPositionOfNodeBefore,
   Handler,
@@ -121,8 +121,8 @@ export interface DropCursorOptions {
  * A drop cursor plugin which adds a decoration at the active drop location. The
  * decoration has a class and can be styled however you want.
  */
-export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
-  static defaultOptions: DefaultExtensionOptions<DropCursorOptions> = {
+@extensionDecorator<DropCursorOptions>({
+  defaultOptions: {
     inlineWidth: '2px',
     inlineSpacing: '10px',
     blockWidth: '100%',
@@ -134,10 +134,10 @@ export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
     inlineClassName: 'remirror-drop-cursor-inline',
     beforeInlineClassName: 'remirror-drop-cursor-before-inline',
     afterInlineClassName: 'remirror-drop-cursor-after-inline',
-  };
-
-  static readonly handlerKeys = ['onInit', 'onDestroy'];
-
+  },
+  handlerKeys: ['onInit', 'onDestroy'],
+})
+export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
   get name() {
     return 'dropCursor' as const;
   }

--- a/packages/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/packages/@remirror/extension-emoji/src/emoji-extension.ts
@@ -3,11 +3,9 @@ import escapeStringRegex from 'escape-string-regexp';
 import {
   AddCustomHandler,
   CommandFunction,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
   ErrorConstant,
+  extensionDecorator,
   FromToParameter,
-  HandlerKeyList,
   invariant,
   object,
   PlainExtension,
@@ -32,16 +30,16 @@ import {
   sortEmojiMatches,
 } from './emoji-utils';
 
-export class EmojiExtension extends PlainExtension<EmojiOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<EmojiOptions> = {
+@extensionDecorator<EmojiOptions>({
+  defaultOptions: {
     defaultEmoji: DEFAULT_FREQUENTLY_USED,
     suggestionCharacter: ':',
     maxResults: 20,
-  };
-
-  static readonly customHandlerKeys: CustomHandlerKeyList<EmojiOptions> = ['keyBindings'];
-  static readonly handlerKeys: HandlerKeyList<EmojiOptions> = ['onChange', 'onExit'];
-
+  },
+  handlerKeys: ['onChange', 'onExit'],
+  customHandlerKeys: ['keyBindings'],
+})
+export class EmojiExtension extends PlainExtension<EmojiOptions> {
   /**
    * The name is dynamically generated based on the passed in type.
    */

--- a/packages/@remirror/extension-epic-mode/src/epic-mode-extension.ts
+++ b/packages/@remirror/extension-epic-mode/src/epic-mode-extension.ts
@@ -1,7 +1,7 @@
 import {
   CreatePluginReturn,
-  DefaultExtensionOptions,
   EditorView,
+  extensionDecorator,
   PlainExtension,
   randomInt,
   throttle,
@@ -10,9 +10,8 @@ import {
 import { defaultEffect, PARTICLE_NUM_RANGE, VIBRANT_COLORS } from './epic-mode-effects';
 import { EpicModeOptions, Particle } from './epic-mode-types';
 
-export class EpicModeExtension extends PlainExtension<EpicModeOptions> {
-  //
-  static readonly defaultOptions: DefaultExtensionOptions<EpicModeOptions> = {
+@extensionDecorator<EpicModeOptions>({
+  defaultOptions: {
     particleEffect: defaultEffect,
     getCanvasContainer: () => document.body,
     colors: VIBRANT_COLORS,
@@ -20,8 +19,9 @@ export class EpicModeExtension extends PlainExtension<EpicModeOptions> {
     active: true,
     shakeTime: 0.3,
     shakeIntensity: 5,
-  };
-
+  },
+})
+export class EpicModeExtension extends PlainExtension<EpicModeOptions> {
   get name() {
     return 'epicMode' as const;
   }

--- a/packages/@remirror/extension-gap-cursor/src/gap-cursor-extension.ts
+++ b/packages/@remirror/extension-gap-cursor/src/gap-cursor-extension.ts
@@ -1,4 +1,4 @@
-import { isInstanceOf, PlainExtension } from '@remirror/core';
+import { extensionDecorator, isInstanceOf, PlainExtension } from '@remirror/core';
 import { GapCursor, gapCursor } from '@remirror/pm/gapcursor';
 
 /**
@@ -17,6 +17,7 @@ import { GapCursor, gapCursor } from '@remirror/pm/gapcursor';
  * import '@remirror/styles/extension-gap-cursor.css';
  * ```
  */
+@extensionDecorator({})
 export class GapCursorExtension extends PlainExtension {
   get name() {
     return 'gapCursor' as const;

--- a/packages/@remirror/extension-hard-break/src/hard-break-extension.ts
+++ b/packages/@remirror/extension-hard-break/src/hard-break-extension.ts
@@ -2,12 +2,14 @@ import {
   ApplySchemaAttributes,
   chainCommands,
   convertCommand,
+  extensionDecorator,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
 } from '@remirror/core';
 import { exitCode } from '@remirror/pm/commands';
 
+@extensionDecorator({})
 export class HardBreakExtension extends NodeExtension {
   get name() {
     return 'hardBreak' as const;

--- a/packages/@remirror/extension-heading/src/heading-extension.ts
+++ b/packages/@remirror/extension-heading/src/heading-extension.ts
@@ -1,9 +1,7 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
-  HandlerKeyList,
+  extensionDecorator,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
@@ -12,7 +10,6 @@ import {
   ProsemirrorAttributes,
   ProsemirrorNode,
   Static,
-  StaticKeyList,
   toggleBlockItem,
 } from '@remirror/core';
 import { setBlockType } from '@remirror/pm/commands';
@@ -43,16 +40,14 @@ export type HeadingExtensionAttributes = ProsemirrorAttributes<{
 
 export interface HeadingOptions {}
 
-export class HeadingExtension extends NodeExtension<HeadingOptions> {
-  static readonly staticKeys: StaticKeyList<HeadingOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<HeadingOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<HeadingOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<HeadingOptions> = {
+@extensionDecorator<HeadingOptions>({
+  defaultOptions: {
     levels: [1, 2, 3, 4, 5, 6],
     defaultLevel: 1,
-  };
-
+  },
+  staticKeys: ['defaultLevel', 'levels'],
+})
+export class HeadingExtension extends NodeExtension<HeadingOptions> {
   get name() {
     return 'heading' as const;
   }

--- a/packages/@remirror/extension-history/src/history-extension.ts
+++ b/packages/@remirror/extension-history/src/history-extension.ts
@@ -1,17 +1,15 @@
 import {
   CommandFunction,
-  DefaultExtensionOptions,
   DispatchFunction,
   EditorState,
   environment,
+  extensionDecorator,
   Handler,
-  HandlerKeyList,
   isFunction,
   KeyBindings,
   PlainExtension,
   ProsemirrorCommandFunction,
   Static,
-  StaticKeyList,
 } from '@remirror/core';
 import { history, redo, undo } from '@remirror/pm/history';
 
@@ -75,17 +73,17 @@ export interface HistoryOptions {
  *
  * @builtin
  */
-export class HistoryExtension extends PlainExtension<HistoryOptions> {
-  static readonly staticKeys: StaticKeyList<HistoryOptions> = ['depth', 'newGroupDelay'];
-  static readonly handlerKeys: HandlerKeyList<HistoryOptions> = ['onRedo', 'onUndo'];
-
-  static readonly defaultOptions: DefaultExtensionOptions<HistoryOptions> = {
+@extensionDecorator<HistoryOptions>({
+  defaultOptions: {
     depth: 100,
     newGroupDelay: 500,
     getDispatch: null,
     getState: null,
-  };
-
+  },
+  staticKeys: ['depth', 'newGroupDelay'],
+  handlerKeys: ['onRedo', 'onUndo'],
+})
+export class HistoryExtension extends PlainExtension<HistoryOptions> {
   get name() {
     return 'history' as const;
   }

--- a/packages/@remirror/extension-horizontal-rule/src/horizontal-rule-extension.ts
+++ b/packages/@remirror/extension-horizontal-rule/src/horizontal-rule-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   CommandFunction,
+  extensionDecorator,
   InputRule,
   NodeExtension,
   NodeExtensionSpec,
@@ -11,6 +12,7 @@ import {
 /**
  * An extension for the remirror editor. CHANGE ME.
  */
+@extensionDecorator({})
 export class HorizontalRuleExtension extends NodeExtension {
   get name() {
     return 'horizontalRule' as const;

--- a/packages/@remirror/extension-image/src/image-extension.ts
+++ b/packages/@remirror/extension-image/src/image-extension.ts
@@ -6,6 +6,7 @@ import {
   CreatePluginReturn,
   CSS_ROTATE_PATTERN,
   EMPTY_CSS_VALUE,
+  extensionDecorator,
   isElementDomNode,
   NodeExtension,
   NodeExtensionSpec,
@@ -20,6 +21,7 @@ import { ResolvedPos } from '@remirror/pm/model';
  * - Captions https://glitch.com/edit/#!/pet-figcaption?path=index.js%3A27%3A1 into a preset
  * - Resizable https://glitch.com/edit/#!/toothsome-shoemaker?path=index.js%3A1%3A0
  */
+@extensionDecorator({})
 export class ImageExtension extends NodeExtension {
   get name() {
     return 'image' as const;

--- a/packages/@remirror/extension-italic/src/italic-extension.ts
+++ b/packages/@remirror/extension-italic/src/italic-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
+  extensionDecorator,
   KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
@@ -10,6 +11,7 @@ import {
 } from '@remirror/core';
 import { toggleMark } from '@remirror/pm/commands';
 
+@extensionDecorator({})
 export class ItalicExtension extends MarkExtension {
   get name() {
     return 'italic' as const;

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -2,11 +2,11 @@ import {
   ApplySchemaAttributes,
   CommandFunction,
   CreatePluginReturn,
+  extensionDecorator,
   getMarkRange,
   getMatchString,
   getSelectedWord,
   Handler,
-  HandlerKeyList,
   isMarkActive,
   isSelectionEmpty,
   isTextSelection,
@@ -30,9 +30,10 @@ export interface LinkOptions {
 
 export type LinkExtensionCommands = 'updateLink' | 'removeLink';
 
+@extensionDecorator<LinkOptions>({
+  handlerKeys: ['onActivateLink'],
+})
 export class LinkExtension extends MarkExtension<LinkOptions> {
-  static readonly handlerKeys: HandlerKeyList<LinkOptions> = ['onActivateLink'];
-
   get name() {
     return 'link' as const;
   }

--- a/packages/@remirror/extension-mention/src/mention-extension.ts
+++ b/packages/@remirror/extension-mention/src/mention-extension.ts
@@ -2,12 +2,10 @@ import {
   AddCustomHandler,
   ApplySchemaAttributes,
   CommandFunction,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
   ErrorConstant,
+  extensionDecorator,
   getMarkRange,
   getMatchString,
-  HandlerKeyList,
   invariant,
   isElementDomNode,
   isMarkActive,
@@ -20,7 +18,6 @@ import {
   RangeParameter,
   removeMark,
   replaceText,
-  StaticKeyList,
 } from '@remirror/core';
 import {
   escapeChar,
@@ -69,22 +66,19 @@ import {
  * remirror I'm hoping to reduce the cognitive strain required to set up
  * mentions in your own editor.
  */
-export class MentionExtension extends MarkExtension<MentionOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<MentionOptions> = {
+@extensionDecorator<MentionOptions>({
+  defaultOptions: {
     mentionTag: 'a' as const,
     matchers: [],
     appendText: ' ',
     suggestTag: 'a' as const,
     noDecorations: false,
-  };
-
-  static readonly staticKeys: StaticKeyList<MentionOptions> = ['matchers', 'mentionTag'];
-  static readonly handlerKeys: HandlerKeyList<MentionOptions> = ['onChange', 'onExit'];
-  static readonly customHandlerKeys: CustomHandlerKeyList<MentionOptions> = [
-    'keyBindings',
-    'onCharacterEntry',
-  ];
-
+  },
+  handlerKeys: ['onChange', 'onExit'],
+  staticKeys: ['matchers', 'mentionTag'],
+  customHandlerKeys: ['keyBindings', 'onCharacterEntry'],
+})
+export class MentionExtension extends MarkExtension<MentionOptions> {
   get name() {
     return 'mention' as const;
   }

--- a/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
+++ b/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
@@ -1,12 +1,9 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
-  DefaultExtensionOptions,
+  extensionDecorator,
   ExtensionPriority,
   ExtensionTag,
-  INDENT_ATTRIBUTE,
-  INDENT_LEVELS,
-  IndentLevels,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -20,14 +17,10 @@ import { setBlockType } from '@remirror/pm/commands';
  *
  * @core
  */
-export class ParagraphExtension extends NodeExtension<ParagraphOptions> {
-  static readonly defaultOptions: DefaultExtensionOptions<ParagraphOptions> = {
-    indentAttribute: INDENT_ATTRIBUTE,
-    indentLevels: INDENT_LEVELS,
-  };
-
-  static readonly defaultPriority = ExtensionPriority.Medium;
-
+@extensionDecorator({
+  defaultPriority: ExtensionPriority.Medium,
+})
+export class ParagraphExtension extends NodeExtension {
   get name() {
     return 'paragraph' as const;
   }
@@ -62,51 +55,13 @@ export class ParagraphExtension extends NodeExtension<ParagraphOptions> {
    */
   createCommands() {
     return {
-      createParagraph: (attributes: ParagraphExtensionAttributes) => {
+      createParagraph: (attributes: ProsemirrorAttributes) => {
         return convertCommand(setBlockType(this.type, attributes));
       },
     };
   }
 }
 
-export interface ParagraphOptions {
-  /**
-   * The attribute to use to store the value of the current indentation level.
-   */
-  indentAttribute?: string;
-
-  /**
-   * The levels of indentation supported - should be a tuple with the lowest value first and
-   * the max indent last.
-   *
-   * @defaultValue `[0,7]`
-   */
-  indentLevels?: IndentLevels;
-}
-
 /**
  * The possible values for text alignment.
  */
-export type TextAlignment = 'left' | 'right' | 'center' | 'justify';
-
-export type ParagraphExtensionAttributes = ProsemirrorAttributes<{
-  /**
-   * The alignment of the text
-   */
-  align?: TextAlignment | null;
-
-  /**
-   * The indentation number.
-   */
-  indent?: number | null;
-
-  /**
-   * The line spacing for the paragraph.
-   */
-  lineSpacing?: string | null;
-
-  /**
-   * The element id (rarely used).
-   */
-  id?: string | null;
-}>;

--- a/packages/@remirror/extension-placeholder/src/placeholder-extension.ts
+++ b/packages/@remirror/extension-placeholder/src/placeholder-extension.ts
@@ -2,16 +2,12 @@ import { css } from 'linaria';
 
 import {
   CreatePluginReturn,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
+  extensionDecorator,
   getPluginState,
-  HandlerKeyList,
   isDocNodeEmpty,
   ManagerPhase,
   OnSetOptionsParameter,
   PlainExtension,
-  Static,
-  StaticKeyList,
   Transaction,
 } from '@remirror/core';
 import { EditorState } from '@remirror/pm/state';
@@ -46,7 +42,7 @@ export interface PlaceholderOptions {
    * The class to decorate the empty top level node with. If you change this
    * then you will also need to apply your own styles.
    */
-  emptyNodeClass?: Static<string>;
+  emptyNodeClass?: string;
 }
 
 export interface PlaceholderPluginState extends Required<PlaceholderOptions> {
@@ -56,16 +52,13 @@ export interface PlaceholderPluginState extends Required<PlaceholderOptions> {
 /**
  * An extension for the remirror editor. CHANGE ME.
  */
-export class PlaceholderExtension extends PlainExtension<PlaceholderOptions> {
-  static readonly staticKeys: StaticKeyList<PlaceholderOptions> = ['emptyNodeClass'];
-  static readonly handlerKeys: HandlerKeyList<PlaceholderOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<PlaceholderOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<PlaceholderOptions> = {
+@extensionDecorator<PlaceholderOptions>({
+  defaultOptions: {
     emptyNodeClass: EMPTY_NODE_CLASS_NAME,
     placeholder: '',
-  };
-
+  },
+})
+export class PlaceholderExtension extends PlainExtension<PlaceholderOptions> {
   get name() {
     return 'placeholder' as const;
   }

--- a/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
+++ b/packages/@remirror/extension-position-tracker/src/position-tracker-extension.ts
@@ -1,10 +1,8 @@
 import {
   CommandFunction,
   CreatePluginReturn,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
+  extensionDecorator,
   getPluginMeta,
-  HandlerKeyList,
   isEmptyArray,
   isNullOrUndefined,
   isNumber,
@@ -12,7 +10,7 @@ import {
   object,
   PlainExtension,
   PosParameter,
-  StaticKeyList,
+  Static,
   Transaction,
 } from '@remirror/core';
 import { Decoration, DecorationSet } from '@remirror/pm/view';
@@ -23,14 +21,14 @@ export interface PositionTrackerOptions {
    *
    * '@defaultValue 'remirror-tracker-position'
    */
-  class?: string;
+  class?: Static<string>;
 
   /**
    * The default element that is used for all trackers.
    *
    * @defaultValue 'tracker'
    */
-  element?: string;
+  element?: Static<string>;
 }
 
 const CLEAR = Symbol('CLEAR');
@@ -38,16 +36,14 @@ const CLEAR = Symbol('CLEAR');
 /**
  * An extension for the remirror editor. CHANGE ME.
  */
-export class PositionTrackerExtension extends PlainExtension<PositionTrackerOptions> {
-  static readonly staticKeys: StaticKeyList<PositionTrackerOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<PositionTrackerOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<PositionTrackerOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<PositionTrackerOptions> = {
+@extensionDecorator<PositionTrackerOptions>({
+  defaultOptions: {
     class: 'remirror-tracker-position',
     element: 'tracker',
-  };
-
+  },
+  staticKeys: ['class', 'element'],
+})
+export class PositionTrackerExtension extends PlainExtension<PositionTrackerOptions> {
   get name() {
     return 'positionTracker' as const;
   }

--- a/packages/@remirror/extension-positioner/src/positioner-extension.ts
+++ b/packages/@remirror/extension-positioner/src/positioner-extension.ts
@@ -1,7 +1,7 @@
 import {
   AddCustomHandler,
   CustomHandler,
-  DefaultExtensionOptions,
+  extensionDecorator,
   isString,
   PlainExtension,
   Position,
@@ -26,16 +26,15 @@ export interface PositionerOptions {
 }
 
 /**
- * This is the default parent node. It is required in the Prosemirror Schema and
- * a representation of the `doc` is required as the top level node in all
- * editors.
+ * This is the positioner extension which is used to track the positions of
+ * different parts of your editor.
  *
- * @required
- * @core
+ * For example, you can track the cursor or all visible paragraph nodes.
  */
+@extensionDecorator<PositionerOptions>({
+  customHandlerKeys: ['positionerHandler'],
+})
 export class PositionerExtension extends PlainExtension<PositionerOptions> {
-  static defaultOptions: DefaultExtensionOptions<PositionerOptions> = {};
-
   get name() {
     return 'positioner' as const;
   }

--- a/packages/@remirror/extension-react-component/src/react-component-extension.ts
+++ b/packages/@remirror/extension-react-component/src/react-component-extension.ts
@@ -2,14 +2,11 @@ import { ComponentType } from 'react';
 
 import {
   AnyCombinedUnion,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
-  HandlerKeyList,
+  extensionDecorator,
   isNodeExtension,
   NodeViewMethod,
   object,
   PlainExtension,
-  StaticKeyList,
 } from '@remirror/core';
 
 import {
@@ -70,18 +67,16 @@ import { ReactNodeView } from './react-node-view';
  * I'm currently improving the API in the next branch and I'll update docs on
  * how it should be used once done.
  */
-export class ReactComponentExtension extends PlainExtension<ReactComponentOptions> {
-  static readonly staticKeys: StaticKeyList<ReactComponentOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<ReactComponentOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<ReactComponentOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<ReactComponentOptions> = {
+@extensionDecorator<ReactComponentOptions>({
+  defaultOptions: {
     defaultBlockNode: 'div',
     defaultInlineNode: 'span',
     defaultContentNode: 'span',
     defaultEnvironment: 'both',
-  };
-
+  },
+  staticKeys: ['defaultEnvironment'],
+})
+export class ReactComponentExtension extends PlainExtension<ReactComponentOptions> {
   /**
    * The portal container which keeps track of all the React Portals containing
    * custom prosemirror NodeViews.

--- a/packages/@remirror/extension-react-ssr/src/react-ssr-extension.ts
+++ b/packages/@remirror/extension-react-ssr/src/react-ssr-extension.ts
@@ -3,6 +3,7 @@ import { Children, cloneElement, ComponentType, createElement, JSXElementConstru
 import {
   AnyCombinedUnion,
   EditorState,
+  extensionDecorator,
   ExtensionPriority,
   isArray,
   object,
@@ -42,13 +43,14 @@ export interface ReactSSROptions {
  * The transformations can also serve as a guideline when creating your own
  * SSRTransforms. However in most cases the defaults should be sufficient.
  */
-export class ReactSSRExtension extends PlainExtension<ReactSSROptions> {
-  static readonly defaultPriority = ExtensionPriority.High;
-
-  static readonly defaultOptions: Required<ReactSSROptions> = {
+@extensionDecorator<ReactSSROptions>({
+  defaultOptions: {
     transformers: [injectBrIntoEmptyParagraphs],
-  };
-
+  },
+  defaultPriority: ExtensionPriority.High,
+  staticKeys: ['transformers'],
+})
+export class ReactSSRExtension extends PlainExtension<ReactSSROptions> {
   get name() {
     return 'reactSSR' as const;
   }

--- a/packages/@remirror/extension-search/src/search-extension.ts
+++ b/packages/@remirror/extension-search/src/search-extension.ts
@@ -4,13 +4,12 @@ import { cx } from 'linaria';
 import {
   CommandFunction,
   CreatePluginReturn,
-  DefaultExtensionOptions,
   DispatchFunction,
+  extensionDecorator,
   findMatches,
   FromToParameter,
   getSelectedWord,
   Handler,
-  HandlerKeyList,
   isEmptyArray,
   isNumber,
   isSelectionEmpty,
@@ -21,7 +20,6 @@ import {
   PlainExtension,
   ProsemirrorNode,
   Static,
-  StaticKeyList,
   Transaction,
 } from '@remirror/core';
 import { Decoration, DecorationSet } from '@remirror/pm/view';
@@ -94,13 +92,10 @@ export interface SearchOptions {
 export type SearchDirection = 'next' | 'previous';
 
 /**
- * An extension for the remirror editor. CHANGE ME.
+ * This extension add search functionality to your editor.
  */
-export class SearchExtension extends PlainExtension<SearchOptions> {
-  static readonly staticKeys: StaticKeyList<SearchOptions> = ['highlightedClass', 'searchClass'];
-  static readonly handlerKeys: HandlerKeyList<SearchOptions> = ['onSearch'];
-
-  static readonly defaultOptions: DefaultExtensionOptions<SearchOptions> = {
+@extensionDecorator<SearchOptions>({
+  defaultOptions: {
     autoSelectNext: true,
     searchClass: 'search',
     highlightedClass: 'highlighted-search',
@@ -111,16 +106,19 @@ export class SearchExtension extends PlainExtension<SearchOptions> {
     searchForwardShortcut: 'Mod-f',
     searchBackwardShortcut: 'Mod-Shift-f',
     clearOnEscape: true,
-  };
+  },
+  handlerKeys: ['onSearch'],
+  staticKeys: ['highlightedClass', 'searchClass'],
+})
+export class SearchExtension extends PlainExtension<SearchOptions> {
+  get name() {
+    return 'search' as const;
+  }
 
   #updating = false;
   #searchTerm?: string;
   #results: FromToParameter[] = [];
   #activeIndex = 0;
-
-  get name() {
-    return 'search' as const;
-  }
 
   createCommands() {
     return {

--- a/packages/@remirror/extension-strike/src/strike-extension.ts
+++ b/packages/@remirror/extension-strike/src/strike-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
+  extensionDecorator,
   KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
@@ -10,6 +11,7 @@ import {
 } from '@remirror/core';
 import { toggleMark } from '@remirror/pm/commands';
 
+@extensionDecorator({})
 export class StrikeExtension extends MarkExtension {
   get name() {
     return 'strike' as const;

--- a/packages/@remirror/extension-text/src/text-extension.ts
+++ b/packages/@remirror/extension-text/src/text-extension.ts
@@ -1,4 +1,4 @@
-import { ExtensionPriority, NodeExtension, NodeGroup } from '@remirror/core';
+import { extensionDecorator, ExtensionPriority, NodeExtension, NodeGroup } from '@remirror/core';
 
 /**
  * The default text passed into the prosemirror schema.
@@ -7,10 +7,11 @@ import { ExtensionPriority, NodeExtension, NodeGroup } from '@remirror/core';
  *
  * @core
  */
+@extensionDecorator({
+  disableExtraAttributes: true,
+  defaultPriority: ExtensionPriority.Medium,
+})
 export class TextExtension extends NodeExtension {
-  static readonly disableExtraAttributes = true;
-  static readonly defaultPriority = ExtensionPriority.Medium;
-
   get name() {
     return 'text' as const;
   }

--- a/packages/@remirror/extension-trailing-node/src/trailing-node-extension.ts
+++ b/packages/@remirror/extension-trailing-node/src/trailing-node-extension.ts
@@ -1,13 +1,10 @@
 import {
   CreatePluginReturn,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
   entries,
-  HandlerKeyList,
+  extensionDecorator,
   nodeEqualsType,
   OnSetOptionsParameter,
   PlainExtension,
-  StaticKeyList,
   uniqueArray,
 } from '@remirror/core';
 
@@ -45,17 +42,14 @@ export interface TrailingNodeOptions {
  * This ensures there's always space to select the position afterward.
  *
  */
-export class TrailingNodeExtension extends PlainExtension<TrailingNodeOptions> {
-  static readonly staticKeys: StaticKeyList<TrailingNodeOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<TrailingNodeOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<TrailingNodeOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<TrailingNodeOptions> = {
+@extensionDecorator<TrailingNodeOptions>({
+  defaultOptions: {
     ignoredNodes: [],
     disableTags: false,
     nodeName: 'paragraph',
-  };
-
+  },
+})
+export class TrailingNodeExtension extends PlainExtension<TrailingNodeOptions> {
   get name() {
     return 'trailingNode' as const;
   }

--- a/packages/@remirror/extension-underline/src/underline-extension.ts
+++ b/packages/@remirror/extension-underline/src/underline-extension.ts
@@ -1,12 +1,14 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
+  extensionDecorator,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
 } from '@remirror/core';
 import { toggleMark } from '@remirror/pm/commands';
 
+@extensionDecorator({})
 export class UnderlineExtension extends MarkExtension {
   get name() {
     return 'underline' as const;

--- a/packages/@remirror/extension-yjs/src/yjs-extension.ts
+++ b/packages/@remirror/extension-yjs/src/yjs-extension.ts
@@ -6,7 +6,7 @@ import { Doc } from 'yjs';
 import {
   CommandFunction,
   convertCommand,
-  DefaultExtensionOptions,
+  extensionDecorator,
   ExtensionPriority,
   isFunction,
   nonChainable,
@@ -45,9 +45,8 @@ export interface YjsOptions<Provider extends YjsRealtimeProvider = YjsRealtimePr
  * The YJS extension is the recommended extension for creating a collaborative
  * editor.
  */
-export class YjsExtension extends PlainExtension<YjsOptions> {
-  static readonly defaultPriority = ExtensionPriority.High;
-  static readonly defaultOptions: DefaultExtensionOptions<YjsOptions> = {
+@extensionDecorator<YjsOptions>({
+  defaultOptions: {
     // TODO remove y-webrtc dependency and this default option.
     getProvider: () => new WebrtcProvider('global', new Doc(), {} as any),
 
@@ -58,8 +57,11 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
       provider.destroy();
       doc.destroy();
     },
-  };
-
+  },
+  defaultPriority: ExtensionPriority.High,
+  staticKeys: ['destroyProvider'],
+})
+export class YjsExtension extends PlainExtension<YjsOptions> {
   get name() {
     return 'yjs' as const;
   }

--- a/packages/@remirror/preset-embed/src/embed-preset.ts
+++ b/packages/@remirror/preset-embed/src/embed-preset.ts
@@ -1,25 +1,14 @@
-import {
-  CustomHandlerKeyList,
-  DefaultPresetOptions,
-  HandlerKeyList,
-  OnSetOptionsParameter,
-  Preset,
-  StaticKeyList,
-} from '@remirror/core';
+import { OnSetOptionsParameter, Preset, presetDecorator } from '@remirror/core';
 
 import { IframeExtension, IframeOptions } from './iframe-extension';
 
 export interface EmbedOptions extends IframeOptions {}
 
+@presetDecorator<EmbedOptions>({
+  defaultOptions: IframeExtension.defaultOptions,
+  staticKeys: ['class', 'defaultSource'],
+})
 export class EmbedPreset extends Preset<EmbedOptions> {
-  static readonly staticKeys: StaticKeyList<EmbedOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<EmbedOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<EmbedOptions> = [];
-
-  static readonly defaultOptions: DefaultPresetOptions<EmbedOptions> = {
-    ...IframeExtension.defaultOptions,
-  };
-
   get name() {
     return 'embed' as const;
   }

--- a/packages/@remirror/preset-embed/src/iframe-extension.ts
+++ b/packages/@remirror/preset-embed/src/iframe-extension.ts
@@ -4,10 +4,8 @@ import { parse, stringify } from 'tiny-querystring';
 import {
   ApplySchemaAttributes,
   CommandFunction,
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
+  extensionDecorator,
   findSelectedNodeOfType,
-  HandlerKeyList,
   NodeExtension,
   NodeExtensionSpec,
   NodeGroup,
@@ -15,7 +13,6 @@ import {
   ProsemirrorAttributes,
   Shape,
   Static,
-  StaticKeyList,
 } from '@remirror/core';
 
 export interface IframeOptions {
@@ -44,16 +41,14 @@ export type IframeAttributes = ProsemirrorAttributes<{
 /**
  * An extension for the remirror editor.
  */
-export class IframeExtension extends NodeExtension<IframeOptions> {
-  static readonly staticKeys: StaticKeyList<IframeOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<IframeOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<IframeOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<IframeOptions> = {
+@extensionDecorator<IframeOptions>({
+  defaultOptions: {
     defaultSource: '',
     class: 'remirror-iframe',
-  };
-
+  },
+  staticKeys: ['class', 'class'],
+})
+export class IframeExtension extends NodeExtension<IframeOptions> {
   get name() {
     return 'iframe' as const;
   }

--- a/packages/@remirror/preset-list/src/bullet-list-extension.ts
+++ b/packages/@remirror/preset-list/src/bullet-list-extension.ts
@@ -1,5 +1,6 @@
 import {
   ApplySchemaAttributes,
+  extensionDecorator,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
@@ -11,6 +12,7 @@ import { wrappingInputRule } from '@remirror/pm/inputrules';
 /**
  * Creates the node for a bullet list.
  */
+@extensionDecorator({})
 export class BulletListExtension extends NodeExtension {
   get name() {
     return 'bulletList' as const;

--- a/packages/@remirror/preset-list/src/list-item-extension.ts
+++ b/packages/@remirror/preset-list/src/list-item-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   convertCommand,
+  extensionDecorator,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
@@ -10,6 +11,7 @@ import { liftListItem, sinkListItem, splitListItem } from '@remirror/pm/schema-l
 /**
  * Creates the node for a list item.
  */
+@extensionDecorator({})
 export class ListItemExtension extends NodeExtension {
   get name() {
     return 'listItem' as const;

--- a/packages/@remirror/preset-list/src/list-preset.ts
+++ b/packages/@remirror/preset-list/src/list-preset.ts
@@ -1,12 +1,13 @@
-import { OnSetOptionsParameter, Preset } from '@remirror/core';
+import { OnSetOptionsParameter, Preset, presetDecorator } from '@remirror/core';
 
 import { BulletListExtension } from './bullet-list-extension';
 import { ListItemExtension } from './list-item-extension';
 import { OrderedListExtension } from './ordered-list-extension';
 
+@presetDecorator({})
 export class ListPreset extends Preset {
   get name() {
-    return 'template' as const;
+    return 'list' as const;
   }
 
   protected onSetOptions(_: OnSetOptionsParameter<object>) {}

--- a/packages/@remirror/preset-list/src/ordered-list-extension.ts
+++ b/packages/@remirror/preset-list/src/ordered-list-extension.ts
@@ -1,5 +1,6 @@
 import {
   ApplySchemaAttributes,
+  extensionDecorator,
   isElementDomNode,
   KeyBindings,
   NodeExtension,
@@ -12,6 +13,7 @@ import { wrappingInputRule } from '@remirror/pm/inputrules';
 /**
  * Creates the list for the ordered list.
  */
+@extensionDecorator({})
 export class OrderedListExtension extends NodeExtension {
   get name() {
     return 'orderedList' as const;

--- a/packages/@remirror/preset-react-checkbox/src/react-checkbox-preset.ts
+++ b/packages/@remirror/preset-react-checkbox/src/react-checkbox-preset.ts
@@ -1,20 +1,9 @@
-import {
-  CustomHandlerKeyList,
-  DefaultPresetOptions,
-  HandlerKeyList,
-  OnSetOptionsParameter,
-  Preset,
-  StaticKeyList,
-} from '@remirror/core';
+import { OnSetOptionsParameter, Preset, presetDecorator } from '@remirror/core';
 
 export interface CheckboxOptions {}
 
+@presetDecorator<CheckboxOptions>({})
 export class CheckboxPreset extends Preset<CheckboxOptions> {
-  static readonly staticKeys: StaticKeyList<CheckboxOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<CheckboxOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<CheckboxOptions> = [];
-  static readonly defaultOptions: DefaultPresetOptions<CheckboxOptions> = {};
-
   get name() {
     return 'reactCheckbox' as const;
   }

--- a/packages/@remirror/preset-react/src/react-preset.ts
+++ b/packages/@remirror/preset-react/src/react-preset.ts
@@ -2,11 +2,11 @@ import { cx } from 'linaria';
 import { Children, cloneElement } from 'react';
 
 import {
-  DefaultPresetOptions,
   isDocNodeEmpty,
   isString,
   OnSetOptionsParameter,
   Preset,
+  presetDecorator,
 } from '@remirror/core';
 import { PlaceholderExtension, PlaceholderOptions } from '@remirror/extension-placeholder';
 import { ReactComponentExtension } from '@remirror/extension-react-component';
@@ -15,12 +15,14 @@ import { getElementProps } from '@remirror/react-utils';
 
 export interface ReactPresetOptions extends ReactSSROptions, PlaceholderOptions {}
 
-export class ReactPreset extends Preset<ReactPresetOptions> {
-  static defaultOptions: DefaultPresetOptions<ReactPresetOptions> = {
+@presetDecorator<ReactPresetOptions>({
+  defaultOptions: {
     ...ReactSSRExtension.defaultOptions,
     ...PlaceholderExtension.defaultOptions,
-  };
-
+  },
+  staticKeys: ['transformers'],
+})
+export class ReactPreset extends Preset<ReactPresetOptions> {
   get name() {
     return 'react' as const;
   }

--- a/packages/@remirror/preset-social/src/social-preset.ts
+++ b/packages/@remirror/preset-social/src/social-preset.ts
@@ -2,14 +2,11 @@ import { Except } from 'type-fest';
 
 import {
   AddCustomHandler,
-  CustomHandlerKeyList,
-  DefaultPresetOptions,
   ExtensionPriority,
-  HandlerKeyList,
   OnSetOptionsParameter,
   Preset,
+  presetDecorator,
   Static,
-  StaticKeyList,
 } from '@remirror/core';
 import { AutoLinkExtension, AutoLinkOptions } from '@remirror/extension-auto-link';
 import { EmojiExtension, EmojiOptions } from '@remirror/extension-emoji';
@@ -38,30 +35,20 @@ export interface SocialOptions
   tagMatcherOptions?: Static<Except<MentionExtensionMatcher, 'name' | 'char'>>;
 }
 
-export class SocialPreset extends Preset<SocialOptions> {
-  static readonly staticKeys: StaticKeyList<SocialOptions> = ['matchers', 'mentionTag', 'urlRegex'];
-  static readonly handlerKeys: HandlerKeyList<SocialOptions> = [
-    'onChange',
-    'onChangeEmoji',
-    'onExit',
-    'onExitEmoji',
-    'onUrlUpdate',
-  ];
-  static readonly customHandlerKeys: CustomHandlerKeyList<SocialOptions> = [
-    'keyBindings',
-    'keyBindingsEmoji',
-    'onCharacterEntry',
-  ];
-
-  static readonly defaultOptions: DefaultPresetOptions<SocialOptions> = {
+@presetDecorator<SocialOptions>({
+  defaultOptions: {
     ...AutoLinkExtension.defaultOptions,
     ...MentionExtension.defaultOptions,
     ...EmojiExtension.defaultOptions,
     matchers: [],
     atMatcherOptions: {},
     tagMatcherOptions: {},
-  };
-
+  },
+  customHandlerKeys: ['keyBindings', 'keyBindingsEmoji', 'onCharacterEntry'],
+  handlerKeys: ['onChange', 'onChangeEmoji', 'onUrlUpdate', 'onExitEmoji', 'onExit'],
+  staticKeys: ['matchers', 'mentionTag', 'urlRegex', 'atMatcherOptions', 'tagMatcherOptions'],
+})
+export class SocialPreset extends Preset<SocialOptions> {
   get name() {
     return 'social' as const;
   }

--- a/packages/@remirror/preset-table/src/table-extensions.ts
+++ b/packages/@remirror/preset-table/src/table-extensions.ts
@@ -3,7 +3,7 @@ import {
   CommandFunction,
   CommandFunctionParameter,
   convertCommand,
-  DefaultExtensionOptions,
+  extensionDecorator,
   NodeExtension,
   OnSetOptionsParameter,
 } from '@remirror/core';
@@ -45,11 +45,12 @@ export interface TableOptions {
 
 let tablesEnabled = false;
 
-export class TableExtension extends NodeExtension<TableOptions> {
-  static defaultOptions: DefaultExtensionOptions<TableOptions> = {
+@extensionDecorator<TableOptions>({
+  defaultOptions: {
     resizable: true,
-  };
-
+  },
+})
+export class TableExtension extends NodeExtension<TableOptions> {
   get name() {
     return 'table' as const;
   }
@@ -207,6 +208,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
 /**
  * The extension for a table row node.
  */
+@extensionDecorator({})
 export class TableRowExtension extends NodeExtension {
   get name() {
     return 'tableRow' as const;
@@ -220,6 +222,7 @@ export class TableRowExtension extends NodeExtension {
 /**
  * The extension for a table cell node.
  */
+@extensionDecorator({})
 export class TableCellExtension extends NodeExtension {
   get name() {
     return 'tableCell' as const;
@@ -233,6 +236,7 @@ export class TableCellExtension extends NodeExtension {
 /**
  * The extension for the table header node.
  */
+@extensionDecorator({})
 export class TableHeaderCellExtension extends NodeExtension {
   get name() {
     return 'tableHeaderCell' as const;

--- a/packages/@remirror/preset-table/src/table-preset.ts
+++ b/packages/@remirror/preset-table/src/table-preset.ts
@@ -1,9 +1,4 @@
-import {
-  DefaultPresetOptions,
-  ExtensionPriority,
-  OnSetOptionsParameter,
-  Preset,
-} from '@remirror/core';
+import { ExtensionPriority, OnSetOptionsParameter, Preset, presetDecorator } from '@remirror/core';
 
 import {
   TableCellExtension,
@@ -16,11 +11,10 @@ import {
 /**
  * The table is packaged up as preset for simpler consumption.
  */
+@presetDecorator<TableOptions>({
+  defaultOptions: TableExtension.defaultOptions,
+})
 export class TablePreset extends Preset<TableOptions> {
-  static readonly defaultOptions: DefaultPresetOptions<TableOptions> = {
-    ...TableExtension.defaultOptions,
-  };
-
   get name() {
     return 'table' as const;
   }

--- a/packages/@remirror/preset-wysiwyg/src/wysiwyg-preset.ts
+++ b/packages/@remirror/preset-wysiwyg/src/wysiwyg-preset.ts
@@ -1,10 +1,4 @@
-import {
-  DefaultPresetOptions,
-  HandlerKeyList,
-  OnSetOptionsParameter,
-  Preset,
-  StaticKeyList,
-} from '@remirror/core';
+import { OnSetOptionsParameter, Preset, presetDecorator } from '@remirror/core';
 import { BidiExtension, BidiOptions } from '@remirror/extension-bidi';
 import { BlockquoteExtension } from '@remirror/extension-blockquote';
 import { BoldExtension, BoldOptions } from '@remirror/extension-bold';
@@ -34,23 +28,8 @@ export interface WysiwygOptions
     SearchOptions,
     TrailingNodeOptions {}
 
-export class WysiwygPreset extends Preset<WysiwygOptions> {
-  static readonly staticKeys: StaticKeyList<WysiwygOptions> = [
-    'defaultLevel',
-    'excludeNodes',
-    'highlightedClass',
-    'levels',
-    'searchClass',
-    'weight',
-  ];
-  static readonly handlerKeys: HandlerKeyList<WysiwygOptions> = [
-    'onActivateLink',
-    'onDestroy',
-    'onInit',
-    'onSearch',
-  ];
-
-  static readonly defaultOptions: DefaultPresetOptions<WysiwygOptions> = {
+@presetDecorator<WysiwygOptions>({
+  defaultOptions: {
     ...BidiExtension.defaultOptions,
     ...BoldExtension.defaultOptions,
     ...CodeBlockExtension.defaultOptions,
@@ -58,8 +37,18 @@ export class WysiwygPreset extends Preset<WysiwygOptions> {
     ...SearchExtension.defaultOptions,
     ...TrailingNodeExtension.defaultOptions,
     ...HeadingExtension.defaultOptions,
-  };
-
+  },
+  staticKeys: [
+    'defaultLevel',
+    'excludeNodes',
+    'highlightedClass',
+    'levels',
+    'searchClass',
+    'weight',
+  ],
+  handlerKeys: ['onActivateLink', 'onDestroy', 'onInit', 'onSearch'],
+})
+export class WysiwygPreset extends Preset<WysiwygOptions> {
   get name() {
     return 'wysiwyg' as const;
   }

--- a/support/templates/extension-template/src/template-extension.ts
+++ b/support/templates/extension-template/src/template-extension.ts
@@ -1,23 +1,12 @@
-import {
-  CustomHandlerKeyList,
-  DefaultExtensionOptions,
-  HandlerKeyList,
-  PlainExtension,
-  StaticKeyList,
-} from '@remirror/core';
+import { extensionDecorator, PlainExtension } from '@remirror/core';
 
 export interface TemplateOptions {}
 
 /**
  * An extension for the remirror editor. CHANGE ME.
  */
+@extensionDecorator<TemplateOptions>({})
 export class TemplateExtension extends PlainExtension<TemplateOptions> {
-  static readonly staticKeys: StaticKeyList<TemplateOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<TemplateOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<TemplateOptions> = [];
-
-  static readonly defaultOptions: DefaultExtensionOptions<TemplateOptions> = {};
-
   get name() {
     return 'template' as const;
   }

--- a/support/templates/preset-template/src/template-preset.ts
+++ b/support/templates/preset-template/src/template-preset.ts
@@ -1,20 +1,9 @@
-import {
-  CustomHandlerKeyList,
-  DefaultPresetOptions,
-  HandlerKeyList,
-  OnSetOptionsParameter,
-  Preset,
-  StaticKeyList,
-} from '@remirror/core';
+import { OnSetOptionsParameter, Preset, presetDecorator } from '@remirror/core';
 
 export interface TemplateOptions {}
 
+@presetDecorator<TemplateOptions>({})
 export class TemplatePreset extends Preset<TemplateOptions> {
-  static readonly staticKeys: StaticKeyList<TemplateOptions> = [];
-  static readonly handlerKeys: HandlerKeyList<TemplateOptions> = [];
-  static readonly customHandlerKeys: CustomHandlerKeyList<TemplateOptions> = [];
-
-  static readonly defaultOptions: DefaultPresetOptions<TemplateOptions> = {};
   get name() {
     return 'template' as const;
   }

--- a/support/website/babel.config.js
+++ b/support/website/babel.config.js
@@ -23,8 +23,6 @@ function babelConfig(api) {
       {
         test: /\.[jt]sx?$/,
         plugins: [
-          [require.resolve('@babel/plugin-proposal-class-properties')],
-          [require.resolve('@babel/plugin-proposal-private-methods')],
           require.resolve('babel-plugin-macros'),
 
           // Polyfills the runtime needed for async/await, generators, and friends
@@ -58,6 +56,8 @@ function babelConfig(api) {
           require.resolve('@babel/plugin-proposal-optional-chaining'),
           require.resolve('@babel/plugin-proposal-numeric-separator'),
           [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
+          [require.resolve('@babel/plugin-proposal-class-properties')],
+          [require.resolve('@babel/plugin-proposal-private-methods')],
         ],
       },
     ],


### PR DESCRIPTION
## Description

### Breaking


**`@remirror/extension-paragraph`**

Remove `ParagraphOptions` and all formatting specific attributes.


### `extensionDecorator`

Add new `extensionDecorator` function which augments the static properties of an `Extension` constructor when used as a decorator.

The following code will add a decorator to the extension.

```ts
import { PlainExtension, ExtensionPriority, extensionDecorator } from 'remirror/core';
interface ExampleOptions {
  color?: string;
  /**
   * This option is annotated as a handler and needs a static property.
   **/
  onChange?: Handler<() => void>;
}
@extensionDecorator<ExampleOptions>({
  defaultOptions: { color: 'red' },
  defaultPriority: ExtensionPriority.Lowest,
  handlerKeys: ['onChange'],
})
class ExampleExtension extends PlainExtension<ExampleOptions> {
  get name() {
    return 'example' as const;
  }
}
```

The extension decorator updates the static properties of the extension. If you prefer not to use decorators it can also be called as a function. The `Extension` constructor is mutated by the function call and does not need to be returned.

```ts
extensionDecorator({ defaultSettings: { color: 'red' } })(ExampleExtension);
```

- Switch all packages from using static properties to using the `@extensionDecorator` and `@presetDecorator` instead.

Closes #392 

### `presetDecorator`

Add new `presetDecorator` function which augments the static properties of an `Preset` constructor when used as a decorator.

The following code will add a decorator to the preset.

```ts
import { Preset presetDecorator } from 'remirror/core';
interface ExampleOptions {
  color?: string;
  /**
   * This option is annotated as a handler and needs a static property.
   **/
  onChange?: Handler<() => void>;
}
@presetDecorator<ExampleOptions>({
  defaultOptions: { color: 'red' },
  handlerKeys: ['onChange'],
})
class ExamplePreset extends Preset<ExampleOptions> {
  get name() {
    return 'example' as const;
  }
}
```

The preset decorator updates the static properties of the preset. If you prefer not to use decorators it can also be called as a function. The `Preset` constructor is mutated by the function call and does not need to be returned.

```ts
presetDecorator({ defaultSettings: { color: 'red' }, handlerKeys: ['onChange'] })(ExamplePreset);
```

### Other

- `@remirror/preset-list` - Change name of `ListPreset` from `template` to `list`.
- `@remirror/core` - Throw error in `Preset` and `Extension` when attempting to update a non-dynamic option at runtime.




## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
