### PR TITLE
Allow updating existing annotations

### DIFF
--- a/.changeset/long-swans-fry.md
+++ b/.changeset/long-swans-fry.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': minor
+---
+
+Allow updating existing annotations

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -32,6 +32,38 @@ describe('commands', () => {
         `);
   });
 
+  it('#updateAnnotation', () => {
+    const id = '1';
+
+    add(doc(p('An <start>important<end> note')));
+    commands.addAnnotation({ id });
+
+    // Pre-condition
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+          <p>
+            An
+            <span class="annotation">
+              important
+            </span>
+            note
+          </p>
+        `);
+
+    commands.updateAnnotation(id, {
+      className: 'updated',
+    });
+
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+          <p>
+            An
+            <span class="annotation updated">
+              important
+            </span>
+            note
+          </p>
+        `);
+  });
+
   it('#setAnnotations', () => {
     add(doc(p('An important note')));
     commands.setAnnotations([

--- a/packages/@remirror/extension-annotation/src/actions.ts
+++ b/packages/@remirror/extension-annotation/src/actions.ts
@@ -4,12 +4,19 @@ export enum ActionType {
   ADD_ANNOTATION,
   REMOVE_ANNOTATIONS,
   SET_ANNOTATIONS,
+  UPDATE_ANNOTATION,
 }
 
 export interface AddAnnotationAction<A extends Annotation> {
   type: ActionType.ADD_ANNOTATION;
   from: number;
   to: number;
+  annotationData: AnnotationData<A>;
+}
+
+export interface UpdateAnnotationAction<A extends Annotation> {
+  type: ActionType.UPDATE_ANNOTATION;
+  annotationId: string;
   annotationData: AnnotationData<A>;
 }
 


### PR DESCRIPTION
## Description

Users could change annotations only by removing and then re-adding them with the changed value.

This is inconvenient when using extended annotations, e.g. an annotation with tags. In those cases, it would be better to simply update the tags of the existing annotation.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
