### PR TITLE
Document how to limit tests to a specific package

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,6 +84,12 @@ Always create your tests inside of a `__tests__/` sub-folder.
 - Unit tests: `*.spec.ts(x)`
 - Integration tests: `*.e2e.test.ts` within the `/e2e` folder
 
+Unit tests can be run limited to a specific package, e.g. for `extension-bold`:
+
+```bash
+pnpm test extension-bold
+```
+
 <br />
 
 ## Using Git


### PR DESCRIPTION
### Description

I spent today - for the second time - a considerable amount of time to find out how to limit the tests to a specific package. Google pointed me consistently to the non-working `pnpm test --filter @remirror/...`.

I could imagine this to be helpful for others working their way into remirror development. Feel free to reject if you find this too obvious.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
