### PR TITLE
fix(extension-italic): paste and input rules

### DIFF
--- a/.changeset/thin-jokes-fold.md
+++ b/.changeset/thin-jokes-fold.md
@@ -1,0 +1,12 @@
+---
+'@remirror/core-utils': minor
+'@remirror/core': minor
+'@remirror/extension-code': patch
+'@remirror/extension-bold': patch
+'@remirror/extension-italic': patch
+'@remirror/extension-strike': patch
+---
+
+Add `ignoreWhitespace` option to `markInputRule` for ignoring a matching input rule if the capture groups is only whitespace. Apply to all wrapping input rules for `MarkExtension`'s in the `project`.
+
+Fix #506 `ItalicExtension` issue with input rule being greedy and capturing one preceding character when activated within a text block.

--- a/packages/@remirror/extension-bold/src/__tests__/bold-extension.spec.ts
+++ b/packages/@remirror/extension-bold/src/__tests__/bold-extension.spec.ts
@@ -69,20 +69,30 @@ function create(options?: BoldOptions) {
   return renderEditor([new BoldExtension(options)]);
 }
 
-test('inputRules', () => {
+describe('inputRules', () => {
   const {
     add,
     nodes: { p, doc },
     marks: { bold },
   } = create();
 
-  add(doc(p('Start<cursor>')))
-    .insertText(' **bold me** for input rule match')
-    .callback((content) => {
-      expect(content.state.doc).toEqualRemirrorDocument(
-        doc(p('Start ', bold('bold me'), ' for input rule match')),
-      );
-    });
+  it('should match input rule', () => {
+    add(doc(p('Start<cursor>')))
+      .insertText(' **bold me** for input rule match')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(
+          doc(p('Start ', bold('bold me'), ' for input rule match')),
+        );
+      });
+  });
+
+  it('should ignore whitespace', () => {
+    add(doc(p('<cursor>')))
+      .insertText('** **\n   **')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(doc(p('** **\n'), p('   **')));
+      });
+  });
 });
 
 test('options', () => {

--- a/packages/@remirror/extension-bold/src/bold-extension.ts
+++ b/packages/@remirror/extension-bold/src/bold-extension.ts
@@ -93,7 +93,13 @@ export class BoldExtension extends MarkExtension<BoldOptions> {
   }
 
   createInputRules(): InputRule[] {
-    return [markInputRule({ regexp: /(?:\*\*|__)([^*_]+)(?:\*\*|__)$/, type: this.type })];
+    return [
+      markInputRule({
+        regexp: /(?:\*\*|__)([^*_]+)(?:\*\*|__)$/,
+        type: this.type,
+        ignoreWhitespace: true,
+      }),
+    ];
   }
 
   createCommands() {

--- a/packages/@remirror/extension-code/src/__tests__/code-extension.spec.ts
+++ b/packages/@remirror/extension-code/src/__tests__/code-extension.spec.ts
@@ -1,5 +1,5 @@
 import { pmBuild } from 'jest-prosemirror';
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
 import { createCoreManager } from '@remirror/testing';
@@ -35,5 +35,66 @@ describe('schema', () => {
     const expected = doc(p(code(parsedString)));
 
     expect(node).toEqualProsemirrorNode(expected);
+  });
+});
+
+describe('inputRules', () => {
+  const {
+    add,
+    nodes: { p, doc },
+    marks: { code },
+  } = renderEditor([new CodeExtension()]);
+
+  it('should match input rule', () => {
+    add(doc(p('Start<cursor>')))
+      .insertText(' `code here!` for input rule match')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(
+          doc(p('Start ', code('code here!'), ' for input rule match')),
+        );
+      });
+  });
+
+  it('should ignore whitespace', () => {
+    add(doc(p('<cursor>')))
+      .insertText('` `\n   `')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(doc(p('` `\n'), p('   `')));
+      });
+  });
+});
+
+describe('commands', () => {
+  const {
+    add,
+    view,
+    nodes: { p, doc },
+    marks: { code },
+    commands,
+  } = renderEditor([new CodeExtension()]);
+
+  it('#toggleBold', () => {
+    add(doc(p('Hello <start>code<end>, lets dance.')));
+    commands.toggleCode();
+
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+          <p>
+            Hello
+            <code>
+              code
+            </code>
+            , lets dance.
+          </p>
+        `);
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello ', code('code'), ', lets dance.')));
+
+    commands.toggleCode();
+
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+          <p>
+            Hello code, lets dance.
+          </p>
+        `);
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello code, lets dance.')));
   });
 });

--- a/packages/@remirror/extension-code/src/code-extension.ts
+++ b/packages/@remirror/extension-code/src/code-extension.ts
@@ -51,6 +51,7 @@ export class CodeExtension extends MarkExtension {
       markInputRule({
         regexp: new RegExp(`(?:\`)([^\`${LEAF_NODE_REPLACING_CHARACTER}]+)(?:\`)$`),
         type: this.type,
+        ignoreWhitespace: true,
       }),
     ];
   }

--- a/packages/@remirror/extension-italic/src/__tests__/italic-extension.spec.ts
+++ b/packages/@remirror/extension-italic/src/__tests__/italic-extension.spec.ts
@@ -7,6 +7,76 @@ import { ItalicExtension } from '../..';
 extensionValidityTest(ItalicExtension);
 
 describe('inputRules', () => {
+  it('makes text italic with `_`', () => {
+    const {
+      add,
+      nodes: { doc, p },
+      marks: { italic },
+    } = renderEditor([new ItalicExtension()]);
+
+    add(doc(p('<cursor>')))
+      .insertText('Text _italic_')
+      .callback((content) => {
+        expect(content.doc.toJSON()).toEqual(doc(p('Text ', italic('italic'))).toJSON());
+      })
+      .insertText(' more')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('Text ', italic('italic'), ' more')));
+      });
+  });
+
+  it('makes text italic with `*`', () => {
+    const {
+      add,
+      nodes: { doc, p },
+      marks: { italic },
+    } = renderEditor([new ItalicExtension()]);
+
+    add(doc(p('<cursor>')))
+      .insertText('Text *italic*')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('Text ', italic('italic'))));
+      })
+      .insertText(' more')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('Text ', italic('italic'), ' more')));
+      });
+  });
+
+  it('should not match only whitespace', () => {
+    const {
+      add,
+      nodes: { doc, p },
+    } = renderEditor([new ItalicExtension()]);
+
+    add(doc(p('<cursor>')))
+      .insertText('_    _')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('_    _')));
+      })
+      .insertText('\n_ * *')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('_    _\n'), p('_ * *')));
+      });
+  });
+
+  it('should not make text italic with mixed `*_` characters', () => {
+    const {
+      add,
+      nodes: { doc, p },
+    } = renderEditor([new ItalicExtension()]);
+
+    add(doc(p('<cursor>')))
+      .insertText('Text *oops_')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('Text *oops_')));
+      })
+      .insertText('\n _oh*')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('Text *oops_\n'), p(' _oh*')));
+      });
+  });
+
   it('supports nested input rule matches', () => {
     const {
       add,

--- a/packages/@remirror/extension-italic/src/italic-extension.ts
+++ b/packages/@remirror/extension-italic/src/italic-extension.ts
@@ -49,10 +49,24 @@ export class ItalicExtension extends MarkExtension {
   }
 
   createInputRules(): InputRule[] {
-    return [markInputRule({ regexp: /(?:^|[^*_])[*_]([^*_]+)[*_]$/, type: this.type })];
+    return [
+      markInputRule({
+        regexp: /(?<=(?:^|[^*]))\*([^*]+)\*/,
+        type: this.type,
+        ignoreWhitespace: true,
+      }),
+      markInputRule({
+        regexp: /(?<=(?:^|[^_]))_([^_]+)_/,
+        type: this.type,
+        ignoreWhitespace: true,
+      }),
+    ];
   }
 
   createPasteRules(): Plugin[] {
-    return [markPasteRule({ regexp: /(?:^|[^*_])[*_]([^*_]+)[*_]/g, type: this.type })];
+    return [
+      markPasteRule({ regexp: /_([^_]+)_/g, type: this.type }),
+      markPasteRule({ regexp: /\*([^*]+)\*/g, type: this.type }),
+    ];
   }
 }

--- a/packages/@remirror/extension-strike/src/__tests__/strike-extension.spec.ts
+++ b/packages/@remirror/extension-strike/src/__tests__/strike-extension.spec.ts
@@ -1,5 +1,67 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { StrikeExtension } from '..';
 
 extensionValidityTest(StrikeExtension);
+
+describe('inputRules', () => {
+  const {
+    add,
+    nodes: { p, doc },
+    marks: { strike },
+  } = renderEditor([new StrikeExtension()]);
+
+  it('should match input rule', () => {
+    add(doc(p('Start<cursor>')))
+      .insertText(' ~strike here!~ for input rule match')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(
+          doc(p('Start ', strike('strike here!'), ' for input rule match')),
+        );
+      });
+  });
+
+  it('should ignore whitespace', () => {
+    add(doc(p('<cursor>')))
+      .insertText('~ ~\n   ~')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(doc(p('~ ~\n'), p('   ~')));
+      });
+  });
+});
+
+describe('commands', () => {
+  const {
+    add,
+    view,
+    nodes: { p, doc },
+    marks: { strike },
+    commands,
+  } = renderEditor([new StrikeExtension()]);
+
+  it('#toggleStrike', () => {
+    add(doc(p('Hello <start>strike<end>, lets dance.')));
+    commands.toggleStrike();
+
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+          <p>
+            Hello
+            <s>
+              strike
+            </s>
+            , lets dance.
+          </p>
+        `);
+    expect(view.state.doc).toEqualRemirrorDocument(
+      doc(p('Hello ', strike('strike'), ', lets dance.')),
+    );
+
+    commands.toggleStrike();
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+          <p>
+            Hello strike, lets dance.
+          </p>
+        `);
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello strike, lets dance.')));
+  });
+});

--- a/packages/@remirror/extension-strike/src/strike-extension.ts
+++ b/packages/@remirror/extension-strike/src/strike-extension.ts
@@ -63,7 +63,7 @@ export class StrikeExtension extends MarkExtension {
   }
 
   createInputRules(): InputRule[] {
-    return [markInputRule({ regexp: /~([^~]+)~$/, type: this.type })];
+    return [markInputRule({ regexp: /~([^~]+)~$/, type: this.type, ignoreWhitespace: true })];
   }
 
   createPasteRules(): Plugin[] {


### PR DESCRIPTION
### Description

Add `ignoreWhitespace` option to `markInputRule` for ignoring a matching input rule if the capture groups is only whitespace. Apply to all wrapping input rules for `MarkExtension`'s in the `project`.

- #506 `ItalicExtension` issue with input rule being greedy and capturing one extra preceding character when activated within a text block.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-08-15 18 59 19](https://user-images.githubusercontent.com/1160934/90320206-d56add80-df36-11ea-916f-7b7110fea4c1.gif)

