### PR TITLE
fix(react): `onChange` callback in `StrictMode`

### DIFF
--- a/.changeset/smooth-dryers-impress.md
+++ b/.changeset/smooth-dryers-impress.md
@@ -1,0 +1,6 @@
+---
+'@remirror/react': patch
+'remirror': patch
+---
+
+Fixes #555 `onChange` callback not being updated when using a controlled editor in `StrictMode`.

--- a/packages/@remirror/react/src/components/__tests__/react-editor-controlled.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/react-editor-controlled.spec.tsx
@@ -477,7 +477,7 @@ test('support for rendering a nested controlled editor in strict mode', () => {
 });
 
 describe('onChange', () => {
-  const chain = RemirrorTestChain.create(createReactManager(() => [new BoldExtension()]));
+  const chain = RemirrorTestChain.create(createReactManager(() => []));
   const mock = jest.fn();
 
   const Component = () => {
@@ -504,7 +504,7 @@ describe('onChange', () => {
   };
 
   const TextEditor = () => {
-    const { getRootProps } = useRemirror<BoldExtension>();
+    const { getRootProps } = useRemirror();
 
     return (
       <>
@@ -512,6 +512,10 @@ describe('onChange', () => {
       </>
     );
   };
+
+  beforeEach(() => {
+    mock.mockClear();
+  });
 
   it('updates values', () => {
     render(<Component />);

--- a/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
@@ -1,9 +1,20 @@
 import { axe } from 'jest-axe';
-import React from 'react';
+import { RemirrorTestChain } from 'jest-remirror';
+import React, { useState } from 'react';
 import { renderToString } from 'react-dom/server';
 
 import { AnyCombinedUnion, fromHtml } from '@remirror/core';
-import { act, createReactManager, fireEvent, strictRender } from '@remirror/testing/react';
+import {
+  act,
+  createReactManager,
+  fireEvent,
+  RemirrorProvider,
+  render,
+  strictRender,
+  useManager,
+  useRemirror,
+} from '@remirror/testing/react';
+import { BoldExtension } from 'remirror/extension/bold';
 
 import type { RemirrorContextProps } from '../../react-types';
 import { ReactEditor } from '../react-editor';
@@ -308,5 +319,63 @@ describe('focus', () => {
     });
 
     expect(context.getState().selection.from).toBe(1);
+  });
+});
+
+describe('onChange', () => {
+  const chain = RemirrorTestChain.create(createReactManager(() => [new BoldExtension()]));
+  const mock = jest.fn();
+
+  const Component = () => {
+    const manager = useManager(chain.manager);
+
+    const [state, setState] = useState(0);
+
+    const onChange = () => {
+      setState((value) => value + 1);
+      mock(state);
+    };
+
+    return (
+      <RemirrorProvider manager={manager} onChange={onChange}>
+        <TextEditor />
+      </RemirrorProvider>
+    );
+  };
+
+  const TextEditor = () => {
+    const { getRootProps } = useRemirror<BoldExtension>();
+
+    return (
+      <>
+        <div {...getRootProps()} />
+      </>
+    );
+  };
+
+  it('updates values', () => {
+    render(<Component />);
+
+    for (const char of 'mazing!') {
+      act(() => {
+        chain.insertText(char);
+      });
+    }
+
+    expect(mock).toHaveBeenCalledTimes(8);
+    expect(mock).toHaveBeenLastCalledWith(7);
+  });
+
+  it('updates values in `StrictMode`', () => {
+    strictRender(<Component />);
+
+    for (const char of 'mazing!') {
+      act(() => {
+        chain.insertText(char);
+      });
+    }
+
+    expect(mock).toHaveBeenCalledTimes(8);
+    expect(mock).toHaveBeenLastCalledWith(7);
   });
 });

--- a/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
@@ -14,7 +14,6 @@ import {
   useManager,
   useRemirror,
 } from '@remirror/testing/react';
-import { BoldExtension } from 'remirror/extension/bold';
 
 import type { RemirrorContextProps } from '../../react-types';
 import { ReactEditor } from '../react-editor';
@@ -323,7 +322,7 @@ describe('focus', () => {
 });
 
 describe('onChange', () => {
-  const chain = RemirrorTestChain.create(createReactManager(() => [new BoldExtension()]));
+  const chain = RemirrorTestChain.create(createReactManager(() => []));
   const mock = jest.fn();
 
   const Component = () => {
@@ -344,7 +343,7 @@ describe('onChange', () => {
   };
 
   const TextEditor = () => {
-    const { getRootProps } = useRemirror<BoldExtension>();
+    const { getRootProps } = useRemirror();
 
     return (
       <>
@@ -352,6 +351,10 @@ describe('onChange', () => {
       </>
     );
   };
+
+  beforeEach(() => {
+    mock.mockClear();
+  });
 
   it('updates values', () => {
     render(<Component />);


### PR DESCRIPTION
### Description

Fixes `onChange` callback not being updated when using a controlled editor in `StrictMode`.

Issues: #555

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
