### PR TITLE
docs: remove `defaultValue` from code comment

### DIFF
--- a/.changeset/dull-crews-tickle.md
+++ b/.changeset/dull-crews-tickle.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-suggest': patch
+---
+
+Remove misleading documentation. The matchOffset field isn't defaulted to zero for MentionExtension.

--- a/packages/prosemirror-suggest/src/suggest-types.ts
+++ b/packages/prosemirror-suggest/src/suggest-types.ts
@@ -98,8 +98,6 @@ export interface Suggester<Command extends AnyFunction<void> = AnyFunction<void>
    * - `matchOffset: 2` matches `'@ab'` but not `'@a'` or `'@'`
    * - `matchOffset: 3` matches `'@abc'` but not `'@ab'` or `'@a'` or `'@'`
    * - And so on...
-   *
-   * @defaultValue 0
    */
   matchOffset?: number;
 


### PR DESCRIPTION
## Description

The matchOffset field isn't defaulted to zero for MentionExtension: https://github.com/remirror/remirror/blob/4b4307bfd039a83dca885640704654d0b23f9747/packages/%40remirror/extension-mention/src/mention-utils.ts#L19

The documentation is therefore misleading when configuring the MentionExtension.

Fixes https://github.com/remirror/remirror/issues/485

## Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/master/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
