### PR TITLE
feat(extension-placeholder): support `emptyNodeClass` updates

### DIFF
--- a/.changeset/violet-eagles-carry.md
+++ b/.changeset/violet-eagles-carry.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-placeholder': minor
+'@remirror/preset-react': minor
+'remirror': minor
+---
+
+Allow runtime updates of `PlaceholderExtension` `emptyNodeClass` option.

--- a/packages/@remirror/extension-placeholder/src/__tests__/placeholder-extension.spec.ts
+++ b/packages/@remirror/extension-placeholder/src/__tests__/placeholder-extension.spec.ts
@@ -2,6 +2,6 @@ import { isExtensionValid } from '@remirror/testing';
 
 import { PlaceholderExtension } from '../placeholder-extension';
 
-test('is valid', () => {
-  expect(isExtensionValid(PlaceholderExtension, {}));
+test('`PlaceholderExtension`: is valid', () => {
+  expect(isExtensionValid(PlaceholderExtension));
 });

--- a/packages/@remirror/extension-placeholder/src/placeholder-extension.ts
+++ b/packages/@remirror/extension-placeholder/src/placeholder-extension.ts
@@ -89,7 +89,7 @@ export class PlaceholderExtension extends PlainExtension<PlaceholderOptions> {
   onSetOptions(parameter: OnSetOptionsParameter<PlaceholderOptions>) {
     const { changes } = parameter;
 
-    if (changes.placeholder && this.store.phase >= ManagerPhase.EditorView) {
+    if (changes.placeholder.changed && this.store.phase >= ManagerPhase.EditorView) {
       // update the attributes object
       this.store.updateAttributes();
     }

--- a/packages/@remirror/preset-react/src/react-preset.ts
+++ b/packages/@remirror/preset-react/src/react-preset.ts
@@ -3,6 +3,7 @@ import { Children, cloneElement } from 'react';
 
 import {
   isDocNodeEmpty,
+  isEmptyArray,
   isString,
   OnSetOptionsParameter,
   Preset,
@@ -31,11 +32,12 @@ export class ReactPreset extends Preset<ReactPresetOptions> {
    * No properties are defined so this can be ignored.
    */
   protected onSetOptions(parameter: OnSetOptionsParameter<ReactPresetOptions>) {
-    const { changes } = parameter;
+    const { pickChanged } = parameter;
 
-    if (changes.placeholder.changed) {
-      const placeholderExtension = this.getExtension(PlaceholderExtension);
-      placeholderExtension.setOptions({ placeholder: changes.placeholder.value });
+    const placeholderOptions = pickChanged(['emptyNodeClass', 'placeholder']);
+
+    if (!isEmptyArray(placeholderOptions)) {
+      this.getExtension(PlaceholderExtension).setOptions(placeholderOptions);
     }
   }
 


### PR DESCRIPTION
## Description

- Allow runtime updates of `PlaceholderExtension` `emptyNodeClass` option.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
