### PR TITLE
Hot fix chained command support

### DIFF
--- a/.changeset/proud-goats-draw.md
+++ b/.changeset/proud-goats-draw.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-bold': minor
+'remirror': patch
+---
+
+Support chaining for `setBold` and `removeBold` commands.

--- a/.changeset/small-timers-smoke.md
+++ b/.changeset/small-timers-smoke.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': minor
+'remirror': patch
+---
+
+Make sure the `transaction` has all the latest updates if changed between `onStateUpdate` events. This allows chaining to be supported properly.

--- a/packages/@remirror/extension-bold/src/bold-extension.ts
+++ b/packages/@remirror/extension-bold/src/bold-extension.ts
@@ -102,10 +102,8 @@ export class BoldExtension extends MarkExtension<BoldOptions> {
        * TODO add selection support.
        * TODO add check to see that provided range is valid.
        */
-      setBold: (range: FromToParameter): CommandFunction => ({ state, dispatch }) => {
-        if (dispatch) {
-          dispatch(state.tr.addMark(range?.from, range?.to, this.type.create()));
-        }
+      setBold: (range: FromToParameter): CommandFunction => ({ tr, dispatch }) => {
+        dispatch?.(tr.addMark(range?.from, range?.to, this.type.create()));
 
         return true;
       },
@@ -116,10 +114,8 @@ export class BoldExtension extends MarkExtension<BoldOptions> {
        * TODO add selection support.
        * TODO add check that the provided range is valid.
        */
-      removeBold: (range: FromToParameter): CommandFunction => ({ state, dispatch }) => {
-        if (dispatch) {
-          dispatch(state.tr.removeMark(range?.from, range?.to, this.type));
-        }
+      removeBold: (range: FromToParameter): CommandFunction => ({ tr, dispatch }) => {
+        dispatch?.(tr.removeMark(range?.from, range?.to, this.type));
 
         return true;
       },


### PR DESCRIPTION
## Description

### `@remirror/extension-bold`

- Support chaining for `setBold` and `removeBold` commands.

### `@remirror/core`

- Make sure the `transaction` has all the latest updates if changed between `onStateUpdate` events. This allows chaining to be supported properly.


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

## Screenshots

![2020-07-31 06 46 10](https://user-images.githubusercontent.com/1160934/89004229-9bc09280-d2f9-11ea-90df-a70d0fe348b4.gif)
