### PR TITLE
feat(core): add option `excludeExtensions` to `CorePreset`

### DIFF
--- a/.changeset/nice-files-explode.md
+++ b/.changeset/nice-files-explode.md
@@ -1,5 +1,6 @@
 ---
-'@remirror/core': minor
+'@remirror/core': major
+'remirror': patch
 ---
 
 Add the option `excludeExtensions` to `CorePreset`'s `constructor` to exclude any extensions.

--- a/.changeset/nice-files-explode.md
+++ b/.changeset/nice-files-explode.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core': minor
+---
+
+Add the option `excludeExtensions` to `CorePreset`'s `constructor` to exclude any extensions.
+
+Remove the option `excludeHistory` from `CorePreset`'s `constructor`.

--- a/packages/@remirror/preset-core/src/core-preset.ts
+++ b/packages/@remirror/preset-core/src/core-preset.ts
@@ -124,7 +124,7 @@ export class CorePreset extends Preset<CorePresetOptions> {
     type ExcludeExtensionKey = typeof excludeExtensions[number];
     const excludeMap: Partial<Record<ExcludeExtensionKey, boolean>> = {};
 
-    for (const name of excludeExtensions || []) {
+    for (const name of excludeExtensions ?? []) {
       excludeMap[name] = true;
     }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Closes #408 

This PR has two modification for the constructor of `CorePreset`:

1. Add a new option call `excludeExtensions`, which is an array of names.
2. Remove option `excludeHistory `

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 