### PR TITLE
chore: remove CI env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ on:
       - next
 
 env:
-  CI: true
   PNPM_VERSION: 5.3.0
   PNPM_CACHE_FOLDER: .pnpm-store
 


### PR DESCRIPTION
## Description

CI is always set to true according GitHub docs

https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

<!-- Delete this section if not applicable -->
