### PR TITLE
fix(react): controlled editor in `StrictMode`

### DIFF
--- a/.changeset/brave-rules-switch.md
+++ b/.changeset/brave-rules-switch.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react': patch
+---
+
+Fix the controlled editor when used in `StrictMode`. Closes #482

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,12 +39,10 @@
 'package: remirror :purple_circle:':
   - any:
       [
-        'packages/remirror/**/*.{ts,tsx,json}',
-        'packages/@remirror/**/*.{ts,tsx,json}',
+        'packages/{remirror,@remirror}/**/*.{ts,tsx,json}',
         '!packages/@remirror/playground/**/*',
         '!packages/@remirror/cli/**/*',
-        '!packages/remirror/**/*.spec.{ts,tsx}',
-        '!packages/@remirror/**/*.spec.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
       ]
 
 'framework: react :atom_symbol:':
@@ -72,7 +70,7 @@
       ]
 
 'type: docs :pencil:':
-  - any: ['docs/**/*', '**/readme.md']
+  - any: ['docs/**/*', '**/readme.{md,mdx}']
 
 'type: changeset :butterfly:':
   - any: ['.changeset/**/*']

--- a/docs/concepts/react-controlled-editor.mdx
+++ b/docs/concepts/react-controlled-editor.mdx
@@ -2,16 +2,19 @@
 title: React controlled editor
 ---
 
+There are times when you will want complete control over the content in your editor. For this reason
+remirror supports **controlled editors**. Setting up your editor like this is more complicated due
+to the asynchronous nature of react updates versus the synchronous nature of ProseMirror `dispatch`.
+It's easy to get yourself in trouble without taking care to understand the concepts. If in doubt,
+start with an uncontrolled editor and upgrade to **controlled** once you're more comfortable with
+`remirror`.
+
 :::note Advanced Topic
 
 The following is considered an advanced topic. If you are struggling to understand some of the
 concepts don't feel bad. It can be hard to understand initially.
 
 :::
-
-There are times when you will want complete control over the content in your editor. For this reason
-remirror supports **controlled editors**. Setting up your editor like this is more complicated and
-for this reason is marked as an advanced topic.
 
 Get started in the usual way.
 
@@ -125,3 +128,71 @@ const EditorWrapper = () => {
   );
 };
 ```
+
+### Potential pitfalls
+
+Commands use the current state stored on `view.state` to dispatch transactions and create a new
+state. In an uncontrolled editor this is perfectly fine since the source of truth is `view.state`.
+Once an update is dispatched the state is updated synchronously and `onChange` is immediately
+called. With **controlled** editors there's often a delay between the `view.dispatch` and the state
+being updated.
+
+When attempting to synchronously run multiple commands in a **controlled** editor, each command
+operates on the current state, not the state as applied by the previous command. As a result, we
+find ourselves in a situation where the last command wins. i.e. the last state update before the
+controlled editor can apply the new state is the one that will be used.
+
+Since the playground is a controlled editor, you can observe the phenomenom there.
+
+I created a
+[controlled editor test](https://github.com/remirror/remirror/blob/7477b9357368d62e201d05db4d9872954ae13c11/packages/%40remirror/react/src/components/__tests__/react-editor-controlled.spec.tsx#L368-L418)
+showing that this is actually expected behaviour. Making multiple state updates before the state has
+been updated will not work in a controlled editor.
+
+### Chained Commands
+
+The advised workaround is to use `chained` commands.
+
+```ts
+const { chained } = useRemirror();
+
+chained.toggleBold().toggleItalic().toggleUnderline().run();
+```
+
+Chained commands allow composing different commands together that have been updated to work with the
+ProseMirror `transaction` rather than the fixed state. This means that each command adds new steps
+and when the `.run()` is called all these steps are dispatched at the same time.
+
+However, not all commands are chainable.
+
+**There are some that will never be chainable.**
+
+- `undo`
+- `redo`
+
+These only work with **synchronous** state updates and it doesn't really make sense to use them as
+part of a chain. Calling them with `chained` will throw an error and if you're using TypeScript your
+code will complain at compile time.
+
+**There are some that still need to be made chainable**
+
+In [#422](https://github.com/remirror/remirror/pull/422) most commands have been made chainable.
+`@remirror/preset-table` and `@remirror/preset-list` have been left out for now since they require a
+bit more work to convert their commands to rely on transactions rather than state.
+
+When I have time, I'll need to convert the commands that are currently being imported by
+`prosemirror-tables` and `prosemirror-schema-list` to use transactions instead of state. At this
+point it might even make sense to remove these libraries from `@remirror/pm`.
+
+You can see an example of one such conversion
+[here](https://github.com/remirror/remirror/blob/7477b9357368d62e201d05db4d9872954ae13c11/packages/%40remirror/core-utils/src/command-utils.ts#L128-L164).
+
+### Workarounds
+
+- Use `chained` commands where possible.
+- Commands that update the transaction will also work since the same transaction is shared, however
+  it's advisable to be explicit about the intent to chain commands together.
+- Certain commands will never be chainable. If you are using TypeScript this will be obvious as they
+  are **non-callable**.
+- Work will be done to convert the `@remirror/preset-tables` library and `@remirror/preset-list` to
+  use chainable commands.

--- a/packages/@remirror/react/src/components/react-editor.tsx
+++ b/packages/@remirror/react/src/components/react-editor.tsx
@@ -521,12 +521,13 @@ class ReactEditorWrapper<Combined extends AnyCombinedUnion> extends EditorWrappe
     this.rootPropsConfig.count = 0;
   }
 
+  /**
+   * Create the react element which renders the text editor.
+   */
   render() {
     this.resetRender();
 
-    const element: JSX.Element | null = this.props.children({
-      ...this.remirrorContext,
-    });
+    const element: JSX.Element | null = this.props.children(this.remirrorContext);
 
     const { children, ...properties } = getElementProps(element);
     let renderedElement: JSX.Element;
@@ -561,6 +562,9 @@ class ReactEditorWrapper<Combined extends AnyCombinedUnion> extends EditorWrappe
   }
 }
 
+/**
+ * The parameter that is passed into the ReactEditorWrapper.
+ */
 interface ReactEditorWrapperParameter<Combined extends AnyCombinedUnion>
   extends EditorWrapperParameter<Combined, ReactEditorProps<Combined>> {
   getShouldRenderClient: () => boolean | undefined;
@@ -613,22 +617,19 @@ function useControlledEditor<Combined extends AnyCombinedUnion>(
   const isControlled = useRef(bool(value)).current;
   const previousValue = usePrevious(value);
 
-  // Handle controlled editor updates every time the value changes.
-  useEffect(() => {
-    // Check if the update is valid based on current value.
-    const validUpdate = value ? isControlled === true : isControlled === false;
+  // Check if the update is valid based on current value.
+  const validUpdate = value ? isControlled === true : isControlled === false;
 
-    invariant(validUpdate, {
-      code: ErrorConstant.REACT_CONTROLLED,
-      message: isControlled
-        ? 'You have attempted to switch from a controlled to an uncontrolled editor. Once you set up an editor as a controlled editor it must always provide a `value` prop.'
-        : 'You have provided a `value` prop to an uncontrolled editor. In order to set up your editor as controlled you must provide the `value` prop from the very first render.',
-    });
+  invariant(validUpdate, {
+    code: ErrorConstant.REACT_CONTROLLED,
+    message: isControlled
+      ? 'You have attempted to switch from a controlled to an uncontrolled editor. Once you set up an editor as a controlled editor it must always provide a `value` prop.'
+      : 'You have provided a `value` prop to an uncontrolled editor. In order to set up your editor as controlled you must provide the `value` prop from the very first render.',
+  });
 
-    if (!value) {
-      return;
-    }
+  if (!value || value === previousValue) {
+    return;
+  }
 
-    methods.updateControlledState(value, previousValue ?? undefined);
-  }, [isControlled, value, methods, previousValue]);
+  methods.updateControlledState(value, previousValue ?? undefined);
 }


### PR DESCRIPTION
### Description

Fix the controlled editor when used in `StrictMode`.

This is mentioned in #482.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
