### PR TITLE
fix(jest-remirror): add missing dependency `@remirror/preset-core`

### DIFF
--- a/.changeset/giant-cameras-repair.md
+++ b/.changeset/giant-cameras-repair.md
@@ -1,0 +1,5 @@
+---
+'jest-remirror': patch
+---
+
+Fix the dependencies.

--- a/packages/jest-remirror/package.json
+++ b/packages/jest-remirror/package.json
@@ -26,6 +26,7 @@
     "@remirror/core": "^1.0.0-next.13",
     "@remirror/dom": "^1.0.0-next.13",
     "@remirror/pm": "^1.0.0-next.4",
+    "@remirror/preset-core": "^1.0.0-next.13",
     "@testing-library/dom": "^7.21.6",
     "@types/node": "^14.0.26",
     "@types/sanitize-html": "^1.23.3",

--- a/packages/jest-remirror/src/jest-remirror-types.ts
+++ b/packages/jest-remirror/src/jest-remirror-types.ts
@@ -6,7 +6,7 @@ import {
   ProsemirrorNode,
 } from '@remirror/core';
 import { DomEditorWrapperProps } from '@remirror/dom';
-import { CreateCoreManagerOptions } from '@remirror/testing';
+import { CreateCoreManagerOptions } from '@remirror/preset-core';
 
 export interface BaseFactoryParameter<Schema extends EditorSchema = EditorSchema>
   extends Partial<AttributesParameter> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1411,6 +1411,7 @@ importers:
       '@remirror/core': 'link:../@remirror/core'
       '@remirror/dom': 'link:../@remirror/dom'
       '@remirror/pm': 'link:../@remirror/pm'
+      '@remirror/preset-core': 'link:../@remirror/preset-core'
       '@testing-library/dom': 7.21.6
       '@types/node': 14.0.26
       '@types/sanitize-html': 1.23.3
@@ -1425,6 +1426,7 @@ importers:
       '@remirror/core': ^1.0.0-next.13
       '@remirror/dom': ^1.0.0-next.13
       '@remirror/pm': ^1.0.0-next.4
+      '@remirror/preset-core': ^1.0.0-next.13
       '@testing-library/dom': ^7.21.6
       '@types/node': ^14.0.26
       '@types/sanitize-html': ^1.23.3


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR fixes two small issues for `jest-remirror`:

1. `CreateCoreManagerOptions` should be imported from `@remirror/preset-core` instead of `@remirror/testing`
2. add dependency `@remirror/preset-core` 

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 