### PR TITLE
feat(react): add `usePositioner` active param

### DIFF
--- a/.changeset/silver-pots-shake.md
+++ b/.changeset/silver-pots-shake.md
@@ -1,0 +1,11 @@
+---
+'@remirror/react': minor
+'@remirror/extension-positioner': patch
+'@remirror/react-social': patch
+---
+
+Fix #516 with social emoji popup when scroll bars are visible.
+
+Export `emptyCoords` object from `@remirror/extension-positioner`.
+
+Add second parameter to `usePositioner` hook which can override when a positioner should be set to active.

--- a/packages/@remirror/extension-positioner/src/index.ts
+++ b/packages/@remirror/extension-positioner/src/index.ts
@@ -11,6 +11,7 @@ export { hasStateChanged, isEmptyBlockNode } from './positioner-utils';
 export {
   centeredSelectionPositioner,
   cursorPopupPositioner,
+  emptyCoords,
   emptyVirtualPosition,
   floatingSelectionPositioner,
 } from './positioners';

--- a/packages/@remirror/extension-positioner/src/positioner-extension.ts
+++ b/packages/@remirror/extension-positioner/src/positioner-extension.ts
@@ -150,6 +150,10 @@ export interface PositionerHandler {
   onChange: PositionerChangeHandlerMethod;
 }
 
+/**
+ * This type is used for setting elements which are associated with the relevant
+ * positioner. Once teh
+ */
 export type PositionerChangeHandlerMethod = (elementSetters: SetActiveElement[]) => void;
 
 const positioners = {
@@ -161,6 +165,10 @@ const positioners = {
   cursor: cursorPopupPositioner,
 };
 
+/**
+ * This is a helper method for getting the positioner. The parameter can either
+ * be a named positioner or a positioner that you've created for the purpose.
+ */
 export function getPositioner(positioner: StringPositioner | Positioner): Positioner {
   if (isString(positioner)) {
     return positioners[positioner];

--- a/packages/@remirror/extension-positioner/src/positioner.ts
+++ b/packages/@remirror/extension-positioner/src/positioner.ts
@@ -144,7 +144,8 @@ interface PositionerEvents {
  * editor. Typically you will use it to get the position of the cursor.
  *
  * But you can be more ambitious and get the position all the active nodes of a
- * certain type. Or all visible nodes of a given time.
+ * certain type. Or all visible nodes of a certain type in the editor, updated
+ * as it scrolls.
  *
  * The positions returned have a rect which is the viewport position.
  *
@@ -162,8 +163,9 @@ export class Positioner<Data = any> {
 
   /**
    * Create a positioner from an existing positioner.
+   *
+   * This is useful when you want to modify parts of the positioner.
    */
-
   static fromPositioner<Data>(positioner: Positioner, base: Partial<BasePositioner<Data>>) {
     return Positioner.create({ ...positioner.basePositioner, ...base });
   }

--- a/packages/@remirror/extension-positioner/src/positioners.ts
+++ b/packages/@remirror/extension-positioner/src/positioners.ts
@@ -3,11 +3,15 @@ import { isSelectionEmpty } from '@remirror/core';
 import { Coords, Positioner, VirtualPosition } from './positioner';
 import { hasStateChanged, isEmptyBlockNode } from './positioner-utils';
 
-const emptyRect = {
+export const emptyCoords: Coords = {
   top: -999_999,
   left: -999_999,
-  right: -999_999,
-  bottom: -999_999,
+  right: 999_999,
+  bottom: 999_999,
+};
+
+const emptyRect = {
+  ...emptyCoords,
   height: 0,
   width: 0,
   x: -999_999,

--- a/packages/@remirror/react-social/src/components/social-editor-emoji.tsx
+++ b/packages/@remirror/react-social/src/components/social-editor-emoji.tsx
@@ -2,6 +2,7 @@ import { css, cx } from 'linaria';
 import { Type, useMultishift } from 'multishift';
 import React, { useCallback, useState } from 'react';
 
+import { bool, isEmptyArray } from '@remirror/core';
 import { usePositioner } from '@remirror/react';
 
 import { useSocialRemirror } from '../hooks';
@@ -14,9 +15,11 @@ import {
 const EmojiDropdown = (props: SocialEmojiState) => {
   const { index, command, list, show } = props;
   const { focus } = useSocialRemirror();
-  const { ref, active, bottom, left } = usePositioner('popup');
   const [isClicking, setIsClicking] = useState(false);
-  const shouldShowPopup = (show || isClicking) && command && active;
+  const { ref, active, bottom, left } = usePositioner(
+    'popup',
+    bool((show || isClicking) && command && !isEmptyArray(list)),
+  );
 
   const { getMenuProps, getItemProps, itemHighlightedAtIndex, hoveredIndex } = useMultishift({
     highlightedIndexes: [index],
@@ -39,7 +42,7 @@ const EmojiDropdown = (props: SocialEmojiState) => {
         left: left,
       }}
     >
-      {shouldShowPopup &&
+      {active &&
         list.map((emoji, index) => {
           const isHighlighted = itemHighlightedAtIndex(index);
           const isHovered = index === hoveredIndex;

--- a/packages/@remirror/react/src/__tests__/editor-hooks.spec.tsx
+++ b/packages/@remirror/react/src/__tests__/editor-hooks.spec.tsx
@@ -2,6 +2,7 @@ import { RemirrorTestChain } from 'jest-remirror';
 import React, { FC } from 'react';
 
 import { RemirrorManager } from '@remirror/core';
+import { emptyCoords, emptyVirtualPosition } from '@remirror/extension-positioner';
 import { EditorView } from '@remirror/pm/view';
 import { act, createReactManager, render, strictRender } from '@remirror/testing/react';
 
@@ -91,7 +92,7 @@ test('`usePositioner` default values', () => {
     const positionerProps = usePositioner('bubble');
     const positioners = useMultiPositioner('bubble');
 
-    expect(positionerProps).toEqual({ active: false });
+    expect(positionerProps).toEqual({ active: false, ...emptyCoords, ...emptyVirtualPosition });
     expect(positioners).toEqual([]);
 
     return <div />;

--- a/packages/@remirror/react/src/hooks/editor-hooks.ts
+++ b/packages/@remirror/react/src/hooks/editor-hooks.ts
@@ -28,6 +28,7 @@ import {
 } from '@remirror/core';
 import {
   ElementsAddedParameter,
+  emptyCoords,
   emptyVirtualPosition,
   getPositioner,
   Positioner,
@@ -444,6 +445,9 @@ export interface UsePositionerReturn extends Partial<UseMultiPositionerReturn> {
  * active position exists for the provided positioner it will return an object
  * with the `ref`, `top`, `left`, `bottom`, `right` properties.
  *
+ * @param isActive - Set this to a boolean to override whether the positioner is
+ * active. `true` leaves the behaviour unchanged.
+ *
  *
  * @remarks
  *
@@ -469,14 +473,17 @@ export interface UsePositionerReturn extends Partial<UseMultiPositionerReturn> {
  * )
  * ```
  */
-export function usePositioner(positioner: Positioner | StringPositioner): UsePositionerReturn {
+export function usePositioner(
+  positioner: Positioner | StringPositioner,
+  isActive = true,
+): UsePositionerReturn {
   const positions = useMultiPositioner(positioner);
 
-  if (positions.length > 0) {
+  if (positions.length > 0 && isActive) {
     return { ...positions[0], active: true };
   }
 
-  return { active: false };
+  return { ...emptyVirtualPosition, ...emptyCoords, active: false };
 }
 
 /**

--- a/support/e2e/src/positioner.e2e.test.ts
+++ b/support/e2e/src/positioner.e2e.test.ts
@@ -22,12 +22,15 @@ describe('Positioner', () => {
       await $editor.type('This is text', { delay: 20 });
       await expect($editor.innerHTML()).resolves.toMatchSnapshot();
       const $bubbleMenu = await getByTestId($document, 'bubble-menu');
-      await expect($bubbleMenu.getAttribute('style')).resolves.toBe('position:absolute');
+      await expect($bubbleMenu.getAttribute('style')).resolves.toBe(
+        'bottom:999999px;left:-999999px;position:absolute',
+      );
 
       await selectAll();
       const $visibleBubbleMenu = await getByTestId($document, 'bubble-menu');
       const newStyles = await $visibleBubbleMenu.getAttribute('style');
       expect(newStyles).toInclude('bottom');
+      expect(newStyles).not.toInclude('999999px');
       expect(newStyles).toInclude('left');
 
       const $boldButton = await getByText($document, 'Bold');


### PR DESCRIPTION
### Description

- #516 with social emoji popup when scroll bars are visible.
- Export `emptyCoords` object from `@remirror/extension-positioner`.
- Add second parameter to `usePositioner` hook which can override when a positioner should be set to active.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-08-15 22 42 26](https://user-images.githubusercontent.com/1160934/90322451-1b7e6c00-df4c-11ea-86c2-2f96494b7805.gif)
