### PR TITLE
fix(extension-emoji): prevent mid word emoji popup

### DIFF
--- a/.changeset/clever-ears-hang.md
+++ b/.changeset/clever-ears-hang.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-emoji': minor
+'remirror': patch
+---
+
+Prevent mid word emoji matches on colon press.

--- a/packages/@remirror/extension-emoji/src/__tests__/emoji-extension.spec.ts
+++ b/packages/@remirror/extension-emoji/src/__tests__/emoji-extension.spec.ts
@@ -137,6 +137,23 @@ describe('suggestions', () => {
         expect(content.state.doc).toEqualRemirrorDocument(doc(p('😃👍')));
       });
   });
+
+  it('does not suggest emoji mid-word', () => {
+    const {
+      nodes: { doc, p },
+      add,
+    } = create();
+
+    add(doc(p('a<cursor>')))
+      .insertText(':')
+      .callback(() => {
+        expect(onChange).not.toHaveBeenCalled();
+      })
+      .press('Enter')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(doc(p('a:'), p('')));
+      });
+  });
 });
 
 describe('commands', () => {
@@ -170,13 +187,11 @@ describe('commands', () => {
     add(doc(p('<cursor>')))
       .callback(({ commands, view }) => {
         commands.insertEmojiByName('heart');
-
         expect(view.state.doc).toEqualRemirrorDocument(doc(p('❤️')));
       })
       .overwrite(doc(p('abcde')))
       .callback(({ commands, view }) => {
         commands.insertEmojiByName('heart', { from: 3, to: 4 });
-
         expect(view.state.doc).toEqualRemirrorDocument(doc(p('ab❤️de')));
       });
   });

--- a/packages/@remirror/extension-emoji/src/emoji-extension.ts
+++ b/packages/@remirror/extension-emoji/src/emoji-extension.ts
@@ -201,7 +201,7 @@ export class EmojiExtension extends PlainExtension<EmojiOptions> {
   createSuggestions(): Suggestion {
     return {
       noDecorations: true,
-      invalidPrefixCharacters: escapeStringRegex(this.options.suggestionCharacter),
+      invalidPrefixCharacters: `${escapeStringRegex(this.options.suggestionCharacter)}|\\w`,
       char: this.options.suggestionCharacter,
       name: this.name,
       appendText: '',


### PR DESCRIPTION
## Description

- Prevent mid word emoji matches on colon press.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

![2020-07-30 11 34 03](https://user-images.githubusercontent.com/1160934/88921227-117b1e80-d266-11ea-97b4-e2d014410a78.gif)