### PR TITLE
feat: add `invalidContent` schema handler

### DIFF
--- a/.changeset/new-apricots-travel.md
+++ b/.changeset/new-apricots-travel.md
@@ -1,0 +1,10 @@
+---
+'@remirror/core': minor
+'@remirror/core-helpers': minor
+'@remirror/core-utils': minor
+'remirror': minor
+---
+
+Add `set` and `unset` methods to `@remirror/core-helpers`.
+
+Add a `transformInvalidJSON` for checking that the schema is valid and transforming the nodes with the provided transformer - Closes #426

--- a/packages/@remirror/core-helpers/src/__tests__/core-helper.spec.ts
+++ b/packages/@remirror/core-helpers/src/__tests__/core-helper.spec.ts
@@ -46,6 +46,7 @@ import {
   uniqueArray,
   uniqueBy,
   uniqueId,
+  unset,
   values,
   within,
 } from '../core-helpers';
@@ -359,6 +360,46 @@ test('get', () => {
   expect(get(['nested', 0, 'fake'], obj)).toBeUndefined();
 
   expect(get(['nested', 0, 'fake'], obj, 'fallback')).toBe('fallback');
+});
+
+test('unset', () => {
+  const obj = { a: 'a', b: 'b', nested: [{ awesome: true }] };
+
+  {
+    const value = unset(['unknown'], obj);
+    expect(value).toEqual(obj);
+    expect(value).not.toBe(obj);
+  }
+
+  {
+    const value = unset(['a'], obj);
+    expect(value).toEqual({ b: 'b', nested: [{ awesome: true }] });
+    expect(value).not.toBe(obj);
+  }
+
+  {
+    const value = unset(['nested'], obj);
+    expect(unset(['nested'], obj)).toEqual({ a: 'a', b: 'b' });
+    expect(value).not.toBe(obj);
+  }
+
+  {
+    const value = unset(['nested', 0], obj);
+    expect(unset(['nested', 0], obj)).toEqual({ a: 'a', b: 'b', nested: [] });
+    expect(value).not.toBe(obj);
+  }
+
+  {
+    const value = unset(['nested', 'invalid'], obj);
+    expect(unset(['nested', 'invalid'], obj)).toEqual(obj);
+    expect(value).not.toBe(obj);
+  }
+
+  {
+    const value = unset(['nested', '0'], obj);
+    expect(unset(['nested', '0'], obj)).toEqual({ a: 'a', b: 'b', nested: [] });
+    expect(value).not.toBe(obj);
+  }
 });
 
 test('deepMerge', () => {


### PR DESCRIPTION
## Description

Add `set` and `unset` methods to `@remirror/core-helpers`.

Add a `transformInvalidJSON` for checking that the schema is valid and transforming the nodes with the provided transformer.

## Checklist


- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
