### PR TITLE
fix(release): link unscoped packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -67,15 +67,20 @@
       "@remirror/preset-social",
       "@remirror/preset-table",
       "@remirror/preset-wysiwyg",
-      "@remirror/react-utils",
       "@remirror/react-social",
+      "@remirror/react-utils",
       "@remirror/react-wysiwyg",
       "@remirror/react",
       "@remirror/showcase",
       "@remirror/styles",
       "@remirror/theme",
+      "a11y-status",
+      "jest-prosemirror",
       "jest-remirror",
-      "remirror"
+      "multishift",
+      "prosemirror-suggest",
+      "remirror",
+      "test-keyboard"
     ]
   ],
   "access": "public",

--- a/.changeset/witty-houses-repeat.md
+++ b/.changeset/witty-houses-repeat.md
@@ -1,0 +1,9 @@
+---
+'a11y-status': major
+'jest-prosemirror': major
+'multishift': major
+'prosemirror-suggest': major
+'test-keyboard': major
+---
+
+Required temporary fix to resolve issue with unlinked packages in prerelease mode. See the [issue](https://github.com/atlassian/changesets/issues/442) for more details.


### PR DESCRIPTION
### Description

Required temporary fix to resolve issue with unlinked packages in prerelease mode. See the [issue](https://github.com/atlassian/changesets/issues/442) for more details.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
