### PR TITLE
fix: bold and italic input rule composition

### DIFF
--- a/.changeset/silver-pandas-cheer.md
+++ b/.changeset/silver-pandas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Ensure the `markInputRule` doesn't reactivate previous marks when rules are nested and activated consecutively. Closes #505

--- a/packages/@remirror/core-utils/src/prosemirror-rules.ts
+++ b/packages/@remirror/core-utils/src/prosemirror-rules.ts
@@ -1,6 +1,7 @@
 import { findMatches, isFunction, isNullOrUndefined } from '@remirror/core-helpers';
 import type {
   GetAttributesParameter,
+  Mark,
   MarkTypeParameter,
   NodeTypeParameter,
   ProsemirrorNode,
@@ -103,11 +104,13 @@ export function markInputRule(parameter: MarkInputRuleParameter) {
     const { tr } = state;
     const attributes = isFunction(getAttributes) ? getAttributes(match) : getAttributes;
     let markEnd = end;
+    let initialStoredMarks: Mark[] = [];
 
     if (match[1]) {
       const startSpaces = match[0].search(/\S/);
       const textStart = start + match[0].indexOf(match[1]);
       const textEnd = textStart + match[1].length;
+      initialStoredMarks = tr.storedMarks ?? [];
 
       if (textEnd < end) {
         tr.delete(textEnd, end);
@@ -124,7 +127,7 @@ export function markInputRule(parameter: MarkInputRuleParameter) {
       tr
         .addMark(start, markEnd, type.create(attributes))
         // Make sure not to continue with any ongoing marks
-        .removeStoredMark(type)
+        .setStoredMarks(initialStoredMarks)
     );
   });
 }

--- a/packages/@remirror/extension-italic/src/__tests__/italic-extension.spec.ts
+++ b/packages/@remirror/extension-italic/src/__tests__/italic-extension.spec.ts
@@ -1,5 +1,33 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { ItalicExtension } from '..';
+import { BoldExtension } from '@remirror/testing';
+
+import { ItalicExtension } from '../..';
 
 extensionValidityTest(ItalicExtension);
+
+describe('inputRules', () => {
+  it('supports nested input rule matches', () => {
+    const {
+      add,
+      nodes: { doc, p },
+      marks: { bold, italic },
+    } = renderEditor([new BoldExtension(), new ItalicExtension()]);
+
+    add(doc(p('_**bold italic<cursor>')))
+      .insertText('**')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('_', bold('bold italic'), '<cursor>')));
+      })
+      .insertText('_')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(
+          doc(p(italic(bold('bold italic')), '<cursor>')),
+        );
+      })
+      .insertText(' more')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p(italic(bold('bold italic')), ' more')));
+      });
+  });
+});


### PR DESCRIPTION
### Description

Ensure the `markInputRule` doesn't reactivate previous marks when rules are nested and activated consecutively.

Created for #505

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-08-14 10 24 03](https://user-images.githubusercontent.com/1160934/90234979-76af4200-de18-11ea-8ba7-acf50dcd9791.gif)

