### PR TITLE
feat(prosemirror-suggest): add and remove suggester

### DIFF
--- a/.changeset/hot-schools-appear.md
+++ b/.changeset/hot-schools-appear.md
@@ -1,0 +1,7 @@
+---
+'prosemirror-suggest': minor
+---
+
+Allow runtime additions to the `prosemirror-suggest` plugin.
+
+You can now add suggester configurations to active suggest plugin instances. The name is used as an identifier and identical names will automatically be replaced.

--- a/packages/prosemirror-suggest/src/__tests__/suggest-plugin.spec.ts
+++ b/packages/prosemirror-suggest/src/__tests__/suggest-plugin.spec.ts
@@ -1,7 +1,7 @@
 import { createEditor, doc, p } from 'jest-prosemirror';
 
 import { ExitReason } from '../suggest-constants';
-import { suggest } from '../suggest-plugin';
+import { addSuggester, suggest } from '../suggest-plugin';
 import { SuggestExitHandlerParameter, SuggestKeyBindingParameter } from '../suggest-types';
 
 describe('Suggest Handlers', () => {
@@ -183,4 +183,42 @@ describe('Suggest Ignore', () => {
         expect(tagHandlers.onExit).toHaveBeenCalledTimes(1);
       });
   });
+});
+
+test('addSuggester', () => {
+  const handlers = {
+    onExit: jest.fn(),
+    onChange: jest.fn(),
+  };
+
+  const plugin = suggest();
+  const editor = createEditor(doc(p('<cursor>')), { plugins: [plugin] });
+
+  const remove = addSuggester(editor.view.state, {
+    char: '@',
+    name: 'at',
+    ...handlers,
+    matchOffset: 0,
+  });
+
+  editor
+    .insertText('@')
+    .callback(() => {
+      expect(handlers.onChange).toHaveBeenCalledTimes(1);
+    })
+    .insertText('suggest ');
+
+  expect(handlers.onExit).toHaveBeenCalledTimes(1);
+  remove();
+
+  jest.clearAllMocks();
+
+  editor
+    .insertText('@')
+    .callback(() => {
+      expect(handlers.onChange).not.toHaveBeenCalled();
+    })
+    .insertText('suggest ');
+
+  expect(handlers.onExit).not.toHaveBeenCalled();
 });

--- a/packages/prosemirror-suggest/src/suggest-plugin.ts
+++ b/packages/prosemirror-suggest/src/suggest-plugin.ts
@@ -20,6 +20,30 @@ export function getSuggestPluginState<Schema extends EditorSchema = any>(
 }
 
 /**
+ * Add a new suggester or replace it if the name already exists in the existing
+ * configuration.
+ *
+ * Will return a function for disposing of the added suggester.
+ */
+export function addSuggester<Schema extends EditorSchema = any>(
+  state: EditorState<Schema>,
+  suggester: Suggestion,
+) {
+  return getSuggestPluginState(state).addSuggester(suggester);
+}
+
+/**
+ * Remove a suggester if it exists. Pass in the name or the full suggester
+ * object.
+ */
+export function removeSuggester<Schema extends EditorSchema = any>(
+  state: EditorState<Schema>,
+  suggester: Suggestion | string,
+) {
+  return getSuggestPluginState(state).removeSuggester(suggester);
+}
+
+/**
  * This creates a suggestion plugin with all the suggesters provided.
  *
  * @remarks


### PR DESCRIPTION
## Description

Allow runtime additions to the `prosemirror-suggest` plugin.

You can now add suggester configurations to active suggest plugin instances. The name is used as an identifier and identical names will automatically be replaced.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

