### PR TITLE
Fix runtime error in Safari with `ItalicExtension`

### DIFF
--- a/.changeset/new-dogs-fry.md
+++ b/.changeset/new-dogs-fry.md
@@ -1,0 +1,9 @@
+---
+'@remirror/core': minor
+'@remirror/core-utils': minor
+'@remirror/extension-link': minor
+---
+
+Add a new mark input rule parameter property, `updateCaptured` which allows the developer to tweak the details of the captured detail rule. This provides a workaround for the a lack of support for the `lookbehind` regex in **Safari** and other browsers.
+
+Fixes #574.

--- a/packages/@remirror/extension-italic/src/italic-extension.ts
+++ b/packages/@remirror/extension-italic/src/italic-extension.ts
@@ -51,14 +51,21 @@ export class ItalicExtension extends MarkExtension {
   createInputRules(): InputRule[] {
     return [
       markInputRule({
-        regexp: /(?<=(?:^|[^*]))\*([^*]+)\*/,
+        regexp: /(?:^|[^*])\*([^*]+)\*/,
         type: this.type,
         ignoreWhitespace: true,
+        updateCaptured: ({ fullMatch, start }) =>
+          !fullMatch.startsWith('*') ? { fullMatch: fullMatch.slice(1), start: start + 1 } : {},
       }),
       markInputRule({
-        regexp: /(?<=(?:^|[^_]))_([^_]+)_/,
+        regexp: /(?:^|[^_])_([^_]+)_/,
         type: this.type,
         ignoreWhitespace: true,
+        updateCaptured: ({ fullMatch, start }) => {
+          return !fullMatch.startsWith('_')
+            ? { fullMatch: fullMatch.slice(1), start: start + 1 }
+            : {};
+        },
       }),
     ];
   }


### PR DESCRIPTION
### Description

Add a new mark input rule parameter property, `updateCaptured` which allows the developer to tweak the details of the captured detail rule. This provides a workaround for the a lack of support for the `lookbehind` regex in **Safari** and other browsers.

Fixes #574.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

