### PR TITLE
feat: new package `@remirror/extension-events` 🎉

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -34,6 +34,7 @@
       "@remirror/extension-drop-cursor",
       "@remirror/extension-emoji",
       "@remirror/extension-epic-mode",
+      "@remirror/extension-events",
       "@remirror/extension-gap-cursor",
       "@remirror/extension-hard-break",
       "@remirror/extension-heading",

--- a/.changeset/neat-gorillas-deny.md
+++ b/.changeset/neat-gorillas-deny.md
@@ -1,0 +1,8 @@
+---
+'@remirror/core': minor
+'remirror': minor
+---
+
+Add support for `Handler` options with custom return values and early returns.
+
+Previously handlers would ignore any return values. Now a handler will honour the return value. The earlyReturn value can be specified in the static options using the `extensionDecorator`. Currently it only supports primitives. Support for a function to check the return value will be added later.

--- a/.changeset/witty-beds-change.md
+++ b/.changeset/witty-beds-change.md
@@ -1,0 +1,26 @@
+---
+'@remirror/extension-events': major
+'@remirror/preset-core': minor
+'remirror': minor
+---
+
+🎉 New extension `@remirror/extension-events`.
+
+This extension adds handlers for the events happening within the remirror editor. The extension is part of the `CorePreset` but it doesn't make it's handlers available to the preset. In order to use the handlers you will need direct access to the `EventsExtension`.
+
+```ts
+import { EventsExtension } from 'remirror/extension-events';
+import { useExtension } from 'remirror/react';
+
+const Editor = () => {
+  useExtension(
+    EventsExtension,
+    ({ addHandler }) => {
+      addHandler('focus', () => log('focused'));
+    },
+    [],
+  );
+};
+```
+
+To begin with the only events added are `focus` and `blur`.

--- a/packages/@remirror/core/src/decorators.ts
+++ b/packages/@remirror/core/src/decorators.ts
@@ -6,6 +6,7 @@ import {
   GetCustomHandler,
   GetHandler,
   GetStatic,
+  HandlerKey,
   HandlerKeyList,
   IfEmpty,
   IfHasRequiredProperties,
@@ -19,6 +20,7 @@ import {
   DefaultExtensionOptions,
   ExtensionConstructor,
 } from './extension';
+import { HandlerKeyOptions } from './extension/base-class';
 import { AnyPresetConstructor, DefaultPresetOptions, PresetConstructor } from './preset';
 
 interface DefaultOptionsParameter<Options extends Shape = EmptyShape> {
@@ -53,6 +55,11 @@ interface HandlerKeysParameter<Options extends Shape = EmptyShape> {
    * The list of all keys which are event handlers.
    */
   handlerKeys: HandlerKeyList<Options>;
+
+  /**
+   * Customize how the handler should work.
+   */
+  handlerKeyOptions?: Partial<Record<HandlerKey<Options> | '__ALL__', HandlerKeyOptions>>;
 }
 
 interface CustomHandlerKeysParameter<Options extends Shape = EmptyShape> {
@@ -95,6 +102,7 @@ export function extensionDecorator<Options extends Shape = EmptyShape>(
       handlerKeys,
       staticKeys,
       defaultPriority,
+      handlerKeyOptions,
       ...rest
     } = options;
 
@@ -106,6 +114,10 @@ export function extensionDecorator<Options extends Shape = EmptyShape>(
 
     if (defaultPriority) {
       Constructor.defaultPriority = defaultPriority;
+    }
+
+    if (handlerKeyOptions) {
+      Constructor.handlerKeyOptions = handlerKeyOptions;
     }
 
     Constructor.staticKeys = staticKeys ?? [];

--- a/packages/@remirror/core/src/extension/__tests__/plain-extension.spec.ts
+++ b/packages/@remirror/core/src/extension/__tests__/plain-extension.spec.ts
@@ -1,0 +1,64 @@
+import { Handler } from '@remirror/core-types';
+
+import { extensionDecorator } from '../../decorators';
+import { PlainExtension } from '../extension-base';
+
+interface TestOptions {
+  onChange: Handler<() => void>;
+  custom: Handler<() => boolean>;
+}
+
+@extensionDecorator<TestOptions>({
+  handlerKeys: ['custom', 'onChange'],
+  handlerKeyOptions: { custom: { earlyReturnValue: true } },
+})
+class TestExtension extends PlainExtension<TestOptions> {
+  get name() {
+    return 'test' as const;
+  }
+}
+
+describe('handlers', () => {
+  it('supports simple handlers', () => {
+    const testExtension = new TestExtension();
+    const changeHandler = jest.fn(() => {});
+
+    const dispose = testExtension.addHandler('onChange', changeHandler);
+    testExtension.options.onChange();
+
+    expect(changeHandler).toHaveBeenCalledTimes(1);
+
+    jest.clearAllMocks();
+    dispose();
+
+    expect(changeHandler).not.toHaveBeenCalled();
+  });
+
+  it('supports early return values', () => {
+    const testExtension = new TestExtension();
+    const firstHandler = jest.fn(() => false);
+    const secondHandler = jest.fn(() => true);
+    const thirdHandler = jest.fn(() => false);
+
+    testExtension.addHandler('custom', firstHandler);
+    const dispose = testExtension.addHandler('custom', secondHandler);
+    testExtension.addHandler('custom', thirdHandler);
+
+    let returnValue = testExtension.options.custom();
+    expect(returnValue).toBe(true);
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+    expect(thirdHandler).not.toHaveBeenCalled();
+
+    jest.clearAllMocks();
+    dispose();
+
+    returnValue = testExtension.options.custom();
+    expect(returnValue).toBe(false);
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(secondHandler).not.toHaveBeenCalled();
+    expect(thirdHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@remirror/core/src/index.ts
+++ b/packages/@remirror/core/src/index.ts
@@ -20,6 +20,7 @@ export { extensionDecorator, presetDecorator } from './decorators';
 export type { ExtensionDecoratorOptions, PresetDecoratorOptions } from './decorators';
 
 export type {
+  HandlerKeyOptions,
   BaseClass,
   BaseClassConstructor,
   AddHandler,

--- a/packages/@remirror/extension-events/package.json
+++ b/packages/@remirror/extension-events/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@remirror/extension-events",
+  "version": "0.0.0",
+  "description": "Manage your remirror editor dom events.",
+  "keywords": [
+    "remirror",
+    "extension"
+  ],
+  "homepage": "https://github.com/remirror/remirror/tree/HEAD/support/eventss/extension-events",
+  "repository": "https://github.com/remirror/remirror/tree/HEAD/packages/@remirror/extension-events",
+  "license": "MIT",
+  "contributors": [
+    "Ifiok Jr. <ifiokotung@gmail.com>"
+  ],
+  "sideEffects": false,
+  "main": "dist/extension-events.cjs.js",
+  "module": "dist/extension-events.esm.js",
+  "types": "dist/extension-events.cjs.d.ts",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@babel/runtime": "^7.10.5"
+  },
+  "devDependencies": {
+    "@remirror/core": "^1.0.0-next.13",
+    "@remirror/pm": "^1.0.0-next.4",
+    "@testing-library/dom": "^7.21.6"
+  },
+  "peerDependencies": {
+    "@remirror/core": "^1.0.0-next.13",
+    "@remirror/pm": "^1.0.0-next.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "meta": {
+    "sizeLimit": "5 KB"
+  }
+}

--- a/packages/@remirror/extension-events/readme.md
+++ b/packages/@remirror/extension-events/readme.md
@@ -1,0 +1,50 @@
+# @remirror/extension-events
+
+> Manage your remirror editor dom events.
+
+[![Version][version]][npm] [![Weekly Downloads][downloads-badge]][npm]
+[![Bundled size][size-badge]][size] [![Typed Codebase][typescript]](./src/index.ts)
+![MIT License][license]
+
+[version]: https://flat.badgen.net/npm/v/@remirror/extension-events
+[npm]: https://npmjs.com/package/@remirror/extension-events
+[license]: https://flat.badgen.net/badge/license/MIT/purple
+[size]: https://bundlephobia.com/result?p=@remirror/extension-events
+[size-badge]: https://flat.badgen.net/bundlephobia/minzip/@remirror/extension-events
+[typescript]: https://flat.badgen.net/badge/icon/TypeScript?icon=typescript&label
+[downloads-badge]: https://badgen.net/npm/dw/@remirror/extension-events/red?icon=npm
+
+## Installation
+
+```bash
+# yarn
+yarn add @remirror/extension-events @remirror/pm @remirror/core
+
+# pnpm
+pnpm add @remirror/extension-events @remirror/pm @remirror/core
+
+# npm
+npm install @remirror/extension-events @remirror/pm @remirror/core
+```
+
+## Usage
+
+The following code creates an instance of this extension.
+
+```ts
+import { EventsExtension } from '@remirror/extension-events';
+
+const extension = new EventsExtension();
+
+extension.addCustomHandler('focus', () => {
+  // Do something.
+});
+```
+
+This extension is included by default in the `@remirror/preset-core`.
+
+## Credits
+
+This package was bootstrapped with [monots].
+
+[monots]: https://github.com/monots/monots

--- a/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
+++ b/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
@@ -1,0 +1,38 @@
+import { fireEvent } from '@testing-library/dom';
+import { renderEditor } from 'jest-remirror';
+
+import { isExtensionValid } from '@remirror/testing';
+
+import { EventsExtension } from '..';
+
+test('`EventsExtension`: is valid', () => {
+  expect(isExtensionValid(EventsExtension, {}));
+});
+
+describe('events', () => {
+  it('responds to editor `focus` events', () => {
+    const eventsExtension = new EventsExtension();
+    const focusHandler = jest.fn(() => true);
+    const editor = renderEditor([eventsExtension]);
+    const { doc, p } = editor.nodes;
+    eventsExtension.addHandler('focus', focusHandler);
+
+    editor.add(doc(p('first')));
+    fireEvent.focus(editor.dom);
+
+    expect(focusHandler).toHaveBeenCalled();
+  });
+
+  it('responds to editor `blur` events', () => {
+    const eventsExtension = new EventsExtension();
+    const blurHandler = jest.fn(() => true);
+    const editor = renderEditor([eventsExtension]);
+    const { doc, p } = editor.nodes;
+    eventsExtension.addHandler('blur', blurHandler);
+
+    editor.add(doc(p('first')));
+    fireEvent.blur(editor.dom);
+
+    expect(blurHandler).toHaveBeenCalled();
+  });
+});

--- a/packages/@remirror/extension-events/src/events-extension.ts
+++ b/packages/@remirror/extension-events/src/events-extension.ts
@@ -1,0 +1,48 @@
+import { CreatePluginReturn, extensionDecorator, Handler, PlainExtension } from '@remirror/core';
+
+export interface EventsOptions {
+  /**
+   * Listens for blur events on the editor.
+   *
+   * Return `true` to prevent any other prosemirror listeners from firing.
+   */
+  blur: Handler<(event: FocusEvent) => boolean | undefined>;
+
+  /**
+   * Listens for focus events on the editor.
+   *
+   * Return `true` to prevent any other prosemirror listeners from firing.
+   */
+  focus: Handler<(event: FocusEvent) => boolean | undefined>;
+}
+
+/**
+ * The events extension which listens to events which occur within the
+ * remirror editor.
+ *
+ * TODO - add more events based on user feedback.
+ */
+@extensionDecorator<EventsOptions>({
+  handlerKeys: ['blur', 'focus'],
+  handlerKeyOptions: { blur: { earlyReturnValue: true }, focus: { earlyReturnValue: true } },
+})
+export class EventsExtension extends PlainExtension<EventsOptions> {
+  get name() {
+    return 'events' as const;
+  }
+
+  createPlugin(): CreatePluginReturn {
+    return {
+      props: {
+        handleDOMEvents: {
+          focus: (_, event) => {
+            return this.options.focus(event as FocusEvent) ?? false;
+          },
+          blur: (_, event) => {
+            return this.options.blur(event as FocusEvent) ?? false;
+          },
+        },
+      },
+    };
+  }
+}

--- a/packages/@remirror/extension-events/src/index.ts
+++ b/packages/@remirror/extension-events/src/index.ts
@@ -1,0 +1,1 @@
+export * from './events-extension';

--- a/packages/@remirror/preset-core/package.json
+++ b/packages/@remirror/preset-core/package.json
@@ -25,6 +25,7 @@
     "@babel/runtime": "^7.10.5",
     "@remirror/extension-base-keymap": "^1.0.0-next.13",
     "@remirror/extension-doc": "^1.0.0-next.13",
+    "@remirror/extension-events": "^0.0.0",
     "@remirror/extension-gap-cursor": "^1.0.0-next.13",
     "@remirror/extension-history": "^1.0.0-next.13",
     "@remirror/extension-paragraph": "^1.0.0-next.13",

--- a/packages/@remirror/preset-core/src/core-preset.ts
+++ b/packages/@remirror/preset-core/src/core-preset.ts
@@ -8,6 +8,7 @@ import {
 } from '@remirror/core';
 import { BaseKeymapExtension, BaseKeymapOptions } from '@remirror/extension-base-keymap';
 import { DocExtension, DocOptions } from '@remirror/extension-doc';
+import { EventsExtension } from '@remirror/extension-events';
 import { GapCursorExtension } from '@remirror/extension-gap-cursor';
 import { HistoryExtension, HistoryOptions } from '@remirror/extension-history';
 import { ParagraphExtension } from '@remirror/extension-paragraph';
@@ -105,6 +106,7 @@ export class CorePreset extends Preset<CorePresetOptions> {
       newGroupDelay,
     } = this.options;
 
+    const eventsExtension = new EventsExtension();
     const gapCursorExtension = new GapCursorExtension();
     const docExtension = new DocExtension({ content });
     const textExtension = new TextExtension();
@@ -141,6 +143,7 @@ export class CorePreset extends Preset<CorePresetOptions> {
       positionerExtension,
       baseKeymapExtension,
       gapCursorExtension,
+      eventsExtension,
     ];
   }
 }

--- a/packages/jest-prosemirror/package.json
+++ b/packages/jest-prosemirror/package.json
@@ -29,7 +29,7 @@
     "@remirror/core-types": "^1.0.0-next.13",
     "@remirror/core-utils": "^1.0.0-next.12",
     "@remirror/pm": "^1.0.0-next.4",
-    "@testing-library/dom": "^7.21.5",
+    "@testing-library/dom": "^7.21.6",
     "@types/prosemirror-schema-basic": "^1.0.1",
     "@types/prosemirror-test-builder": "^1.0.1",
     "chalk": "^4.1.0",

--- a/packages/jest-remirror/package.json
+++ b/packages/jest-remirror/package.json
@@ -26,7 +26,7 @@
     "@remirror/core": "^1.0.0-next.13",
     "@remirror/dom": "^1.0.0-next.13",
     "@remirror/pm": "^1.0.0-next.4",
-    "@testing-library/dom": "^7.21.5",
+    "@testing-library/dom": "^7.21.6",
     "@types/node": "^14.0.26",
     "@types/sanitize-html": "^1.23.3",
     "jest-prosemirror": "^1.0.0-next.3",

--- a/packages/remirror/extension/events/package.json
+++ b/packages/remirror/extension/events/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "dist/remirror.cjs.js",
+  "module": "dist/remirror.esm.js",
+  "types": "dist/remirror.cjs.d.ts",
+  "preconstruct": {
+    "source": "../../src/extension/events"
+  }
+}

--- a/packages/remirror/package.json
+++ b/packages/remirror/package.json
@@ -52,6 +52,7 @@
     "@remirror/extension-drop-cursor": "^1.0.0-next.13",
     "@remirror/extension-emoji": "^1.0.0-next.13",
     "@remirror/extension-epic-mode": "^1.0.0-next.13",
+    "@remirror/extension-events": "^0.0.0",
     "@remirror/extension-gap-cursor": "^1.0.0-next.13",
     "@remirror/extension-hard-break": "^1.0.0-next.13",
     "@remirror/extension-heading": "^1.0.0-next.13",

--- a/packages/remirror/src/extension/events.ts
+++ b/packages/remirror/src/extension/events.ts
@@ -1,0 +1,1 @@
+export * from '@remirror/extension-events';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,18 @@ importers:
       '@babel/runtime': ^7.10.5
       '@remirror/core': ^1.0.0-next.13
       '@remirror/pm': ^1.0.0-next.4
+  packages/@remirror/extension-events:
+    dependencies:
+      '@babel/runtime': 7.10.5
+    devDependencies:
+      '@remirror/core': 'link:../core'
+      '@remirror/pm': 'link:../pm'
+      '@testing-library/dom': 7.21.6
+    specifiers:
+      '@babel/runtime': ^7.10.5
+      '@remirror/core': ^1.0.0-next.13
+      '@remirror/pm': ^1.0.0-next.4
+      '@testing-library/dom': ^7.21.6
   packages/@remirror/extension-gap-cursor:
     dependencies:
       '@babel/runtime': 7.10.5
@@ -900,6 +912,7 @@ importers:
       '@babel/runtime': 7.10.5
       '@remirror/extension-base-keymap': 'link:../extension-base-keymap'
       '@remirror/extension-doc': 'link:../extension-doc'
+      '@remirror/extension-events': 'link:../extension-events'
       '@remirror/extension-gap-cursor': 'link:../extension-gap-cursor'
       '@remirror/extension-history': 'link:../extension-history'
       '@remirror/extension-paragraph': 'link:../extension-paragraph'
@@ -913,6 +926,7 @@ importers:
       '@remirror/core': ^1.0.0-next.13
       '@remirror/extension-base-keymap': ^1.0.0-next.13
       '@remirror/extension-doc': ^1.0.0-next.13
+      '@remirror/extension-events': ^0.0.0
       '@remirror/extension-gap-cursor': ^1.0.0-next.13
       '@remirror/extension-history': ^1.0.0-next.13
       '@remirror/extension-paragraph': ^1.0.0-next.13
@@ -1359,7 +1373,7 @@ importers:
       '@remirror/core-types': 'link:../@remirror/core-types'
       '@remirror/core-utils': 'link:../@remirror/core-utils'
       '@remirror/pm': 'link:../@remirror/pm'
-      '@testing-library/dom': 7.21.5
+      '@testing-library/dom': 7.21.6
       '@types/prosemirror-schema-basic': 1.0.1
       '@types/prosemirror-test-builder': 1.0.1
       chalk: 4.1.0
@@ -1377,7 +1391,7 @@ importers:
       '@remirror/core-types': ^1.0.0-next.13
       '@remirror/core-utils': ^1.0.0-next.12
       '@remirror/pm': ^1.0.0-next.4
-      '@testing-library/dom': ^7.21.5
+      '@testing-library/dom': ^7.21.6
       '@types/prosemirror-schema-basic': ^1.0.1
       '@types/prosemirror-test-builder': ^1.0.1
       chalk: ^4.1.0
@@ -1393,7 +1407,7 @@ importers:
       '@remirror/core': 'link:../@remirror/core'
       '@remirror/dom': 'link:../@remirror/dom'
       '@remirror/pm': 'link:../@remirror/pm'
-      '@testing-library/dom': 7.21.5
+      '@testing-library/dom': 7.21.6
       '@types/node': 14.0.26
       '@types/sanitize-html': 1.23.3
       jest-prosemirror: 'link:../jest-prosemirror'
@@ -1407,7 +1421,7 @@ importers:
       '@remirror/core': ^1.0.0-next.13
       '@remirror/dom': ^1.0.0-next.13
       '@remirror/pm': ^1.0.0-next.4
-      '@testing-library/dom': ^7.21.5
+      '@testing-library/dom': ^7.21.6
       '@types/node': ^14.0.26
       '@types/sanitize-html': ^1.23.3
       jest: ^26.1.0
@@ -1497,6 +1511,7 @@ importers:
       '@remirror/extension-drop-cursor': 'link:../@remirror/extension-drop-cursor'
       '@remirror/extension-emoji': 'link:../@remirror/extension-emoji'
       '@remirror/extension-epic-mode': 'link:../@remirror/extension-epic-mode'
+      '@remirror/extension-events': 'link:../@remirror/extension-events'
       '@remirror/extension-gap-cursor': 'link:../@remirror/extension-gap-cursor'
       '@remirror/extension-hard-break': 'link:../@remirror/extension-hard-break'
       '@remirror/extension-heading': 'link:../@remirror/extension-heading'
@@ -1557,6 +1572,7 @@ importers:
       '@remirror/extension-drop-cursor': ^1.0.0-next.13
       '@remirror/extension-emoji': ^1.0.0-next.13
       '@remirror/extension-epic-mode': ^1.0.0-next.13
+      '@remirror/extension-events': ^0.0.0
       '@remirror/extension-gap-cursor': ^1.0.0-next.13
       '@remirror/extension-hard-break': ^1.0.0-next.13
       '@remirror/extension-heading': ^1.0.0-next.13
@@ -6526,18 +6542,17 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-IXjKRTAH31nQ+mx6q3IPw85RTLul8VlWBm1rxURoxDt7JI0HPlAAfbtrKTdeq83XYCYO7HSHogyV+OsD+6FX0Q==
-  /@testing-library/dom/7.21.5:
+  /@testing-library/dom/7.21.6:
     dependencies:
       '@babel/runtime': 7.10.5
       '@types/aria-query': 4.2.0
       aria-query: 4.2.2
       dom-accessibility-api: 0.4.6
       pretty-format: 25.5.0
-    dev: false
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-zZqC5T/9Upjs0/3hyrYNpGxw75dr/bLLD27pUdb3WWJ50JHwutvnQ1FJNHbVth9f2hLzEnh7hBdZ9pD++8pJ8g==
+      integrity: sha512-Xj6AMM9Xb24NSeann91fmXFuyJEzZ1lpVgiaPiy/KY2pNX9y4OeDrEm2ZYZt6mfZgFSGZW0eEWpF7YfcvRq5LQ==
   /@testing-library/jest-dom/5.11.1:
     dependencies:
       '@babel/runtime': 7.10.5


### PR DESCRIPTION
## Description

### `Handler`

Add support for `Handler` options with custom return values and early returns.

Previously handlers would ignore any return values. Now a handler will honour the return value. The earlyReturn value can be specified in the static options using the `extensionDecorator`. Currently it only supports primitives. Support for a function to check the return value will be added later.

### `@remirror/extension-events`

🎉 New extension `@remirror/extension-events`.

This extension adds handlers for the events happening within the remirror editor. The extension is part of the `CorePreset` but it doesn't make it's handlers available to the preset. In order to use the handlers you will need direct access to the `EventsExtension`.

```ts
import { EventsExtension } from 'remirror/extension-events';
import { useExtension } from 'remirror/react';
const Editor = () => {
  useExtension(
    EventsExtension,
    ({ addHandler }) => {
      addHandler('focus', () => log('focused'));
    },
    [],
  );
};
```

To begin with the only events added are `focus` and `blur`.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
