### PR TITLE
Add range parameter to `commands.insertText`

### DIFF
--- a/.changeset/itchy-owls-trade.md
+++ b/.changeset/itchy-owls-trade.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Add range parameter to `commands.insertText`. Closes #327.

--- a/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/commands-extension.spec.ts
@@ -58,3 +58,17 @@ test('rejects clearing range selection if there is none', () => {
 
   expect(commands.clearRangeSelection()).toBeFalse();
 });
+
+test('it can insert a range of text', () => {
+  const editor = renderEditor([]);
+  const { doc, p } = editor.nodes;
+
+  editor.add(doc(p('my <cursor>content')));
+  editor.commands.insertText('awesome ');
+
+  expect(editor.doc).toEqualProsemirrorNode(doc(p('my awesome content')));
+
+  editor.commands.insertText('all ', { from: 1 });
+
+  expect(editor.doc).toEqualProsemirrorNode(doc(p('all my awesome content')));
+});

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -173,12 +173,14 @@ export class CommandsExtension extends PlainExtension {
       },
 
       /**
-       * Insert text into the dom at the current location.
+       * Insert text into the dom at the current location by default.
        */
-      insertText(text: string): CommandFunction {
+      insertText(text: string, range?: Partial<FromToParameter>): CommandFunction {
         return ({ tr, dispatch }) => {
+          const { from, to } = range ?? tr.selection;
+
           if (dispatch) {
-            dispatch(tr.insertText(text));
+            dispatch(tr.insertText(text, from, to));
           }
 
           return true;


### PR DESCRIPTION
### Description

Add range parameter to `commands.insertText`. Closes #327.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
