### PR TITLE
Adjust docu after renaming createSuggestion to createSuggesters

### DIFF
--- a/packages/@remirror/core/src/builtins/suggest-extension.ts
+++ b/packages/@remirror/core/src/builtins/suggest-extension.ts
@@ -20,7 +20,7 @@ export interface SuggestOptions {
 }
 
 /**
- * This extension allows others extension to add the `createSuggestion` method
+ * This extension allows others extension to add the `createSuggesters` method
  * for adding the prosemirror-suggest functionality to your editor.
  *
  * @remarks


### PR DESCRIPTION
## Description

createSuggestion was renamed by https://github.com/remirror/remirror/commit/982a6b15b8e5b435f3ad7c5bc39d1c163bc67fd8

This commit adjusts the docu accordingly.

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
