### PR TITLE
fix(preset-social): reduce `AutoLinkExtension` priority

### DIFF
--- a/.changeset/nasty-pears-lie.md
+++ b/.changeset/nasty-pears-lie.md
@@ -1,0 +1,6 @@
+---
+'@remirror/preset-social': patch
+'remirror': patch
+---
+
+Reduce the `AutoLinkExtension` priority and remove priority override for the mention and emoji extensions.

--- a/packages/@remirror/preset-social/src/__tests__/social-preset.spec.ts
+++ b/packages/@remirror/preset-social/src/__tests__/social-preset.spec.ts
@@ -1,7 +1,31 @@
+import { renderEditor } from 'jest-remirror';
+
+import { ExtensionPriority } from '@remirror/core';
+import { AutoLinkExtension } from '@remirror/extension-auto-link';
+import { EmojiExtension } from '@remirror/extension-emoji';
+import { MentionExtension } from '@remirror/extension-mention';
 import { isPresetValid } from '@remirror/testing';
 
 import { SocialPreset } from '..';
 
 test('is valid', () => {
   expect(isPresetValid(SocialPreset, { matchers: [] }));
+});
+
+test('can override extensions', () => {
+  const autoLinkExtension = new AutoLinkExtension({ defaultProtocol: 'https:' });
+  const mentionExtension = new MentionExtension({ matchers: [] });
+  const emojiExtension = new EmojiExtension({ priority: ExtensionPriority.Low });
+  const socialPreset = new SocialPreset();
+  const { manager } = renderEditor([
+    autoLinkExtension,
+    mentionExtension,
+    emojiExtension,
+    socialPreset,
+  ]);
+
+  expect(manager.getExtension(AutoLinkExtension)).toBe(autoLinkExtension);
+  expect(manager.getExtension(MentionExtension)).toBe(mentionExtension);
+  expect(manager.getExtension(EmojiExtension)).not.toBe(emojiExtension);
+  expect(manager.getExtension(EmojiExtension)).toBe(socialPreset.getExtension(EmojiExtension));
 });

--- a/packages/@remirror/preset-social/src/social-preset.ts
+++ b/packages/@remirror/preset-social/src/social-preset.ts
@@ -93,7 +93,7 @@ export class SocialPreset extends Preset<SocialOptions> {
     const autoLinkExtension = new AutoLinkExtension({
       defaultProtocol,
       urlRegex,
-      priority: ExtensionPriority.Medium,
+      priority: ExtensionPriority.Lowest,
     });
     autoLinkExtension.addHandler('onUrlUpdate', this.options.onUrlUpdate);
 
@@ -102,7 +102,6 @@ export class SocialPreset extends Preset<SocialOptions> {
       defaultEmoji,
       maxResults,
       suggestionCharacter,
-      priority: ExtensionPriority.Medium,
       extraAttributes: { role: { default: 'presentation' } },
     });
     emojiExtension.addHandler('onChange', this.options.onChangeEmoji);
@@ -127,7 +126,6 @@ export class SocialPreset extends Preset<SocialOptions> {
       mentionTag,
       noDecorations,
       suggestTag,
-      priority: ExtensionPriority.Medium,
       extraAttributes: {
         href: { default: null },
         role: 'presentation',


### PR DESCRIPTION
## Description

- reduce `AutoLinkExtension` priority so that it can be overridden
- Remove priority override for the mention and emoji extensions
- Add test to verify

Raised by @emilschutte on [discord channel](https://discord.gg/C4cfrMK).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

