### PR TITLE
feat(extension-horizontal-rule): auto append node

### DIFF
--- a/.changeset/early-shoes-bathe.md
+++ b/.changeset/early-shoes-bathe.md
@@ -1,0 +1,15 @@
+---
+'@remirror/extension-horizontal-rule': major
+'remirror': major
+'@remirror/styles': major
+---
+
+Default to inserting a new paragraph node after the `HorizontalRuleExtension`.
+
+BREAKING: 💥 Rename `horizonalRule` command to `insertHorizontalRule`.
+
+Add a new option `insertionNode` to the `HorizontalRuleExtension` which sets the default node to automatically append after insertion.
+
+Update the css styles for the default `hr` tag.
+
+Closes #417

--- a/.changeset/wet-islands-jam.md
+++ b/.changeset/wet-islands-jam.md
@@ -1,0 +1,8 @@
+---
+'@remirror/extension-hard-break': minor
+'remirror': minor
+---
+
+Add `insertHardBreak` command.
+
+Add inline documentation instructing developers to use the `TrailingNodeExtension` when using `hardBreak` to exit a `codeBlock`.

--- a/packages/@remirror/core/src/styles.ts
+++ b/packages/@remirror/core/src/styles.ts
@@ -24,6 +24,10 @@ export const editorStyles = css`
     &[contenteditable='true'] {
       white-space: pre-wrap;
     }
+
+    hr {
+      border-color: #2e2e2e;
+    }
   }
 
   .ProseMirror-hideselection {

--- a/packages/@remirror/extension-hard-break/src/__tests__/hard-break-extension.spec.ts
+++ b/packages/@remirror/extension-hard-break/src/__tests__/hard-break-extension.spec.ts
@@ -1,7 +1,23 @@
+import { renderEditor } from 'jest-remirror';
+
+import { isTextSelection } from '@remirror/core';
 import { isExtensionValid } from '@remirror/testing';
 
 import { HardBreakExtension } from '..';
 
 test('is valid', () => {
   expect(isExtensionValid(HardBreakExtension, {}));
+});
+
+describe('commands', () => {
+  it('insertHardBreak', () => {
+    const { add, nodes, commands, view } = renderEditor([new HardBreakExtension()]);
+    const { doc, hardBreak: br, p } = nodes;
+
+    add(doc(p('This is content<cursor>')));
+    commands.insertHardBreak();
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content', br())));
+    expect(isTextSelection(view.state.selection)).toBe(true);
+  });
 });

--- a/packages/@remirror/extension-hard-break/src/hard-break-extension.ts
+++ b/packages/@remirror/extension-hard-break/src/hard-break-extension.ts
@@ -1,6 +1,7 @@
 import {
   ApplySchemaAttributes,
   chainCommands,
+  CommandFunction,
   convertCommand,
   extensionDecorator,
   KeyBindings,
@@ -9,6 +10,17 @@ import {
 } from '@remirror/core';
 import { exitCode } from '@remirror/pm/commands';
 
+/**
+ * An extension which provides the functionality for inserting a `hardBreak`
+ * `<br />` tag into the editor.
+ *
+ * @remarks
+ *
+ * It will automatically exit when used inside a `codeClock`. To
+ * prevent problems occurring when the codeblock is the last node in the
+ * doc, you should add the `TrailingNodeExtension` which automatically appends a
+ * paragraph node to the last node..
+ */
 @extensionDecorator({})
 export class HardBreakExtension extends NodeExtension {
   get name() {
@@ -27,17 +39,30 @@ export class HardBreakExtension extends NodeExtension {
   }
 
   createKeymap(): KeyBindings {
-    const command = chainCommands(convertCommand(exitCode), ({ state, dispatch }) => {
-      if (dispatch) {
-        dispatch(state.tr.replaceSelectionWith(this.type.create()).scrollIntoView());
-      }
-
+    const command = chainCommands(convertCommand(exitCode), () => {
+      this.store.getCommands().insertHardBreak();
       return true;
     });
 
     return {
       'Mod-Enter': command,
       'Shift-Enter': command,
+    };
+  }
+
+  createCommands() {
+    return {
+      /**
+       * Inserts a hardBreak `<br />` tag into the editor.
+       */
+      insertHardBreak: (): CommandFunction => (parameter) => {
+        const { tr, dispatch } = parameter;
+
+        // Create the `hardBreak`
+        dispatch?.(tr.replaceSelectionWith(this.type.create()).scrollIntoView());
+
+        return true;
+      },
     };
   }
 }

--- a/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
+++ b/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
@@ -1,7 +1,36 @@
+import { renderEditor } from 'jest-remirror';
+
+import { isNodeSelection, isTextSelection } from '@remirror/core';
 import { isExtensionValid } from '@remirror/testing';
 
 import { HorizontalRuleExtension } from '..';
 
 test('is valid', () => {
   expect(isExtensionValid(HorizontalRuleExtension, {}));
+});
+
+describe('insertHorizontalRule', () => {
+  it('adds a trailing node by default', () => {
+    const { add, nodes, commands, view } = renderEditor([new HorizontalRuleExtension()]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This is content<cursor>')));
+    commands.insertHorizontalRule();
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content'), hr(), p()));
+    expect(isTextSelection(view.state.selection)).toBe(true);
+  });
+
+  it('does not add a trailing node when set to false', () => {
+    const { add, nodes, commands, view } = renderEditor([
+      new HorizontalRuleExtension({ insertionNode: false }),
+    ]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This is content<cursor>')));
+    commands.insertHorizontalRule();
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content'), hr()));
+    expect(isNodeSelection(view.state.selection)).toBe(true);
+  });
 });

--- a/packages/@remirror/styles/all.css
+++ b/packages/@remirror/styles/all.css
@@ -27,6 +27,10 @@
   white-space: pre-wrap;
 }
 
+.remirror-editor.ProseMirror hr {
+  border-color: #2e2e2e;
+}
+
 .remirror-editor .ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }

--- a/packages/@remirror/styles/core.css
+++ b/packages/@remirror/styles/core.css
@@ -27,6 +27,10 @@
   white-space: pre-wrap;
 }
 
+.remirror-editor.ProseMirror hr {
+  border-color: #2e2e2e;
+}
+
 .remirror-editor .ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }


### PR DESCRIPTION
## Description

- Default to inserting a new paragraph node after the `HorizontalRuleExtension`.
- BREAKING: 💥 Rename `horizonalRule` command to `insertHorizontalRule`.
- Add a new option `insertionNode` to the `HorizontalRuleExtension` which sets the default node to automatically append after insertion.
- Update the css styles for the default `hr` tag.

Closes #417

- Add `insertHardBreak` command.
- Add inline documentation instructing developers to use the `TrailingNodeExtension` when using `hardBreak` to exit a `codeBlock`.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

![2020-07-30 21 13 20](https://user-images.githubusercontent.com/1160934/88970344-29749180-d2aa-11ea-93a2-eb9f548862e1.gif)
