### PR TITLE
Add positioner to center on a selected annotation

### DIFF
--- a/.changeset/tender-beers-breathe.md
+++ b/.changeset/tender-beers-breathe.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': minor
+---
+
+Provide positioner to center on a selected annotation

--- a/packages/@remirror/extension-annotation/package.json
+++ b/packages/@remirror/extension-annotation/package.json
@@ -28,10 +28,12 @@
   },
   "devDependencies": {
     "@remirror/core": "1.0.0-next.22",
+    "@remirror/extension-positioner": "*",
     "@remirror/pm": "1.0.0-next.22"
   },
   "peerDependencies": {
     "@remirror/core": "1.0.0-next.22",
+    "@remirror/extension-positioner": "1.0.0-next.22",
     "@remirror/pm": "1.0.0-next.22"
   },
   "publishConfig": {

--- a/packages/@remirror/extension-annotation/package.json
+++ b/packages/@remirror/extension-annotation/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@remirror/core": "1.0.0-next.22",
-    "@remirror/extension-positioner": "*",
+    "@remirror/extension-positioner": "1.0.0-next.22",
     "@remirror/pm": "1.0.0-next.22"
   },
   "peerDependencies": {

--- a/packages/@remirror/extension-annotation/src/index.ts
+++ b/packages/@remirror/extension-annotation/src/index.ts
@@ -1,2 +1,3 @@
 export type { Annotation, AnnotationOptions } from './types';
 export { AnnotationExtension } from './annotation-extension';
+export { createCenteredAnnotationPositioner } from './positioners';

--- a/packages/@remirror/extension-annotation/src/positioners.ts
+++ b/packages/@remirror/extension-annotation/src/positioners.ts
@@ -3,7 +3,7 @@ import {
   emptyVirtualPosition,
   hasStateChanged,
   Positioner,
-} from 'remirror/extension/positioner';
+} from '@remirror/extension-positioner';
 
 import type { Annotation } from './types';
 

--- a/packages/@remirror/extension-annotation/src/positioners.ts
+++ b/packages/@remirror/extension-annotation/src/positioners.ts
@@ -1,0 +1,98 @@
+import {
+  Coords,
+  emptyVirtualPosition,
+  hasStateChanged,
+  Positioner,
+} from 'remirror/extension/positioner';
+
+import type { Annotation } from './types';
+
+/**
+ * You can pass `helpers.getAnnotationsAt`, which implements the required
+ * behavior.
+ *
+ * @returns the annotations at a specific position
+ */
+type GetAnnotationsAt = (pos: number) => Annotation[];
+
+/**
+ * Render a positioner which is centered around a selected annotation.
+ *
+ * @remarks
+ *
+ * The menu will horizontally center itself `from` / `to` bounds of the current
+ * selected annotation.
+ *
+ * - `right` is undefined
+ * - `left` will center your element based on the width of the current selected
+ *   annotation
+ *   .
+ * - `bottom` absolutely positions the element below the selected annotation.
+ * - `top` absolutely positions the element above the selected annotation
+ */
+export const createCenteredAnnotationPositioner = (getAnnotationsAt: GetAnnotationsAt) => {
+  return Positioner.create<{
+    start: Coords;
+    end: Coords;
+  }>({
+    hasChanged: hasStateChanged,
+    getActive: (parameter) => {
+      const { state, view } = parameter;
+
+      if (!state.selection.empty) {
+        return [];
+      }
+
+      const annotations = getAnnotationsAt(state.selection.from);
+
+      if (annotations.length === 0) {
+        return [];
+      }
+
+      // Using the shortest annotation allows users to select the other
+      // overlapping annotation. If we were to use e.g. the longest annotation,
+      // there is the possibility that the shorter annotations aren't selectable
+      // because they might be fully overlapped by the longer annotation.
+      const shortestAnnotation = annotations.sort(
+        (annotation1, annotation2) => annotation1.text.length - annotation2.text.length,
+      )[0];
+
+      const start = view.coordsAtPos(shortestAnnotation.from);
+      const end = view.coordsAtPos(shortestAnnotation.to);
+
+      return [{ start, end }];
+    },
+
+    getPosition(parameter) {
+      const { element, data } = parameter;
+      const { start, end } = data;
+      const parent = element.offsetParent;
+
+      if (!parent) {
+        return emptyVirtualPosition;
+      }
+
+      // The box in which the bubble menu is positioned, to use as an anchor
+      const parentBox = parent.getBoundingClientRect();
+
+      // The bubble menu element
+      const elementBox = element.getBoundingClientRect();
+
+      const calculatedLeft = (start.left + end.left) / 2 - parentBox.left;
+      const left = Math.min(
+        parentBox.width - elementBox.width / 2,
+        Math.max(calculatedLeft, elementBox.width / 2),
+      );
+      const top = Math.trunc(start.top - parentBox.top);
+      const bottom = Math.trunc(start.bottom - parentBox.top);
+      const rect = new DOMRect(
+        start.left,
+        start.top,
+        end.right - start.left,
+        end.bottom - start.top,
+      );
+
+      return { rect, left, top, bottom, right: left };
+    },
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,7 +388,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.11.0
       '@remirror/core': 1.0.0-next.22
-      '@remirror/extension-positioner': '*'
+      '@remirror/extension-positioner': 1.0.0-next.22
       '@remirror/pm': 1.0.0-next.22
   packages/@remirror/extension-auto-link:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,10 +383,12 @@ importers:
       '@babel/runtime': 7.11.2
     devDependencies:
       '@remirror/core': 'link:../core'
+      '@remirror/extension-positioner': 'link:../extension-positioner'
       '@remirror/pm': 'link:../pm'
     specifiers:
       '@babel/runtime': ^7.11.0
       '@remirror/core': 1.0.0-next.22
+      '@remirror/extension-positioner': '*'
       '@remirror/pm': 1.0.0-next.22
   packages/@remirror/extension-auto-link:
     dependencies:
@@ -5015,9 +5017,7 @@ packages:
       '@hapi/bourne': 1.3.2
       '@hapi/hoek': 8.5.1
       '@hapi/topo': 3.1.6
-    deprecated:
-      "joi is leaving the @hapi organization and moving back to 'joi'
-      (https://github.com/sideway/joi/issues/2411)"
+    deprecated: 'joi is leaving the @hapi organization and moving back to ''joi'' (https://github.com/sideway/joi/issues/2411)'
     dev: false
     resolution:
       integrity: sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==
@@ -5028,9 +5028,7 @@ packages:
       '@hapi/hoek': 9.0.4
       '@hapi/pinpoint': 2.0.0
       '@hapi/topo': 5.0.0
-    deprecated:
-      "joi is leaving the @hapi organization and moving back to 'joi'
-      (https://github.com/sideway/joi/issues/2411)"
+    deprecated: 'joi is leaving the @hapi organization and moving back to ''joi'' (https://github.com/sideway/joi/issues/2411)'
     dev: false
     resolution:
       integrity: sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==
@@ -9774,8 +9772,7 @@ packages:
       path-is-absolute: 1.0.1
       readdirp: 2.2.1
       upath: 1.2.0
-    deprecated:
-      Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
+    deprecated: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
     dev: false
     optionalDependencies:
       fsevents: 1.2.13
@@ -10411,16 +10408,12 @@ packages:
     resolution:
       integrity: sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
   /core-js/1.2.7:
-    deprecated:
-      'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues.
-      Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
     dev: false
     resolution:
       integrity: sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
   /core-js/2.6.11:
-    deprecated:
-      'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues.
-      Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
     dev: false
     requiresBuild: true
     resolution:
@@ -13630,9 +13623,7 @@ packages:
     dependencies:
       bindings: 1.5.0
       nan: 2.14.1
-    deprecated:
-      fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents
-      2.
+    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
     dev: false
     engines:
       node: '>= 4.0'
@@ -18354,9 +18345,7 @@ packages:
   /mkdirp/0.5.3:
     dependencies:
       minimist: 1.2.5
-    deprecated:
-      Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the
-      API surface has changed to use Promises in 1.x.)
+    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
     dev: false
     hasBin: true
     resolution:
@@ -20274,8 +20263,7 @@ packages:
     resolution:
       integrity: sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==
   /popper.js/1.16.1:
-    deprecated:
-      'You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1'
+    deprecated: 'You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1'
     dev: false
     resolution:
       integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
@@ -22932,9 +22920,7 @@ packages:
       request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
-    deprecated:
-      'request-promise-native has been deprecated because it extends the now deprecated request
-      package, see https://github.com/request/request/issues/3142'
+    deprecated: 'request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142'
     engines:
       node: '>=0.12.0'
     peerDependencies:
@@ -25421,9 +25407,7 @@ packages:
     engines:
       node: '>= 6'
     peerDependencies:
-      typescript:
-        '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev ||
-        >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     resolution:
       integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tty-browserify/0.0.0:


### PR DESCRIPTION
When working with annotations (extention-annotation), it's handy to have a positioner that places a popup in the middle of the selected annotation. This allows e.g. to add a popup to remove/change the annotation when the user clicks on it.

@see https://discord.com/channels/726035064831344711/745695557976195072/745697774355480606

### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] ~New code is unit tested~ and all current tests pass when running `pnpm test`. - [Discussed with @ifiokjr](https://discord.com/channels/726035064831344711/745695557976195072/745762246013091922) to not test the code for now
