### PR TITLE
feat(core-utils): select `all` text in editor

### DIFF
--- a/.changeset/hot-seals-stare.md
+++ b/.changeset/hot-seals-stare.md
@@ -1,0 +1,13 @@
+---
+'@remirror/core-types': minor
+'@remirror/core-utils': minor
+---
+
+Enable `all` selection when setting initial content and focusing on the editor.
+
+```tsx
+import { useRemirror } from 'remirror/react';
+
+const { focus } = useRemirror();
+focus('all');
+```

--- a/packages/@remirror/core-types/src/core-types.ts
+++ b/packages/@remirror/core-types/src/core-types.ts
@@ -347,4 +347,4 @@ export interface RemirrorIdentifierShape {
  * - A single position with a `number`
  * - `'start' | 'end'`
  */
-export type PrimitiveSelection = Selection | FromToParameter | number | 'start' | 'end';
+export type PrimitiveSelection = Selection | FromToParameter | number | 'start' | 'end' | 'all';

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -45,6 +45,7 @@ import {
   Slice,
 } from '@remirror/pm/model';
 import {
+  AllSelection,
   EditorState as PMEditorState,
   NodeSelection,
   Plugin,
@@ -752,6 +753,10 @@ export function getTextSelection(
 
   if (isSelection(selection)) {
     return selection;
+  }
+
+  if (selection === 'all') {
+    return new AllSelection(doc);
   }
 
   if (selection === 'start') {

--- a/packages/@remirror/dom/readme.md
+++ b/packages/@remirror/dom/readme.md
@@ -52,7 +52,7 @@ const element = document.querySelector('#editor');
 const manager = createDomManager([new BoldExtension()]);
 const editor = createDomEditor({ manager, element });
 
-editor.addHandler('change', () => console.log('your editor has changed'));
+editor.addHandler('change', () => log('your editor has changed'));
 
 // Make selected text bold.
 editor.commands.toggleBold();

--- a/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
@@ -212,7 +212,7 @@ describe('focus', () => {
     expect(context.getState().selection.from).toBe(1);
   });
 
-  it('can focus on the end', () => {
+  it('can focus on the `end`', () => {
     fireEvent.blur(editorNode);
 
     act(() => {
@@ -223,7 +223,19 @@ describe('focus', () => {
     expect(context.getState().selection.from).toBe(16);
   });
 
-  it('can focus on the start even when already focused', () => {
+  it('can focus on `all`', () => {
+    fireEvent.blur(editorNode);
+
+    act(() => {
+      context.focus('all');
+      jest.runAllTimers();
+    });
+
+    expect(context.getState().selection.from).toBe(0);
+    expect(context.getState().selection.to).toBe(17);
+  });
+
+  it('can focus on the `start` even when already focused', () => {
     act(() => {
       context.focus('start');
       jest.runAllTimers();


### PR DESCRIPTION
### Description

Enable `all` selection when setting initial content and focusing on the editor.

```tsx
import { useRemirror } from 'remirror/react';
const { focus } = useRemirror();
focus('all');
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
