### PR TITLE
feat(core): add `beforeDispatch` method to input rules

### DIFF
--- a/.changeset/brave-ducks-turn.md
+++ b/.changeset/brave-ducks-turn.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-horizontal-rule': patch
+---
+
+Fix uneccessary lines being added to the editor when creating a new horizontal line with the commands or input rules. Closes #451.

--- a/.changeset/six-eggs-peel.md
+++ b/.changeset/six-eggs-peel.md
@@ -1,0 +1,18 @@
+---
+'@remirror/core-utils': major
+'@remirror/core': major
+---
+
+💥 Remove property `updateSelection` from the `nodeInputRule`, `markInputRule` and `plainInputRule` functions. You should use the new `beforeDispatch` method instead.
+
+Add new `beforeDispatch` method to the `nodeInputRule`, `markInputRule` and `plainInputRule` parameter. This method allows users to add extra steps to the transaction after a matching input rule has been run and just before it is dispatched.
+
+```ts
+import { nodeInputRule } from 'remirror/core';
+
+nodeInputRule({
+  type,
+  regexp: /abc/,
+  beforeDispatch: ({ tr }) => tr.insertText('hello'),
+});
+```

--- a/packages/@remirror/core-utils/src/command-utils.ts
+++ b/packages/@remirror/core-utils/src/command-utils.ts
@@ -275,9 +275,9 @@ interface ReplaceTextParameter extends Partial<RangeParameter>, Partial<Attribut
  * Taken from https://stackoverflow.com/a/4900484
  *
  * Check that the browser is chrome. Supports passing a minimum version to check
- * that it is a greater than or equal version.
+ * that it is a greater than or equal to this version.
  */
-function isChrome(minVersion = 0): boolean {
+export function isChrome(minVersion = 0): boolean {
   const parsedAgent = navigator.userAgent.match(/Chrom(e|ium)\/(\d+)\./);
 
   return parsedAgent ? Number.parseInt(parsedAgent[2], 10) >= minVersion : false;

--- a/packages/@remirror/core-utils/src/index.ts
+++ b/packages/@remirror/core-utils/src/index.ts
@@ -1,5 +1,6 @@
 export {
   emptyCommandFunction,
+  isChrome,
   lift,
   removeMark,
   replaceText,

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -174,6 +174,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
    */
   createInputRules() {
     const regexp = /^```([\dA-Za-z]*) $/;
+
     const getAttributes: GetAttributes = (match) => {
       const language = getLanguage({
         language: getMatchString(match, 1),
@@ -187,7 +188,10 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
       nodeInputRule({
         regexp,
         type: this.type,
-        updateSelection: true,
+        beforeDispatch: ({ tr, start }) => {
+          const $pos = tr.doc.resolve(start);
+          tr.setSelection(new TextSelection($pos));
+        },
         getAttributes: getAttributes,
       }),
     ];

--- a/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
+++ b/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
@@ -30,4 +30,73 @@ describe('insertHorizontalRule', () => {
     expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content'), hr()));
     expect(isNodeSelection(view.state.selection)).toBe(true);
   });
+
+  it('can insert multiple horizontal rules without clashes', () => {
+    const { add, nodes, commands, view, insertText } = renderEditor([
+      new HorizontalRuleExtension({}),
+    ]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This is content<cursor>')));
+    commands.insertHorizontalRule();
+    commands.insertHorizontalRule();
+    commands.insertHorizontalRule();
+    commands.insertHorizontalRule();
+
+    const initialExpected = doc(p('This is content'), hr(), hr(), hr(), hr(), p());
+    const finalExpected = doc(p('This is content'), hr(), hr(), hr(), hr(), p(' amazing!'));
+
+    expect(view.state.doc.toJSON()).toEqual(initialExpected.toJSON());
+    expect(view.state.selection.$anchor.parent.type.name).toBe('paragraph');
+    expect(view.state.selection.anchor).toBe(22);
+
+    insertText(' amazing!');
+    expect(view.state.doc.toJSON()).toEqual(finalExpected.toJSON());
+  });
+});
+
+describe('inputRules', () => {
+  it('adds a trailing node by default', () => {
+    const { add, nodes, view, insertText } = renderEditor([new HorizontalRuleExtension()]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This is content'), p('<cursor>'))).insertText('---');
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content'), hr(), p()));
+
+    insertText('Amazing!');
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content'), hr(), p('Amazing!')));
+  });
+
+  it('does not add a trailing node when set to false', () => {
+    const { add, nodes, view } = renderEditor([
+      new HorizontalRuleExtension({ insertionNode: false }),
+    ]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This is content'), p('<cursor>'))).insertText('---');
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This is content'), hr()));
+    expect(isNodeSelection(view.state.selection)).toBe(true);
+  });
+
+  it('can insert multiple horizontal rules without clashes', () => {
+    const { add, nodes, view, insertText } = renderEditor([new HorizontalRuleExtension({})]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This is content'), p('<cursor>')))
+      .insertText('---')
+      .insertText('---')
+      .insertText('---')
+      .insertText('---');
+
+    const initialExpected = doc(p('This is content'), hr(), hr(), hr(), hr(), p());
+    const finalExpected = doc(p('This is content'), hr(), hr(), hr(), hr(), p(' amazing!'));
+
+    expect(view.state.doc.toJSON()).toEqual(initialExpected.toJSON());
+    expect(view.state.selection.$anchor.parent.type.name).toBe('paragraph');
+    expect(view.state.selection.anchor).toBe(22);
+
+    insertText(' amazing!');
+    expect(view.state.doc.toJSON()).toEqual(finalExpected.toJSON());
+  });
 });


### PR DESCRIPTION
### Description

💥 Remove property `updateSelection` from the `nodeInputRule`, `markInputRule` and `plainInputRule` functions. You should use the new `beforeDispatch` method instead.

Add new `beforeDispatch` method to the `nodeInputRule`, `markInputRule` and `plainInputRule` parameter. This method allows users to add extra steps to the transaction after a matching input rule has been run and just before it is dispatched.

```ts
import { nodeInputRule } from 'remirror/core';
nodeInputRule({
  type,
  regexp: /abc/,
  beforeDispatch: ({ tr }) => tr.insertText('hello'),
});
```

- Fix uneccessary lines being added to the editor when creating a new horizontal line with the commands or input rules. 

Issue: #451.

Please note that although the direct issue has been fixed, it's possible I uncovered another one. Since I've already spent too much time diving into it I'll just post the screenshots. 

ProseMirror jumps position when the `hr` is added to the dom while it was unfocused and then text is typed. Probably something to do with the selection API. I've posted the screenshots below of the different editors. And I'll open in issue the `ProseMirror` issue tracker. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

- [ ] Create a follow up issue in the `ProseMirror` repository.

### Screenshots

#### Chrome with focus ✅

![2020-08-15 15 05 56](https://user-images.githubusercontent.com/1160934/90315474-cc1c4980-df13-11ea-81c7-3dfd34521c10.gif)

#### Chrome without focus ❌

![2020-08-15 15 06 58](https://user-images.githubusercontent.com/1160934/90315486-e3f3cd80-df13-11ea-8f64-68eebf2beb53.gif)

#### Firefox without focus ✅

![2020-08-15 15 23 52](https://user-images.githubusercontent.com/1160934/90315498-fb32bb00-df13-11ea-9cd8-256e5736e37e.gif)

#### Safari without focus ✅

![2020-08-15 15 24 20](https://user-images.githubusercontent.com/1160934/90315502-04bc2300-df14-11ea-9ec7-3e071a50ef9f.gif)




