### PR TITLE
Add command to clear current range selection

### DIFF
--- a/.changeset/rotten-foxes-judge.md
+++ b/.changeset/rotten-foxes-judge.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Add command to clear current range selection

--- a/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
@@ -46,6 +46,7 @@ test('clears range selection', () => {
   expect(commands.clearRangeSelection()).toBeTrue();
 
   expect(editor.state.selection.to).toBe(editor.state.selection.from);
+  expect(editor.state.doc).toEqualRemirrorDocument(doc(p('')));
 });
 
 test('rejects clearing range selection if there is none', () => {

--- a/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
@@ -30,3 +30,30 @@ test('can chain commands', () => {
 
   expect(editor.state.doc).toEqualRemirrorDocument(doc(p(bold(italic('my content')))));
 });
+
+test('clears range selection', () => {
+  const text = 'my content';
+
+  const editor = renderEditor([]);
+  const { doc, p } = editor.nodes;
+  const { commands } = editor;
+
+  editor.add(doc(p(`<start>${text}<end>`)));
+
+  // Pre-condition: range selection covers complete text
+  expect(editor.state.selection.to).toBe(editor.state.selection.from + text.length);
+
+  expect(commands.clearRangeSelection()).toBeTrue();
+
+  expect(editor.state.selection.to).toBe(editor.state.selection.from);
+});
+
+test('rejects clearing range selection if there is none', () => {
+  const editor = renderEditor([]);
+  const { doc, p } = editor.nodes;
+  const { commands } = editor;
+
+  editor.add(doc(p('my content')));
+
+  expect(commands.clearRangeSelection()).toBeFalse();
+});

--- a/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
@@ -46,7 +46,7 @@ test('clears range selection', () => {
   expect(commands.clearRangeSelection()).toBeTrue();
 
   expect(editor.state.selection.to).toBe(editor.state.selection.from);
-  expect(editor.state.doc).toEqualRemirrorDocument(doc(p('')));
+  expect(editor.state.doc).toEqualRemirrorDocument(doc(p(text)));
 });
 
 test('rejects clearing range selection if there is none', () => {

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -10,6 +10,7 @@ import type {
   ProsemirrorAttributes,
   Transaction,
 } from '@remirror/core-types';
+import { TextSelection } from '@remirror/pm/state';
 import type { EditorView } from '@remirror/pm/view';
 
 import { extensionDecorator } from '../decorators';
@@ -240,6 +241,26 @@ export class CommandsExtension extends PlainExtension {
         return ({ tr, dispatch }) => {
           if (dispatch) {
             dispatch(tr.setNodeMarkup(pos, undefined, attrs));
+          }
+
+          return true;
+        };
+      },
+
+      /**
+       * Fire an update to remove the current range selection. The cursor will
+       * be placed at the beginning of the current range selection.
+       */
+      clearRangeSelection: (): CommandFunction => {
+        return ({ tr, dispatch }) => {
+          const { selection } = tr;
+
+          if (selection.empty) {
+            return false;
+          }
+
+          if (dispatch) {
+            dispatch(tr.setSelection(TextSelection.create(tr.doc, tr.selection.from)));
           }
 
           return true;


### PR DESCRIPTION
### Description

Add command to clear current range selection

See https://discord.com/channels/726035064831344711/726035065338986528/745695215104557126

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
