### PR TITLE
feat(jest-remirror): new validity check helpers

### DIFF
--- a/.changeset/cuddly-lemons-raise.md
+++ b/.changeset/cuddly-lemons-raise.md
@@ -1,0 +1,8 @@
+---
+'jest-remirror': minor
+---
+
+Add validity check function exports to `jest-remirror`.
+
+- `presetValidityTest` for testing your `Preset`.
+- `extensionValidityTest` for testing your `Extension`.

--- a/.changeset/unlucky-beans-share.md
+++ b/.changeset/unlucky-beans-share.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-heading': patch
+---
+
+Support `extraAttributes` in the `HeadingExtension`.
+
+Closes #384

--- a/.changeset/weak-snails-decide.md
+++ b/.changeset/weak-snails-decide.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Public `dynamicKeys` property now available on `Extension`'s and `Preset`'s.

--- a/packages/@remirror/core/src/builtins/__tests__/attributes-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/attributes-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { AttributesExtension } from '..';
 
-test('`AttributesExtension`: is valid', () => {
-  expect(isExtensionValid(AttributesExtension)).toBeTrue();
-});
+extensionValidityTest(AttributesExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/builtin-preset.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/builtin-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { BuiltinPreset } from '..';
 
-test('`BuiltinPreset`: is valid', () => {
-  expect(isPresetValid(BuiltinPreset)).toBeTrue();
-});
+presetValidityTest(BuiltinPreset);

--- a/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
@@ -1,12 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { BoldExtension, isExtensionValid, ItalicExtension } from '@remirror/testing';
+import { BoldExtension, ItalicExtension } from '@remirror/testing';
 
 import { CommandsExtension } from '..';
 
-test('`CommandsExtension`: is valid', () => {
-  expect(isExtensionValid(CommandsExtension)).toBeTrue();
-});
+extensionValidityTest(CommandsExtension);
 
 test('can call multiple commands', () => {
   const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);

--- a/packages/@remirror/core/src/builtins/__tests__/helpers-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/helpers-extension.spec.ts
@@ -1,12 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { HeadingExtension, isExtensionValid } from '@remirror/testing';
+import { HeadingExtension } from '@remirror/testing';
 
 import { HelpersExtension } from '..';
 
-test('`HelpersExtension`: is valid', () => {
-  expect(isExtensionValid(HelpersExtension)).toBeTrue();
-});
+extensionValidityTest(HelpersExtension);
 
 describe('active', () => {
   it('should recognise active nodes by attrs', () => {

--- a/packages/@remirror/core/src/builtins/__tests__/input-rules-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/input-rules-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { InputRulesExtension } from '..';
 
-test('`InputRulesExtension`: is valid', () => {
-  expect(isExtensionValid(InputRulesExtension)).toBeTrue();
-});
+extensionValidityTest(InputRulesExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/keymap-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/keymap-extension.spec.ts
@@ -1,12 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { BuiltinPreset, isExtensionValid } from '@remirror/testing';
+import { BuiltinPreset } from '@remirror/testing';
 
 import { KeymapExtension } from '..';
 
-test('`KeymapExtension`: is valid', () => {
-  expect(isExtensionValid(KeymapExtension)).toBeTrue();
-});
+extensionValidityTest(KeymapExtension);
 
 test('supports custom keymaps', () => {
   const mock = jest.fn();

--- a/packages/@remirror/core/src/builtins/__tests__/node-views-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/node-views-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { NodeViewsExtension } from '..';
 
-test('`NodeViewsExtension`: is valid', () => {
-  expect(isExtensionValid(NodeViewsExtension)).toBeTrue();
-});
+extensionValidityTest(NodeViewsExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/paste-rules-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/paste-rules-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { PasteRulesExtension } from '..';
 
-test('`PasteRulesExtension`: is valid', () => {
-  expect(isExtensionValid(PasteRulesExtension)).toBeTrue();
-});
+extensionValidityTest(PasteRulesExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/plugins-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/plugins-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { PluginsExtension } from '..';
 
-test('`PluginsExtension`: is valid', () => {
-  expect(isExtensionValid(PluginsExtension)).toBeTrue();
-});
+extensionValidityTest(PluginsExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/schema-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/schema-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { SchemaExtension } from '..';
 
-test('`SchemaExtension`: is valid', () => {
-  expect(isExtensionValid(SchemaExtension)).toBeTrue();
-});
+extensionValidityTest(SchemaExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/suggest-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/suggest-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { SuggestExtension } from '..';
 
-test('`SuggestExtension`: is valid', () => {
-  expect(isExtensionValid(SuggestExtension)).toBeTrue();
-});
+extensionValidityTest(SuggestExtension);

--- a/packages/@remirror/core/src/builtins/__tests__/tags-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/tags-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { TagsExtension } from '..';
 
-test('`TagsExtension`: is valid', () => {
-  expect(isExtensionValid(TagsExtension)).toBeTrue();
-});
+extensionValidityTest(TagsExtension);

--- a/packages/@remirror/core/src/extension/base-class.ts
+++ b/packages/@remirror/core/src/extension/base-class.ts
@@ -130,6 +130,13 @@ export abstract class BaseClass<
   }
 
   /**
+   * Get the dynamic keys for this extension.
+   */
+  get dynamicKeys() {
+    return this.#dynamicKeys;
+  }
+
+  /**
    * The options that this instance was created with, merged with all the
    * default options.
    */

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -1,13 +1,9 @@
-import { renderEditor } from 'jest-remirror';
-
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { Annotation, AnnotationExtension } from '..';
 import type { AnnotationOptions } from '../types';
 
-test('is valid', () => {
-  expect(isExtensionValid(AnnotationExtension, {}));
-});
+extensionValidityTest(AnnotationExtension);
 
 function create(options?: AnnotationOptions) {
   return renderEditor([new AnnotationExtension(options)]);

--- a/packages/@remirror/extension-bidi/src/__tests__/bidi-extension.spec.ts
+++ b/packages/@remirror/extension-bidi/src/__tests__/bidi-extension.spec.ts
@@ -1,12 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { HeadingExtension, isExtensionValid } from '@remirror/testing';
+import { HeadingExtension } from '@remirror/testing';
 
 import { BidiExtension } from '..';
 
-test('`BidiExtension`: is valid', () => {
-  expect(isExtensionValid(BidiExtension)).toBeTrue();
-});
+extensionValidityTest(BidiExtension);
 
 test('captures the direction of each node', () => {
   const {

--- a/packages/@remirror/extension-blockquote/src/__tests__/blockquote-extension.spec.ts
+++ b/packages/@remirror/extension-blockquote/src/__tests__/blockquote-extension.spec.ts
@@ -1,14 +1,12 @@
 import { pmBuild } from 'jest-prosemirror';
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
-import { createCoreManager, isExtensionValid } from '@remirror/testing';
+import { createCoreManager } from '@remirror/testing';
 
 import { BlockquoteExtension } from '..';
 
-test('`BlockquoteExtension`: is valid', () => {
-  expect(isExtensionValid(BlockquoteExtension)).toBeTrue();
-});
+extensionValidityTest(BlockquoteExtension);
 
 describe('schema', () => {
   const { schema } = createCoreManager([new BlockquoteExtension()]);

--- a/packages/@remirror/extension-bold/src/__tests__/bold-extension.spec.ts
+++ b/packages/@remirror/extension-bold/src/__tests__/bold-extension.spec.ts
@@ -1,14 +1,12 @@
 import { pmBuild } from 'jest-prosemirror';
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
-import { createCoreManager, isExtensionValid } from '@remirror/testing';
+import { createCoreManager } from '@remirror/testing';
 
 import { BoldExtension, BoldOptions } from '../..';
 
-test('`BoldExtension`: is valid', () => {
-  expect(isExtensionValid(BoldExtension)).toBeTrue();
-});
+extensionValidityTest(BoldExtension);
 
 describe('schema', () => {
   const { schema } = createCoreManager([new BoldExtension()]);

--- a/packages/@remirror/extension-code-block/src/__tests__/code-block-extension.spec.ts
+++ b/packages/@remirror/extension-code-block/src/__tests__/code-block-extension.spec.ts
@@ -1,5 +1,5 @@
 import { pmBuild } from 'jest-prosemirror';
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import typescriptPlugin from 'prettier/parser-typescript';
 import { formatWithCursor } from 'prettier/standalone';
 import refractor from 'refractor/core';
@@ -11,14 +11,12 @@ import typescript from 'refractor/lang/typescript';
 import yaml from 'refractor/lang/yaml';
 
 import { ExtensionPriority, fromHtml, object, toHtml } from '@remirror/core';
-import { createCoreManager, isExtensionValid } from '@remirror/testing';
+import { createCoreManager } from '@remirror/testing';
 
 import { CodeBlockExtension, CodeBlockOptions, FormatterParameter } from '..';
 import { getLanguage } from '../code-block-utils';
 
-test('`CodeBlockExtension`: is valid', () => {
-  expect(isExtensionValid(CodeBlockExtension)).toBeTrue();
-});
+extensionValidityTest(CodeBlockExtension);
 
 describe('schema', () => {
   const { schema } = createCoreManager([

--- a/packages/@remirror/extension-code/src/__tests__/code-extension.spec.ts
+++ b/packages/@remirror/extension-code/src/__tests__/code-extension.spec.ts
@@ -1,13 +1,12 @@
 import { pmBuild } from 'jest-prosemirror';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
-import { createCoreManager, isExtensionValid } from '@remirror/testing';
+import { createCoreManager } from '@remirror/testing';
 
 import { CodeExtension } from '..';
 
-test('`CodeExtension`: is valid', () => {
-  expect(isExtensionValid(CodeExtension)).toBeTrue();
-});
+extensionValidityTest(CodeExtension);
 
 describe('schema', () => {
   const codeTester = () => {

--- a/packages/@remirror/extension-collaboration/src/__tests__/collaboration-extension.spec.ts
+++ b/packages/@remirror/extension-collaboration/src/__tests__/collaboration-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { CollaborationExtension } from '..';
 
-test('`CollaborationExtension`: is valid', () => {
-  expect(isExtensionValid(CollaborationExtension, { clientID: 'abc' })).toBeTrue();
-});
+extensionValidityTest(CollaborationExtension, { clientID: 'abc' });

--- a/packages/@remirror/extension-diff/src/__tests__/diff-extension.spec.ts
+++ b/packages/@remirror/extension-diff/src/__tests__/diff-extension.spec.ts
@@ -1,13 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { entries, GetHandler } from '@remirror/core';
-import { isExtensionValid } from '@remirror/testing';
 
 import { DiffExtension, DiffOptions } from '..';
 
-test('`DiffExtension`: is valid', () => {
-  expect(isExtensionValid(DiffExtension)).toBeTrue();
-});
+extensionValidityTest(DiffExtension);
 
 function create(options?: DiffOptions, handlers: GetHandler<DiffOptions> = {}) {
   const extension = new DiffExtension(options);

--- a/packages/@remirror/extension-doc/src/__tests__/doc-extension.spec.ts
+++ b/packages/@remirror/extension-doc/src/__tests__/doc-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { DocExtension } from '../..';
 
-test('`DocExtension`: is valid', () => {
-  expect(isExtensionValid(DocExtension)).toBeTrue();
-});
+extensionValidityTest(DocExtension);

--- a/packages/@remirror/extension-drop-cursor/src/__tests__/drop-cursor-extension.spec.ts
+++ b/packages/@remirror/extension-drop-cursor/src/__tests__/drop-cursor-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { DropCursorExtension } from '..';
 
-test('`DropCursorExtension`: is valid', () => {
-  expect(isExtensionValid(DropCursorExtension)).toBeTrue();
-});
+extensionValidityTest(DropCursorExtension);

--- a/packages/@remirror/extension-epic-mode/src/__tests__/epic-mode-extension.spec.ts
+++ b/packages/@remirror/extension-epic-mode/src/__tests__/epic-mode-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { EpicModeExtension } from '../..';
 
-test('`EpicModeExtension`: is valid', () => {
-  expect(isExtensionValid(EpicModeExtension)).toBeTrue();
-});
+extensionValidityTest(EpicModeExtension);

--- a/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
+++ b/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
@@ -1,13 +1,9 @@
 import { fireEvent } from '@testing-library/dom';
-import { renderEditor } from 'jest-remirror';
-
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { EventsExtension } from '..';
 
-test('`EventsExtension`: is valid', () => {
-  expect(isExtensionValid(EventsExtension, {}));
-});
+extensionValidityTest(EventsExtension);
 
 describe('events', () => {
   it('responds to editor `focus` events', () => {

--- a/packages/@remirror/extension-gap-cursor/src/__tests__/gap-cursor-extension.spec.ts
+++ b/packages/@remirror/extension-gap-cursor/src/__tests__/gap-cursor-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { GapCursorExtension } from '../..';
 
-test('`GapCursorExtension`: is valid', () => {
-  expect(isExtensionValid(GapCursorExtension)).toBeTrue();
-});
+extensionValidityTest(GapCursorExtension);

--- a/packages/@remirror/extension-hard-break/src/__tests__/hard-break-extension.spec.ts
+++ b/packages/@remirror/extension-hard-break/src/__tests__/hard-break-extension.spec.ts
@@ -1,13 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { isTextSelection } from '@remirror/core';
-import { isExtensionValid } from '@remirror/testing';
 
 import { HardBreakExtension } from '..';
 
-test('`HardBreakExtension`: is valid', () => {
-  expect(isExtensionValid(HardBreakExtension)).toBeTrue();
-});
+extensionValidityTest(HardBreakExtension);
 
 describe('commands', () => {
   it('insertHardBreak', () => {

--- a/packages/@remirror/extension-heading/src/__tests__/heading-extension.spec.ts
+++ b/packages/@remirror/extension-heading/src/__tests__/heading-extension.spec.ts
@@ -1,14 +1,12 @@
 import { pmBuild } from 'jest-prosemirror';
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
-import { BoldExtension, createCoreManager, isExtensionValid } from '@remirror/testing';
+import { BoldExtension, createCoreManager } from '@remirror/testing';
 
 import { HeadingExtension, HeadingOptions } from '../heading-extension';
 
-test('`HeadingExtension`: is valid', () => {
-  expect(isExtensionValid(HeadingExtension)).toBeTrue();
-});
+extensionValidityTest(HeadingExtension);
 
 describe('schema', () => {
   const { schema } = createCoreManager([new HeadingExtension()]);

--- a/packages/@remirror/extension-heading/src/heading-extension.ts
+++ b/packages/@remirror/extension-heading/src/heading-extension.ts
@@ -65,15 +65,15 @@ export class HeadingExtension extends NodeExtension<HeadingOptions> {
       draggable: false,
       parseDOM: this.options.levels.map((level) => ({
         tag: `h${level}`,
-        attrs: { level },
+        getAttrs: (element) => ({ ...extra.parse(element), level }),
       })),
       toDOM: (node: ProsemirrorNode) => {
         if (!this.options.levels.includes(node.attrs.level)) {
           // Use the first level available
-          return [`h${this.options.defaultLevel}`, 0];
+          return [`h${this.options.defaultLevel}`, extra.dom(node), 0];
         }
 
-        return [`h${node.attrs.level as string}`, 0];
+        return [`h${node.attrs.level as string}`, extra.dom(node), 0];
       },
     };
   }

--- a/packages/@remirror/extension-history/src/__tests__/history-extension.spec.ts
+++ b/packages/@remirror/extension-history/src/__tests__/history-extension.spec.ts
@@ -1,13 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import type { EditorState } from '@remirror/core';
-import { isExtensionValid } from '@remirror/testing';
 
 import { HistoryExtension } from '../history-extension';
 
-test('`HistoryExtension`: is valid', () => {
-  expect(isExtensionValid(HistoryExtension)).toBeTrue();
-});
+extensionValidityTest(HistoryExtension);
 
 describe('commands', () => {
   const create = () => renderEditor([new HistoryExtension()]);

--- a/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
+++ b/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
@@ -1,13 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { isNodeSelection, isTextSelection } from '@remirror/core';
-import { isExtensionValid } from '@remirror/testing';
 
 import { HorizontalRuleExtension } from '..';
 
-test('`HorizontalRuleExtension`: is valid', () => {
-  expect(isExtensionValid(HorizontalRuleExtension)).toBeTrue();
-});
+extensionValidityTest(HorizontalRuleExtension);
 
 describe('insertHorizontalRule', () => {
   it('adds a trailing node by default', () => {

--- a/packages/@remirror/extension-image/src/__tests__/image-extension.spec.ts
+++ b/packages/@remirror/extension-image/src/__tests__/image-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { ImageExtension } from '../..';
 
-test('`ImageExtension`: is valid', () => {
-  expect(isExtensionValid(ImageExtension)).toBeTrue();
-});
+extensionValidityTest(ImageExtension);

--- a/packages/@remirror/extension-italic/src/__tests__/italic-extension.spec.ts
+++ b/packages/@remirror/extension-italic/src/__tests__/italic-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { ItalicExtension } from '..';
 
-test('`ItalicExtension`: is valid', () => {
-  expect(isExtensionValid(ItalicExtension)).toBeTrue();
-});
+extensionValidityTest(ItalicExtension);

--- a/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
+++ b/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
@@ -1,14 +1,12 @@
 import { pmBuild } from 'jest-prosemirror';
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, GetHandler, toHtml } from '@remirror/core';
-import { createCoreManager, isExtensionValid } from '@remirror/testing';
+import { createCoreManager } from '@remirror/testing';
 
 import { LinkExtension, LinkOptions } from '..';
 
-test('`LinkExtension`: is valid', () => {
-  expect(isExtensionValid(LinkExtension)).toBeTrue();
-});
+extensionValidityTest(LinkExtension);
 
 const href = 'https://test.com';
 

--- a/packages/@remirror/extension-paragraph/src/__tests__/paragraph-extension.spec.ts
+++ b/packages/@remirror/extension-paragraph/src/__tests__/paragraph-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { ParagraphExtension } from '../..';
 
-test('`ParagraphExtension`: is valid', () => {
-  expect(isExtensionValid(ParagraphExtension)).toBeTrue();
-});
+extensionValidityTest(ParagraphExtension);

--- a/packages/@remirror/extension-placeholder/src/__tests__/placeholder-extension.spec.ts
+++ b/packages/@remirror/extension-placeholder/src/__tests__/placeholder-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { PlaceholderExtension } from '../placeholder-extension';
 
-test('`PlaceholderExtension`: is valid', () => {
-  expect(isExtensionValid(PlaceholderExtension)).toBeTrue();
-});
+extensionValidityTest(PlaceholderExtension);

--- a/packages/@remirror/extension-position-tracker/src/__tests__/position-tracker-extension.spec.ts
+++ b/packages/@remirror/extension-position-tracker/src/__tests__/position-tracker-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { PositionTrackerExtension } from '../..';
 
-test('`PositionTrackerExtension`: is valid', () => {
-  expect(isExtensionValid(PositionTrackerExtension)).toBeTrue();
-});
+extensionValidityTest(PositionTrackerExtension);

--- a/packages/@remirror/extension-positioner/src/__tests__/positioner-extension.spec.ts
+++ b/packages/@remirror/extension-positioner/src/__tests__/positioner-extension.spec.ts
@@ -1,13 +1,9 @@
-import { renderEditor } from 'jest-remirror';
-
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { PositionerExtension } from '../positioner-extension';
 import { centeredSelectionPositioner, cursorPopupPositioner } from '../positioners';
 
-test('`PositionerExtension`: is valid', () => {
-  expect(isExtensionValid(PositionerExtension)).toBeTrue();
-});
+extensionValidityTest(PositionerExtension);
 
 test('`cursorPopupPositioner` can position itself', () => {
   const positionerExtension = new PositionerExtension();

--- a/packages/@remirror/extension-react-component/src/__tests__/react-component-extension.spec.tsx
+++ b/packages/@remirror/extension-react-component/src/__tests__/react-component-extension.spec.tsx
@@ -1,16 +1,13 @@
-import { RemirrorTestChain } from 'jest-remirror';
+import { extensionValidityTest, RemirrorTestChain } from 'jest-remirror';
 import React, { ComponentType } from 'react';
 
 import { ApplySchemaAttributes, NodeExtension, NodeExtensionSpec, NodeGroup } from '@remirror/core';
-import { isExtensionValid } from '@remirror/testing';
 import { act, createReactManager, RemirrorProvider, strictRender } from '@remirror/testing/react';
 
 import { ReactComponentExtension } from '..';
 import type { NodeViewComponentProps } from '../node-view-types';
 
-test('`ReactComponentExtension`: is valid', () => {
-  expect(isExtensionValid(ReactComponentExtension)).toBeTrue();
-});
+extensionValidityTest(ReactComponentExtension);
 
 class TestExtension extends NodeExtension<{ useContent: boolean }> {
   createNodeSpec(extra: ApplySchemaAttributes): NodeExtensionSpec {

--- a/packages/@remirror/extension-react-ssr/src/__tests__/react-ssr-extension.spec.ts
+++ b/packages/@remirror/extension-react-ssr/src/__tests__/react-ssr-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { ReactSSRExtension } from '../..';
 
-test('`ReactSSRExtension`: is valid', () => {
-  expect(isExtensionValid(ReactSSRExtension)).toBeTrue();
-});
+extensionValidityTest(ReactSSRExtension);

--- a/packages/@remirror/extension-search/src/__tests__/search-extension.spec.ts
+++ b/packages/@remirror/extension-search/src/__tests__/search-extension.spec.ts
@@ -1,12 +1,8 @@
-import { renderEditor } from 'jest-remirror';
-
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { SearchExtension, SearchOptions } from '..';
 
-test('`SearchExtension`: is valid', () => {
-  expect(isExtensionValid(SearchExtension)).toBeTrue();
-});
+extensionValidityTest(SearchExtension);
 
 function create(options?: SearchOptions) {
   const {

--- a/packages/@remirror/extension-strike/src/__tests__/strike-extension.spec.ts
+++ b/packages/@remirror/extension-strike/src/__tests__/strike-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { StrikeExtension } from '..';
 
-test('`StrikeExtension`: is valid', () => {
-  expect(isExtensionValid(StrikeExtension)).toBeTrue();
-});
+extensionValidityTest(StrikeExtension);

--- a/packages/@remirror/extension-text/src/__tests__/text-extension.spec.ts
+++ b/packages/@remirror/extension-text/src/__tests__/text-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { TextExtension } from '../..';
 
-test('`TextExtension`: is valid', () => {
-  expect(isExtensionValid(TextExtension)).toBeTrue();
-});
+extensionValidityTest(TextExtension);

--- a/packages/@remirror/extension-trailing-node/src/__tests__/trailing-node-extension.spec.ts
+++ b/packages/@remirror/extension-trailing-node/src/__tests__/trailing-node-extension.spec.ts
@@ -1,12 +1,10 @@
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { BlockquoteExtension, HeadingExtension, isExtensionValid } from '@remirror/testing';
+import { BlockquoteExtension, HeadingExtension } from '@remirror/testing';
 
 import { TrailingNodeExtension, TrailingNodeOptions } from '../trailing-node-extension';
 
-test('`TrailingNodeExtension`: is valid', () => {
-  expect(isExtensionValid(TrailingNodeExtension)).toBeTrue();
-});
+extensionValidityTest(TrailingNodeExtension);
 
 function create(params?: Partial<TrailingNodeOptions>) {
   const {

--- a/packages/@remirror/extension-underline/src/__tests__/underline-extension.spec.ts
+++ b/packages/@remirror/extension-underline/src/__tests__/underline-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { UnderlineExtension } from '..';
 
-test('`UnderlineExtension`: is valid', () => {
-  expect(isExtensionValid(UnderlineExtension)).toBeTrue();
-});
+extensionValidityTest(UnderlineExtension);

--- a/packages/@remirror/extension-yjs/src/__tests__/yjs-extension.spec.ts
+++ b/packages/@remirror/extension-yjs/src/__tests__/yjs-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { YjsExtension } from '..';
 
-test('`YjsExtension`: is valid', () => {
-  expect(isExtensionValid(YjsExtension, {} as any)).toBeTrue();
-});
+extensionValidityTest(YjsExtension, {} as any);

--- a/packages/@remirror/preset-core/src/__tests__/core-preset.spec.ts
+++ b/packages/@remirror/preset-core/src/__tests__/core-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { CorePreset } from '../..';
 
-test('`CorePreset`: is valid', () => {
-  expect(isPresetValid(CorePreset)).toBeTrue();
-});
+presetValidityTest(CorePreset);

--- a/packages/@remirror/preset-embed/src/__tests__/embed-preset.spec.ts
+++ b/packages/@remirror/preset-embed/src/__tests__/embed-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { EmbedPreset } from '../..';
 
-test('`EmbedPreset`: is valid', () => {
-  expect(isPresetValid(EmbedPreset)).toBeTrue();
-});
+presetValidityTest(EmbedPreset);

--- a/packages/@remirror/preset-embed/src/__tests__/iframe-extension.spec.ts
+++ b/packages/@remirror/preset-embed/src/__tests__/iframe-extension.spec.ts
@@ -1,14 +1,12 @@
 import { pmBuild } from 'jest-prosemirror';
-import { renderEditor } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
-import { createCoreManager, isExtensionValid } from '@remirror/testing';
+import { createCoreManager } from '@remirror/testing';
 
 import { IframeExtension, IframeOptions } from '../iframe-extension';
 
-test('`IframeExtension`: is valid', () => {
-  expect(isExtensionValid(IframeExtension)).toBeTrue();
-});
+extensionValidityTest(IframeExtension);
 
 function create(options?: IframeOptions) {
   return renderEditor([new IframeExtension(options)]);

--- a/packages/@remirror/preset-list/src/__tests__/list-preset.spec.ts
+++ b/packages/@remirror/preset-list/src/__tests__/list-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { ListPreset } from '..';
 
-test('`ListPreset`: is valid', () => {
-  expect(isPresetValid(ListPreset)).toBeTrue();
-});
+presetValidityTest(ListPreset);

--- a/packages/@remirror/preset-react-checkbox/src/__tests__/react-checkbox-preset.spec.ts
+++ b/packages/@remirror/preset-react-checkbox/src/__tests__/react-checkbox-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { CheckboxPreset } from '..';
 
-test('`CheckboxPreset`: is valid', () => {
-  expect(isPresetValid(CheckboxPreset)).toBeTrue();
-});
+presetValidityTest(CheckboxPreset);

--- a/packages/@remirror/preset-react/src/__tests__/react-preset.spec.ts
+++ b/packages/@remirror/preset-react/src/__tests__/react-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { ReactPreset } from '..';
 
-test('`ReactPreset`: is valid', () => {
-  expect(isPresetValid(ReactPreset)).toBeTrue();
-});
+presetValidityTest(ReactPreset);

--- a/packages/@remirror/preset-social/src/__tests__/social-preset.spec.ts
+++ b/packages/@remirror/preset-social/src/__tests__/social-preset.spec.ts
@@ -1,16 +1,13 @@
-import { renderEditor } from 'jest-remirror';
+import { presetValidityTest, renderEditor } from 'jest-remirror';
 
 import { ExtensionPriority } from '@remirror/core';
 import { AutoLinkExtension } from '@remirror/extension-auto-link';
 import { EmojiExtension } from '@remirror/extension-emoji';
 import { MentionExtension } from '@remirror/extension-mention';
-import { isPresetValid } from '@remirror/testing';
 
 import { SocialPreset } from '..';
 
-test('`SocialPreset`: is valid', () => {
-  expect(isPresetValid(SocialPreset, { matchers: [] })).toBeTrue();
-});
+presetValidityTest(SocialPreset, { matchers: [] });
 
 test('can override extensions', () => {
   const autoLinkExtension = new AutoLinkExtension({ defaultProtocol: 'https:' });

--- a/packages/@remirror/preset-wysiwyg/src/__tests__/wysiwyg-preset.spec.ts
+++ b/packages/@remirror/preset-wysiwyg/src/__tests__/wysiwyg-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { WysiwygPreset } from '..';
 
-test('`WysiwygPreset`: is valid', () => {
-  expect(isPresetValid(WysiwygPreset)).toBeTrue();
-});
+presetValidityTest(WysiwygPreset);

--- a/packages/@remirror/testing/src/index.ts
+++ b/packages/@remirror/testing/src/index.ts
@@ -1,106 +1,11 @@
 import diff from 'jest-diff';
 
-import {
-  AnyExtensionConstructor,
-  AnyPresetConstructor,
-  BaseExtensionOptions,
-  ErrorConstant,
-  ExtensionConstructorParameter,
-  invariant,
-  isEqual,
-  isFunction,
-  isMarkExtension,
-  isNodeExtension,
-  mutateDefaultExtensionOptions,
-  object,
-  omit,
-  OptionsOfConstructor,
-  PresetConstructorParameter,
-} from '@remirror/core';
-
 export const initialJson = {
   type: 'doc',
   content: [
     { type: 'paragraph', content: [{ type: 'text', text: 'Better docs to come soon...' }] },
   ],
 };
-
-function emptyObject() {
-  return {};
-}
-
-/**
- * Validate the shape of your extension.
- */
-export function isExtensionValid<Type extends AnyExtensionConstructor>(
-  Extension: Type,
-  ...[options]: ExtensionConstructorParameter<OptionsOfConstructor<Type>>
-) {
-  const extension = new Extension(options);
-
-  expect(extension.name).toBeString();
-  expect(() => extension.setOptions({})).not.toThrow();
-
-  if (isNodeExtension(extension)) {
-    expect(
-      extension.createNodeSpec({ defaults: emptyObject, dom: emptyObject, parse: emptyObject }),
-    ).toBeObject();
-  } else if (isMarkExtension(extension)) {
-    expect(
-      extension.createMarkSpec({ defaults: emptyObject, dom: emptyObject, parse: emptyObject }),
-    ).toBeObject();
-  }
-
-  let defaultOptions: BaseExtensionOptions = object();
-
-  mutateDefaultExtensionOptions((value) => {
-    defaultOptions = value;
-  });
-
-  for (const key of Extension.handlerKeys) {
-    invariant(isFunction(extension.options[key]), {
-      message: `Invalid handler 'key'. Make sure not to overwrite the default handler`,
-      code: ErrorConstant.INVALID_EXTENSION,
-    });
-  }
-
-  const expectedOptions = {
-    ...defaultOptions,
-    ...Extension.defaultOptions,
-    ...options,
-  };
-  invariant(isEqual(omit(extension.options, Extension.handlerKeys), expectedOptions), {
-    message: `Invalid 'defaultOptions' for '${Extension.name}'\n\n${
-      diff(extension.options, expectedOptions) ?? ''
-    }\n`,
-    code: ErrorConstant.INVALID_EXTENSION,
-  });
-
-  return true;
-}
-
-/**
- * Validate the shape of your preset.
- */
-export function isPresetValid<Type extends AnyPresetConstructor>(
-  Preset: Type,
-  ...[options]: PresetConstructorParameter<OptionsOfConstructor<Type>>
-) {
-  const preset = new Preset(options);
-
-  expect(preset.name).toBeString();
-  expect(() => preset.setOptions({})).not.toThrow();
-
-  const expectedOptions = { ...Preset.defaultOptions, ...options };
-
-  invariant(isEqual(omit(preset.options, Preset.handlerKeys), expectedOptions), {
-    message: `Invalid 'defaultOptions' for '${Preset.name}'\n\n${
-      diff(preset.options, expectedOptions) ?? ''
-    }\n`,
-  });
-
-  return true;
-}
 
 export { diff };
 

--- a/packages/jest-remirror/src/index.ts
+++ b/packages/jest-remirror/src/index.ts
@@ -4,6 +4,8 @@ export { renderEditor, RemirrorTestChain } from './jest-remirror-editor';
 export { setupRemirrorEnvironment } from './jest-remirror-environment';
 export type { RenderEditorParameter, TaggedProsemirrorNode } from './jest-remirror-types';
 
+export { extensionValidityTest, presetValidityTest } from './jest-remirror-validator';
+
 declare global {
   interface Window {
     hasWarnedAboutCancelAnimationFramePolyfill?: boolean;

--- a/packages/jest-remirror/src/jest-remirror-validator.ts
+++ b/packages/jest-remirror/src/jest-remirror-validator.ts
@@ -1,0 +1,180 @@
+import {
+  AnyExtensionConstructor,
+  AnyPresetConstructor,
+  BaseExtensionOptions,
+  ExtensionConstructorParameter,
+  fromHtml,
+  isEmptyArray,
+  isFunction,
+  isMarkExtension,
+  isMarkType,
+  isNodeExtension,
+  isNodeType,
+  isPlainObject,
+  mutateDefaultExtensionOptions,
+  object,
+  omit,
+  OptionsOfConstructor,
+  pick,
+  PresetConstructorParameter,
+} from '@remirror/core';
+
+import { renderEditor } from './jest-remirror-editor';
+
+/**
+ * Test that your extension is valid.
+ */
+export function extensionValidityTest<Type extends AnyExtensionConstructor>(
+  Extension: Type,
+  ...[options]: ExtensionConstructorParameter<OptionsOfConstructor<Type>>
+) {
+  describe(`\`${Extension.name}\``, () => {
+    it(`has the right properties`, () => {
+      const extension = new Extension(options);
+      expect(extension.name).toBeString();
+
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        extension.name = '_CHANGE_';
+      }).toThrowError();
+    });
+
+    it('can safely set empty options', () => {
+      const extension = new Extension(options);
+      expect(() => extension.setOptions({})).not.toThrow();
+    });
+
+    it('can safely be cloned', () => {
+      const extension = new Extension(options);
+      const dynamicKeys = [...extension.dynamicKeys, ...Extension.staticKeys];
+      const clonedExtension = extension.clone(options);
+      expect(pick(clonedExtension.options, dynamicKeys)).toEqual(
+        pick(extension.options, dynamicKeys),
+      );
+    });
+
+    let defaultOptions: BaseExtensionOptions = object();
+    mutateDefaultExtensionOptions((value) => {
+      defaultOptions = value;
+    });
+
+    const handlerKeys = Extension.handlerKeys.map((key) => [key]);
+
+    if (!isEmptyArray(handlerKeys)) {
+      it.each(handlerKeys)('has valid handlerKey: %s', (handlerKey) => {
+        const extension = new Extension(options);
+        expect(isFunction(extension.options[handlerKey])).toBe(true);
+      });
+    }
+
+    it('has the correct options', () => {
+      const extension = new Extension(options);
+      const expectedOptions = {
+        ...defaultOptions,
+        ...Extension.defaultOptions,
+        ...options,
+      };
+
+      expect(omit(extension.options, Extension.handlerKeys)).toEqual(expectedOptions);
+    });
+
+    const extension = new Extension(options);
+
+    if (isNodeExtension(extension)) {
+      it('creates a valid node spec', () => {
+        const extraAttributes = {
+          defaults: jest.fn(() => ({})),
+          dom: jest.fn(() => ({})),
+          parse: jest.fn(() => ({})),
+        };
+
+        const spec = extension.createNodeSpec(extraAttributes);
+        expect(isPlainObject(spec)).toBe(true);
+
+        renderEditor([extension], { props: { stringHandler: fromHtml, initialContent: '' } });
+        expect(isNodeType(extension.type)).toBe(true);
+
+        if (Extension.disableExtraAttributes) {
+          return;
+        }
+
+        expect(extraAttributes.defaults).toHaveBeenCalled();
+      });
+    }
+
+    if (isMarkExtension(extension)) {
+      it('creates a valid mark spec', () => {
+        const extraAttributes = {
+          defaults: jest.fn(() => ({})),
+          dom: jest.fn(() => ({})),
+          parse: jest.fn(() => ({})),
+        };
+
+        const spec = extension.createMarkSpec(extraAttributes);
+        expect(isPlainObject(spec)).toBe(true);
+
+        renderEditor([extension], { props: { stringHandler: fromHtml, initialContent: '' } });
+        expect(isMarkType(extension.type)).toBe(true);
+
+        if (Extension.disableExtraAttributes) {
+          return;
+        }
+
+        expect(extraAttributes.defaults).toHaveBeenCalled();
+      });
+    }
+  });
+}
+
+/**
+ * Test that your `Preset` is valid.
+ */
+export function presetValidityTest<Type extends AnyPresetConstructor>(
+  Preset: Type,
+  ...[options]: PresetConstructorParameter<OptionsOfConstructor<Type>>
+) {
+  describe(`\`${Preset.name}\``, () => {
+    it(`has the right properties`, () => {
+      const preset = new Preset(options);
+      expect(preset.name).toBeString();
+
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        preset.name = 'change';
+      }).toThrowError();
+    });
+
+    it('can safely set empty options', () => {
+      const preset = new Preset(options);
+      expect(() => preset.setOptions({})).not.toThrow();
+    });
+
+    it('can safely be cloned', () => {
+      const preset = new Preset(options);
+      const keys = [...preset.dynamicKeys, ...Preset.staticKeys];
+      const clonedPreset = preset.clone(options);
+      expect(pick(clonedPreset.options, keys)).toEqual(pick(preset.options, keys));
+    });
+
+    const handlerKeys = Preset.handlerKeys.map((key) => [key]);
+
+    if (!isEmptyArray(handlerKeys)) {
+      it.each(handlerKeys)('has valid handlerKey: %s', (handlerKey) => {
+        const preset = new Preset(options);
+        expect(isFunction(preset.options[handlerKey])).toBe(true);
+      });
+    }
+
+    it('has the correct options', () => {
+      const preset = new Preset(options);
+      const expectedOptions = {
+        ...Preset.defaultOptions,
+        ...options,
+      };
+
+      expect(omit(preset.options, Preset.handlerKeys)).toEqual(expectedOptions);
+    });
+  });
+}

--- a/support/templates/extension-template/src/__tests__/template-extension.spec.ts
+++ b/support/templates/extension-template/src/__tests__/template-extension.spec.ts
@@ -1,7 +1,5 @@
-import { isExtensionValid } from '@remirror/testing';
+import { extensionValidityTest } from 'jest-remirror';
 
 import { TemplateExtension } from '..';
 
-test('`TemplateExtension`: is valid', () => {
-  expect(isExtensionValid(TemplateExtension)).toBeTrue();
-});
+extensionValidityTest(TemplateExtension);

--- a/support/templates/preset-template/src/__tests__/template-preset.spec.ts
+++ b/support/templates/preset-template/src/__tests__/template-preset.spec.ts
@@ -1,7 +1,5 @@
-import { isPresetValid } from '@remirror/testing';
+import { presetValidityTest } from 'jest-remirror';
 
 import { TemplatePreset } from '..';
 
-test('`TemplatePreset`: is valid', () => {
-  expect(isPresetValid(TemplatePreset)).toBeTrue();
-});
+presetValidityTest(TemplatePreset);


### PR DESCRIPTION
## Description

Add validity check function exports to `jest-remirror`.

- `presetValidityTest` for testing your `Preset`.
- `extensionValidityTest` for testing your `Extension`.

Public `dynamicKeys` property now available on `Extension`'s and `Preset`'s.

Support `extraAttributes` in the `HeadingExtension` #384

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
