### PR TITLE
fix(extension-drop-cursor): simplify the implementation with the `prosemirror-dropcursor` plugin

### DIFF
--- a/.changeset/healthy-pugs-itch.md
+++ b/.changeset/healthy-pugs-itch.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-drop-cursor': major
+---
+
+Use the default `prosemirror-dropcursor` plugin instead of the broken custom implentation. Everything is different.

--- a/.changeset/moody-geckos-obey.md
+++ b/.changeset/moody-geckos-obey.md
@@ -1,0 +1,5 @@
+---
+'@remirror/preset-core': minor
+---
+
+Add `GapCursorExtension` to the `CorePreset`.

--- a/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
+++ b/packages/@remirror/extension-drop-cursor/src/drop-cursor-extension.ts
@@ -1,428 +1,46 @@
-import {
-  bool,
-  CreatePluginReturn,
-  EditorView,
-  extensionDecorator,
-  findPositionOfNodeAfter,
-  findPositionOfNodeBefore,
-  Handler,
-  isUndefined,
-  pick,
-  PlainExtension,
-  ResolvedPos,
-  throttle,
-} from '@remirror/core';
-import { dropPoint, insertPoint } from '@remirror/pm/transform';
-import { Decoration, DecorationSet } from '@remirror/pm/view';
-
-interface OnInitParameter extends OnDestroyParameter {
-  extension: DropCursorExtension;
-}
-
-interface OnDestroyParameter {
-  blockElement: HTMLElement;
-  inlineElement: HTMLElement;
-}
+import { extensionDecorator, PlainExtension } from '@remirror/core';
+import { dropCursor } from '@remirror/pm/dropcursor';
 
 export interface DropCursorOptions {
   /**
-   * The main color of the component being rendered.
+   * Set the color of the cursor.
    *
-   * This can be a named color from the theme such as `background`
-   *
-   * @defaultValue `primary`
+   * @defaultValue 'black'
    */
   color?: string;
 
   /**
-   * The width of the inline drop cursor.
+   * Set the precise width of the cursor in pixels.
    *
-   * @defaultValue '2px'
+   * @defaultValue 1
    */
-  inlineWidth?: string | number;
-
-  /**
-   * The horizontal margin around the inline cursor.
-   *
-   * @defaultValue '10px'
-   */
-  inlineSpacing?: string | number;
-
-  /**
-   * The width of the block drop cursor.
-   *
-   * @defaultValue '100%'
-   */
-  blockWidth?: string | number;
-
-  /**
-   * The height of the block drop cursor.
-   */
-  blockHeight?: string | number;
-
-  /**
-   * The class name added to the block widget
-   *
-   * @defaultValue 'remirror-drop-cursor-block'
-   */
-  blockClassName?: string;
-
-  /**
-   * The class name added to the node that appears before the block drop cursor widget.
-   *
-   * @defaultValue 'remirror-drop-cursor-before-block'
-   */
-  beforeBlockClassName?: string;
-
-  /**
-   * The class name added to the node that appears after the block drop cursor widget.
-   *
-   * @defaultValue 'remirror-drop-cursor-after-block'
-   */
-  afterBlockClassName?: string;
-
-  /**
-   * The class name added to the inline drop cursor widget
-   *
-   * @defaultValue 'remirror-drop-cursor-inline'
-   */
-  inlineClassName?: string;
-
-  /**
-   * The class name added to the node that appears before the inline drop cursor widget.
-   *
-   * @defaultValue 'remirror-drop-cursor-before-inline'
-   */
-  beforeInlineClassName?: string;
-
-  /**
-   * The class name added to the node that appears after the inline drop cursor widget.
-   *
-   * @defaultValue 'remirror-drop-cursor-after-inline'
-   */
-  afterInlineClassName?: string;
-
-  /**
-   * When the plugin is first initialized.
-   */
-  onInit: Handler<(parameter: OnInitParameter) => void>;
-
-  /**
-   * Cleanup when the drop cursor plugin is destroyed. This happens when the
-   * editor is unmounted.
-   *
-   * If you've attached a portal to the element then this is the place to handle
-   * that.
-   */
-  onDestroy: Handler<(parameter: OnDestroyParameter) => void>;
+  width?: number;
 }
 
 /**
- * A drop cursor plugin which adds a decoration at the active drop location. The
- * decoration has a class and can be styled however you want.
+ * Create a plugin that, when added to a ProseMirror instance,
+ * causes a decoration to show up at the drop position when something
+ * is dragged over the editor.
+ *
+ * @builtin
  */
 @extensionDecorator<DropCursorOptions>({
   defaultOptions: {
-    inlineWidth: '2px',
-    inlineSpacing: '10px',
-    blockWidth: '100%',
-    blockHeight: '10px',
-    color: 'primary',
-    blockClassName: 'remirror-drop-cursor-block',
-    beforeBlockClassName: 'remirror-drop-cursor-before-block',
-    afterBlockClassName: 'remirror-drop-cursor-after-block',
-    inlineClassName: 'remirror-drop-cursor-inline',
-    beforeInlineClassName: 'remirror-drop-cursor-before-inline',
-    afterInlineClassName: 'remirror-drop-cursor-after-inline',
+    color: 'black',
+    width: 1,
   },
-  handlerKeys: ['onInit', 'onDestroy'],
 })
 export class DropCursorExtension extends PlainExtension<DropCursorOptions> {
   get name() {
     return 'dropCursor' as const;
   }
 
-  createHelpers() {
-    return {
-      /**
-       * Check if the anything is currently being dragged over the editor.
-       */
-      isDragging: () => {
-        return this.store.getPluginState<DropCursorState>(this.name).isDragging();
-      },
-    };
-  }
-
   /**
    * Use the dropCursor plugin with provided options.
    */
-  createPlugin(): CreatePluginReturn<DropCursorState> {
-    const dropCursorState = new DropCursorState(this);
+  public createExternalPlugins() {
+    const { color, width } = this.options;
 
-    return {
-      view(editorView) {
-        dropCursorState.init(editorView);
-        return pick(dropCursorState, ['destroy']);
-      },
-      state: {
-        init: () => dropCursorState,
-        apply: () => dropCursorState,
-      },
-      props: {
-        decorations: () => dropCursorState.decorationSet,
-        handleDOMEvents: {
-          dragover: (_, event) => {
-            dropCursorState.dragover(event as DragEvent);
-            return false;
-          },
-          dragend: () => {
-            dropCursorState.dragend();
-            return false;
-          },
-          drop: () => {
-            dropCursorState.drop();
-            return false;
-          },
-          dragleave: (_, event) => {
-            dropCursorState.dragleave(event as DragEvent);
-            return false;
-          },
-        },
-      },
-    };
-  }
-}
-
-/**
- * This indicates whether the current cursor position is within a textblock or
- * between two nodes.
- */
-export type DropCursorType = 'block' | 'inline';
-
-class DropCursorState {
-  /**
-   * The set of all currently active decorations.
-   */
-  decorationSet = DecorationSet.empty;
-
-  readonly #extension: DropCursorExtension;
-
-  /**
-   * The editor view.
-   */
-  private view!: EditorView;
-
-  /**
-   * The dom element which holds the block `Decoration.widget`.
-   */
-  private blockElement!: HTMLElement;
-
-  /**
-   * The dom element which holds the inline `Decoration.widget`.
-   */
-  private inlineElement!: HTMLElement;
-
-  /**
-   * The currently active timeout. This is used when removing the drop cursor to prevent any flicker.
-   */
-  #timeout?: any;
-
-  /**
-   * The current derived target position. This is cached to help prevent unnecessary re-rendering.
-   */
-  #target?: number;
-
-  constructor(extension: DropCursorExtension) {
-    this.#extension = extension;
-    this.dragover = throttle(50, this.dragover);
-  }
-
-  init(view: EditorView) {
-    const { blockClassName, inlineClassName } = this.#extension.options;
-
-    this.view = view;
-    this.blockElement = document.createElement('div');
-    this.inlineElement = document.createElement('span');
-    this.blockElement.classList.add(blockClassName);
-    this.inlineElement.classList.add(inlineClassName);
-
-    this.#extension.options.onInit({
-      blockElement: this.blockElement,
-      inlineElement: this.inlineElement,
-      extension: this.#extension,
-    });
-  }
-
-  /**
-   * Called when the view is destroyed
-   */
-  destroy = () => {
-    this.#extension.options.onDestroy({
-      blockElement: this.blockElement,
-      inlineElement: this.inlineElement,
-    });
-  };
-
-  /**
-   * Check if the editor is currently being dragged around.
-   */
-  isDragging = () =>
-    bool(
-      this.view.dragging ??
-        (this.decorationSet !== DecorationSet.empty || !isUndefined(this.#target)),
-    );
-
-  /**
-   * Called on every dragover event.
-   *
-   * Captures the current position and whether
-   */
-  dragover = (event: DragEvent) => {
-    const pos = this.view.posAtCoords({ left: event.clientX, top: event.clientY });
-
-    if (pos) {
-      const {
-        dragging,
-        state: { doc, schema },
-      } = this.view;
-
-      const target = dragging?.slice
-        ? dropPoint(doc, pos.pos, dragging.slice) ?? pos.pos
-        : insertPoint(doc, pos.pos, schema.image) ?? pos.pos;
-
-      if (target === this.#target) {
-        // This line resets the timeout.
-        this.scheduleRemoval(100);
-        return;
-      }
-
-      this.#target = target;
-      this.updateDecorationSet();
-      this.scheduleRemoval(100);
-    }
-  };
-
-  /**
-   * Called when the drag ends.
-   *
-   * ? Sometimes this event doesn't fire, is there a way to prevent this.
-   */
-  dragend = () => {
-    this.scheduleRemoval(100);
-  };
-
-  /**
-   * Called when the element is dropped.
-   *
-   * ? Sometimes this event doesn't fire, is there a way to prevent this.
-   */
-  drop = () => {
-    this.scheduleRemoval(100);
-  };
-
-  /**
-   * Called when the drag leaves the boundaries of the prosemirror editor dom node.
-   */
-  dragleave = (event: DragEvent) => {
-    if (event.target === this.view.dom || !this.view.dom.contains(event.relatedTarget as Node)) {
-      this.scheduleRemoval(100);
-    }
-  };
-
-  /**
-   * Dispatch an empty transaction to trigger a decoration update.
-   */
-  private readonly triggerDecorationSet = () => this.view.dispatch(this.view.state.tr);
-
-  /**
-   * Removes the decoration and (by default) the current target value.
-   */
-  private readonly removeDecorationSet = (ignoreTarget = false) => {
-    if (!ignoreTarget) {
-      this.#target = undefined;
-    }
-
-    this.decorationSet = DecorationSet.empty;
-    this.triggerDecorationSet();
-  };
-
-  /**
-   * Removes the drop cursor decoration from the view after the set timeout.
-   *
-   * Sometimes the drag events don't automatically trigger so it's important to have this cleanup in place.
-   */
-  private scheduleRemoval(timeout: number, ignoreTarget = false) {
-    if (this.#timeout) {
-      clearTimeout(this.#timeout);
-    }
-
-    this.#timeout = setTimeout(() => {
-      this.removeDecorationSet(ignoreTarget);
-    }, timeout);
-  }
-
-  /**
-   * Update the decoration set with a new position.
-   */
-  private readonly updateDecorationSet = () => {
-    if (!this.#target) {
-      return;
-    }
-
-    const {
-      state: { doc },
-    } = this.view;
-    const $pos = doc.resolve(this.#target);
-    const cursorIsInline = $pos.parent.inlineContent;
-
-    this.decorationSet = DecorationSet.create(
-      doc,
-      cursorIsInline ? this.createInlineDecoration($pos) : this.createBlockDecoration($pos),
-    );
-    this.triggerDecorationSet();
-  };
-
-  /**
-   * Create an inline decoration for the document which is rendered when the cursor position
-   * is within a text block.
-   */
-  private createInlineDecoration($pos: ResolvedPos): Decoration[] {
-    const dropCursor = Decoration.widget($pos.pos, this.inlineElement, {
-      key: 'drop-cursor-inline',
-    });
-
-    return [dropCursor];
-  }
-
-  /**
-   * Create a block decoration for the document which is rendered when the cursor position
-   * is between two nodes.
-   */
-  private createBlockDecoration($pos: ResolvedPos): Decoration[] {
-    const { beforeBlockClassName, afterBlockClassName } = this.#extension.options;
-    const decorations: Decoration[] = [];
-
-    const dropCursor = Decoration.widget($pos.pos, this.blockElement, {
-      key: 'drop-cursor-block',
-    });
-    const before = findPositionOfNodeBefore($pos);
-    const after = findPositionOfNodeAfter($pos);
-    decorations.push(dropCursor);
-
-    if (before) {
-      const beforeDecoration = Decoration.node(before.pos, before.end, {
-        class: beforeBlockClassName,
-      });
-      decorations.push(beforeDecoration);
-    }
-
-    if (after) {
-      const afterDecoration = Decoration.node(after.pos, after.end, {
-        class: afterBlockClassName,
-      });
-      decorations.push(afterDecoration);
-    }
-
-    return decorations;
+    return [dropCursor({ color, width })];
   }
 }

--- a/packages/@remirror/preset-core/package.json
+++ b/packages/@remirror/preset-core/package.json
@@ -25,6 +25,7 @@
     "@babel/runtime": "^7.10.5",
     "@remirror/extension-base-keymap": "^1.0.0-next.12",
     "@remirror/extension-doc": "^1.0.0-next.12",
+    "@remirror/extension-gap-cursor": "^1.0.0-next.12",
     "@remirror/extension-history": "^1.0.0-next.12",
     "@remirror/extension-paragraph": "^1.0.0-next.12",
     "@remirror/extension-positioner": "^1.0.0-next.12",

--- a/packages/@remirror/preset-core/src/core-preset.ts
+++ b/packages/@remirror/preset-core/src/core-preset.ts
@@ -8,6 +8,7 @@ import {
 } from '@remirror/core';
 import { BaseKeymapExtension, BaseKeymapOptions } from '@remirror/extension-base-keymap';
 import { DocExtension, DocOptions } from '@remirror/extension-doc';
+import { GapCursorExtension } from '@remirror/extension-gap-cursor';
 import { HistoryExtension, HistoryOptions } from '@remirror/extension-history';
 import { ParagraphExtension } from '@remirror/extension-paragraph';
 import { PositionerExtension, PositionerOptions } from '@remirror/extension-positioner';
@@ -104,6 +105,7 @@ export class CorePreset extends Preset<CorePresetOptions> {
       newGroupDelay,
     } = this.options;
 
+    const gapCursorExtension = new GapCursorExtension();
     const docExtension = new DocExtension({ content });
     const textExtension = new TextExtension();
     const paragraphExtension = new ParagraphExtension();
@@ -138,6 +140,7 @@ export class CorePreset extends Preset<CorePresetOptions> {
       paragraphExtension,
       positionerExtension,
       baseKeymapExtension,
+      gapCursorExtension,
     ];
   }
 }

--- a/packages/@remirror/preset-wysiwyg/src/wysiwyg-preset.ts
+++ b/packages/@remirror/preset-wysiwyg/src/wysiwyg-preset.ts
@@ -46,7 +46,7 @@ export interface WysiwygOptions
     'searchClass',
     'weight',
   ],
-  handlerKeys: ['onActivateLink', 'onDestroy', 'onInit', 'onSearch'],
+  handlerKeys: ['onActivateLink', 'onSearch'],
 })
 export class WysiwygPreset extends Preset<WysiwygOptions> {
   get name() {
@@ -69,19 +69,7 @@ export class WysiwygPreset extends Preset<WysiwygOptions> {
     ]);
     this.getExtension(CodeBlockExtension).setOptions(codeBlockOptions);
 
-    const dropCursorOptions = pickChanged([
-      'afterBlockClassName',
-      'afterInlineClassName',
-      'beforeBlockClassName',
-      'beforeInlineClassName',
-      'blockClassName',
-      'blockHeight',
-      'blockWidth',
-      'color',
-      'inlineClassName',
-      'inlineSpacing',
-      'inlineWidth',
-    ]);
+    const dropCursorOptions = pickChanged(['color', 'width']);
     this.getExtension(DropCursorExtension).setOptions(dropCursorOptions);
 
     const searchOptions = pickChanged([
@@ -137,34 +125,11 @@ export class WysiwygPreset extends Preset<WysiwygOptions> {
       keyboardShortcut,
     });
 
-    const {
-      afterBlockClassName,
-      afterInlineClassName,
-      beforeBlockClassName,
-      beforeInlineClassName,
-      blockClassName,
-      blockHeight,
-      blockWidth,
-      color,
-      inlineClassName,
-      inlineSpacing,
-      inlineWidth,
-    } = this.options;
+    const { color, width } = this.options;
     const dropCursorExtension = new DropCursorExtension({
-      afterBlockClassName,
-      afterInlineClassName,
-      beforeBlockClassName,
-      beforeInlineClassName,
-      blockClassName,
-      blockHeight,
-      blockWidth,
       color,
-      inlineClassName,
-      inlineSpacing,
-      inlineWidth,
+      width,
     });
-    dropCursorExtension.addHandler('onDestroy', this.options.onDestroy);
-    dropCursorExtension.addHandler('onInit', this.options.onInit);
 
     const epicModeExtension = new EpicModeExtension({ active: false });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,6 +900,7 @@ importers:
       '@babel/runtime': 7.10.5
       '@remirror/extension-base-keymap': 'link:../extension-base-keymap'
       '@remirror/extension-doc': 'link:../extension-doc'
+      '@remirror/extension-gap-cursor': 'link:../extension-gap-cursor'
       '@remirror/extension-history': 'link:../extension-history'
       '@remirror/extension-paragraph': 'link:../extension-paragraph'
       '@remirror/extension-positioner': 'link:../extension-positioner'
@@ -912,6 +913,7 @@ importers:
       '@remirror/core': ^1.0.0-next.12
       '@remirror/extension-base-keymap': ^1.0.0-next.12
       '@remirror/extension-doc': ^1.0.0-next.12
+      '@remirror/extension-gap-cursor': ^1.0.0-next.12
       '@remirror/extension-history': ^1.0.0-next.12
       '@remirror/extension-paragraph': ^1.0.0-next.12
       '@remirror/extension-positioner': ^1.0.0-next.12


### PR DESCRIPTION
## Description

- Use the default `prosemirror-dropcursor` plugin instead of the broken custom implentation. Everything is different.
- Add `GapCursorExtension` and `DropCursorExtension` to the `CorePreset`

Closes #381


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

![2020-07-28 16 56 37](https://user-images.githubusercontent.com/1160934/88690307-6cd8cf80-d0f3-11ea-9091-2d09f01f0172.gif)
