### PR TITLE
fix: multiple commands issue

### DIFF
--- a/.changeset/beige-birds-develop.md
+++ b/.changeset/beige-birds-develop.md
@@ -1,0 +1,5 @@
+---
+'jest-remirror': minor
+---
+
+Add `chain` method to `RemirrorTestChain` and update select text to receive `all` for selecting all text.

--- a/.changeset/modern-pens-judge.md
+++ b/.changeset/modern-pens-judge.md
@@ -1,0 +1,16 @@
+---
+'@remirror/core': minor
+'@remirror/core-utils': minor
+'@remirror/extension-code': minor
+'@remirror/extension-code-block': minor
+'@remirror/extension-heading': minor
+'@remirror/extension-italic': minor
+'@remirror/extension-paragraph': minor
+'@remirror/extension-strike': minor
+'@remirror/extension-underline': minor
+'remirror': minor
+---
+
+Support `chained` commands and multiple command updates in controlled editors.
+
+Fixes #418

--- a/.changeset/tame-points-build.md
+++ b/.changeset/tame-points-build.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-history': patch
+'@remirror/extension-yjs': patch
+'remirror': patch
+---
+
+Use `NonChainableCommandFunction` annotation to indicate commands are not chainable.

--- a/packages/@remirror/core-utils/src/prosemirror-utils.ts
+++ b/packages/@remirror/core-utils/src/prosemirror-utils.ts
@@ -16,7 +16,6 @@ import {
   CommandFunction,
   EditorSchema,
   EditorState,
-  EditorStateParameter,
   EditorView,
   EmptyShape,
   Fragment,
@@ -519,10 +518,12 @@ export function hasTransactionChanged(tr: Transaction) {
   return tr.docChanged || tr.selectionSet;
 }
 
-interface IsNodeActiveParameter
-  extends EditorStateParameter,
-    NodeTypeParameter,
-    Partial<AttributesParameter> {}
+interface IsNodeActiveParameter extends NodeTypeParameter, Partial<AttributesParameter> {
+  /**
+   * State or transaction parameter.
+   */
+  state: EditorState | Transaction;
+}
 
 /**
  * Checks whether the node type passed in is active within the region. Used by

--- a/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
@@ -1,7 +1,34 @@
-import { isExtensionValid } from '@remirror/testing';
+import { renderEditor } from 'jest-remirror';
+
+import { BoldExtension, isExtensionValid, ItalicExtension } from '@remirror/testing';
 
 import { CommandsExtension } from '..';
 
 test('is commands extension valid', () => {
   expect(isExtensionValid(CommandsExtension, {}));
+});
+
+test('can call multiple commands', () => {
+  const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
+  const { doc, p } = editor.nodes;
+  const { bold, italic } = editor.marks;
+  const { commands } = editor;
+
+  editor.add(doc(p('<start>my content<end>')));
+  commands.toggleBold();
+  commands.toggleItalic();
+
+  expect(editor.state.doc).toEqualRemirrorDocument(doc(p(bold(italic('my content')))));
+});
+
+test('can chain commands', () => {
+  const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
+  const { doc, p } = editor.nodes;
+  const { bold, italic } = editor.marks;
+  const { chain } = editor;
+
+  editor.add(doc(p('<start>my content<end>')));
+  chain.toggleBold().toggleItalic().run();
+
+  expect(editor.state.doc).toEqualRemirrorDocument(doc(p(bold(italic('my content')))));
 });

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -2,7 +2,6 @@ import refractor from 'refractor/core';
 
 import {
   ApplySchemaAttributes,
-  convertCommand,
   CreatePluginReturn,
   extensionDecorator,
   findNodeAtSelection,
@@ -23,9 +22,9 @@ import {
   PosParameter,
   removeNodeAtPosition,
   replaceNodeAtPosition,
+  setBlockType,
   toggleBlockItem,
 } from '@remirror/core';
-import { setBlockType } from '@remirror/pm/commands';
 import { keydownHandler } from '@remirror/pm/keymap';
 import { TextSelection } from '@remirror/pm/state';
 
@@ -128,7 +127,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
        * ```
        */
       createCodeBlock: (attributes: CodeBlockAttributes) => {
-        return convertCommand(setBlockType(this.type, attributes));
+        return setBlockType(this.type, attributes);
       },
 
       /**

--- a/packages/@remirror/extension-code/src/code-extension.ts
+++ b/packages/@remirror/extension-code/src/code-extension.ts
@@ -1,7 +1,7 @@
 import {
   ApplySchemaAttributes,
-  convertCommand,
   extensionDecorator,
+  InputRule,
   KeyBindings,
   LEAF_NODE_REPLACING_CHARACTER,
   MarkExtension,
@@ -9,8 +9,9 @@ import {
   MarkGroup,
   markInputRule,
   markPasteRule,
+  Plugin,
+  toggleMark,
 } from '@remirror/core';
-import { toggleMark } from '@remirror/pm/commands';
 
 /**
  * Add a `code` mark to the editor. This is used to mark inline text as a code snippet.
@@ -32,7 +33,7 @@ export class CodeExtension extends MarkExtension {
 
   createKeymap(): KeyBindings {
     return {
-      'Mod-`': convertCommand(toggleMark(this.type)),
+      'Mod-`': toggleMark({ type: this.type }),
     };
   }
 
@@ -41,11 +42,11 @@ export class CodeExtension extends MarkExtension {
       /**
        * Toggle the current selection as a code mark.
        */
-      toggleCode: () => convertCommand(toggleMark(this.type)),
+      toggleCode: () => toggleMark({ type: this.type }),
     };
   }
 
-  createInputRules() {
+  createInputRules(): InputRule[] {
     return [
       markInputRule({
         regexp: new RegExp(`(?:\`)([^\`${LEAF_NODE_REPLACING_CHARACTER}]+)(?:\`)$`),
@@ -54,7 +55,7 @@ export class CodeExtension extends MarkExtension {
     ];
   }
 
-  createPasteRules() {
+  createPasteRules(): Plugin[] {
     return [markPasteRule({ regexp: /`([^`]+)`/g, type: this.type })];
   }
 }

--- a/packages/@remirror/extension-heading/src/heading-extension.ts
+++ b/packages/@remirror/extension-heading/src/heading-extension.ts
@@ -1,6 +1,5 @@
 import {
   ApplySchemaAttributes,
-  convertCommand,
   extensionDecorator,
   KeyBindings,
   NodeExtension,
@@ -9,10 +8,10 @@ import {
   object,
   ProsemirrorAttributes,
   ProsemirrorNode,
+  setBlockType,
   Static,
   toggleBlockItem,
 } from '@remirror/core';
-import { setBlockType } from '@remirror/pm/commands';
 import { textblockTypeInputRule } from '@remirror/pm/inputrules';
 
 export interface HeadingOptions {
@@ -98,7 +97,7 @@ export class HeadingExtension extends NodeExtension<HeadingOptions> {
     const keys: KeyBindings = object();
 
     this.options.levels.forEach((level) => {
-      keys[`Shift-Ctrl-${level}`] = convertCommand(setBlockType(this.type, { level }));
+      keys[`Shift-Ctrl-${level}`] = setBlockType(this.type, { level });
     });
     return keys;
   }

--- a/packages/@remirror/extension-history/src/history-extension.ts
+++ b/packages/@remirror/extension-history/src/history-extension.ts
@@ -7,6 +7,7 @@ import {
   Handler,
   isFunction,
   KeyBindings,
+  nonChainable,
   PlainExtension,
   ProsemirrorCommandFunction,
   Static,
@@ -152,7 +153,7 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
        * tr.setMeta(pluginKey, { addToHistory: false })
        * ```
        */
-      undo: () => this.wrapMethod(undo),
+      undo: () => nonChainable(this.wrapMethod(undo)),
 
       /**
        * Redo an action that was in the undo stack.
@@ -161,7 +162,7 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
        * actions.redo()
        * ```
        */
-      redo: () => this.wrapMethod(redo),
+      redo: () => nonChainable(this.wrapMethod(redo)),
     };
   }
 }

--- a/packages/@remirror/extension-italic/src/italic-extension.ts
+++ b/packages/@remirror/extension-italic/src/italic-extension.ts
@@ -1,15 +1,17 @@
 import {
   ApplySchemaAttributes,
-  convertCommand,
   extensionDecorator,
+  FromToParameter,
+  InputRule,
   KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
   markInputRule,
   markPasteRule,
+  Plugin,
+  toggleMark,
 } from '@remirror/core';
-import { toggleMark } from '@remirror/pm/commands';
 
 @extensionDecorator({})
 export class ItalicExtension extends MarkExtension {
@@ -33,7 +35,7 @@ export class ItalicExtension extends MarkExtension {
 
   createKeymap(): KeyBindings {
     return {
-      'Mod-i': convertCommand(toggleMark(this.type)),
+      'Mod-i': toggleMark({ type: this.type }),
     };
   }
 
@@ -42,15 +44,15 @@ export class ItalicExtension extends MarkExtension {
       /**
        * Toggle the italic formatting on the selected text.
        */
-      toggleItalic: () => convertCommand(toggleMark(this.type)),
+      toggleItalic: (range?: FromToParameter) => toggleMark({ type: this.type, range }),
     };
   }
 
-  createInputRules() {
+  createInputRules(): InputRule[] {
     return [markInputRule({ regexp: /(?:^|[^*_])[*_]([^*_]+)[*_]$/, type: this.type })];
   }
 
-  createPasteRules() {
+  createPasteRules(): Plugin[] {
     return [markPasteRule({ regexp: /(?:^|[^*_])[*_]([^*_]+)[*_]/g, type: this.type })];
   }
 }

--- a/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
+++ b/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
@@ -1,6 +1,5 @@
 import {
   ApplySchemaAttributes,
-  convertCommand,
   extensionDecorator,
   ExtensionPriority,
   ExtensionTag,
@@ -8,8 +7,8 @@ import {
   NodeExtensionSpec,
   NodeGroup,
   ProsemirrorAttributes,
+  setBlockType,
 } from '@remirror/core';
-import { setBlockType } from '@remirror/pm/commands';
 
 /**
  * The paragraph is one of the essential building blocks for a prosemirror
@@ -56,12 +55,8 @@ export class ParagraphExtension extends NodeExtension {
   createCommands() {
     return {
       createParagraph: (attributes: ProsemirrorAttributes) => {
-        return convertCommand(setBlockType(this.type, attributes));
+        return setBlockType(this.type, attributes);
       },
     };
   }
 }
-
-/**
- * The possible values for text alignment.
- */

--- a/packages/@remirror/extension-strike/src/strike-extension.ts
+++ b/packages/@remirror/extension-strike/src/strike-extension.ts
@@ -1,16 +1,20 @@
 import {
   ApplySchemaAttributes,
-  convertCommand,
   extensionDecorator,
+  InputRule,
   KeyBindings,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
   markInputRule,
   markPasteRule,
+  Plugin,
+  toggleMark,
 } from '@remirror/core';
-import { toggleMark } from '@remirror/pm/commands';
 
+/**
+ * The extension for adding strike-through marks to the editor.
+ */
 @extensionDecorator({})
 export class StrikeExtension extends MarkExtension {
   get name() {
@@ -45,7 +49,7 @@ export class StrikeExtension extends MarkExtension {
 
   createKeymap(): KeyBindings {
     return {
-      'Mod-d': convertCommand(toggleMark(this.type)),
+      'Mod-d': toggleMark({ type: this.type }),
     };
   }
 
@@ -54,15 +58,15 @@ export class StrikeExtension extends MarkExtension {
       /**
        * Toggle the strike through formatting annotation.
        */
-      toggleStrike: () => convertCommand(toggleMark(this.type)),
+      toggleStrike: () => toggleMark({ type: this.type }),
     };
   }
 
-  createInputRules() {
+  createInputRules(): InputRule[] {
     return [markInputRule({ regexp: /~([^~]+)~$/, type: this.type })];
   }
 
-  createPasteRules() {
+  createPasteRules(): Plugin[] {
     return [markPasteRule({ regexp: /~([^~]+)~/g, type: this.type })];
   }
 }

--- a/packages/@remirror/extension-underline/src/underline-extension.ts
+++ b/packages/@remirror/extension-underline/src/underline-extension.ts
@@ -1,12 +1,11 @@
 import {
   ApplySchemaAttributes,
-  convertCommand,
   extensionDecorator,
   MarkExtension,
   MarkExtensionSpec,
   MarkGroup,
+  toggleMark,
 } from '@remirror/core';
-import { toggleMark } from '@remirror/pm/commands';
 
 @extensionDecorator({})
 export class UnderlineExtension extends MarkExtension {
@@ -34,7 +33,7 @@ export class UnderlineExtension extends MarkExtension {
 
   createKeymap() {
     return {
-      'Mod-u': convertCommand(toggleMark(this.type)),
+      'Mod-u': toggleMark({ type: this.type }),
     };
   }
 
@@ -43,7 +42,7 @@ export class UnderlineExtension extends MarkExtension {
       /**
        * Toggle the underline formatting of the selected text.
        */
-      toggleUnderline: () => convertCommand(toggleMark(this.type)),
+      toggleUnderline: () => toggleMark({ type: this.type }),
     };
   }
 }

--- a/packages/@remirror/extension-yjs/src/yjs-extension.ts
+++ b/packages/@remirror/extension-yjs/src/yjs-extension.ts
@@ -9,7 +9,6 @@ import {
   extensionDecorator,
   ExtensionPriority,
   isFunction,
-  nonChainable,
   OnSetOptionsParameter,
   PlainExtension,
   Static,
@@ -106,12 +105,12 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
       /**
        * Undo within a collaborative editor.
        */
-      yUndo: (): CommandFunction => nonChainable(convertCommand(undo)),
+      yUndo: (): CommandFunction => convertCommand(undo),
 
       /**
        * Redo, within a collaborative editor.
        */
-      yRedo: (): CommandFunction => nonChainable(convertCommand(redo)),
+      yRedo: (): CommandFunction => convertCommand(redo),
     };
   }
 


### PR DESCRIPTION
## Description

- Add `chain` method to `RemirrorTestChain` and update select text to receive `all` for selecting all text.
- Support `chained` commands and multiple command updates in controlled editors.

Fixes #418

- Use `NonChainableCommandFunction` annotation to indicate commands are not chainable.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
