### PR TITLE
feat(core): add new helper methods

### DIFF
--- a/.changeset/big-apples-unite.md
+++ b/.changeset/big-apples-unite.md
@@ -1,0 +1,9 @@
+---
+'@remirror/core-utils': major
+'@remirror/core': major
+'remirror': major
+---
+
+Add three new helpers to `@remirror/core-utils` / `@remirror/core`: `isStateEqual`, `areSchemaCompatible` and `getRemirrorJSON`.
+
+BREAKING: 💥 Rename `getObjectNode` to `getRemirrorJSON`.

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -86,13 +86,16 @@ export function createEditor<Schema extends EditorSchema = EditorSchema>(
   options: CreateEditorOptions = object(),
 ) {
   const { plugins = [], rules = [], autoClean = true, ...editorOptions } = options;
-  const place = document.createElement('div');
-  document.body.append(place);
+  const element = document.createElement('div');
   const state = createState(taggedDocument, [...plugins, inputRules({ rules })]);
-  const view = new EditorView<Schema>(place, { state, ...editorOptions }) as TestEditorView<Schema>;
+  const view = new EditorView<Schema>(element, { state, ...editorOptions }) as TestEditorView<
+    Schema
+  >;
+
+  document.body.append(element);
 
   if (autoClean) {
-    cleanupItems.add([view, place]);
+    cleanupItems.add([view, element]);
   }
 
   return new ProsemirrorTestChain(view);


### PR DESCRIPTION

## Description

Add three new helpers to `@remirror/core-utils` / `@remirror/core`: `isStateEqual`, `areSchemaCompatible` and `getRemirrorJSON`. Requested by @benjie 



BREAKING: 💥 Rename `getObjectNode` to `getRemirrorJSON`.




<!-- Describe your changes in detail and reference any issues it addresses-->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

