### PR TITLE
Support dynamic attributes for nodes and marks

### DIFF
--- a/.changeset/grumpy-dolls-drop.md
+++ b/.changeset/grumpy-dolls-drop.md
@@ -1,0 +1,9 @@
+---
+'@remirror/core': minor
+'@remirror/core-utils': minor
+---
+
+🚀 Now featuring support for `DynamicExtraAttributes` as mentioned in [#387](https://github.com/remirror/remirror/issues/387).
+
+- Also add support for `action` method being passed to `findChildren`, `findTextNodes`, `findInlineNodes`, `findBlockNodes`, `findChildrenByAttribute`, `findChildrenByNode`, `findChildrenByMark` and `containsNodesOfType`.
+- Deprecate `flattenNodeDescendants`. `findChildren` is now the preferred method and automatically flattens the returned output.

--- a/packages/@remirror/core-types/src/index.ts
+++ b/packages/@remirror/core-types/src/index.ts
@@ -65,6 +65,7 @@ export type {
   DeepPartial,
   DeepString,
   Diff,
+  DynamicAttributeCreator,
   EmptyShape,
   Flavor,
   Flavoring,

--- a/packages/@remirror/core-utils/src/__tests__/prosemirror-node-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/prosemirror-node-utils.spec.ts
@@ -23,7 +23,7 @@ import {
   flattenNodeDescendants,
 } from '../prosemirror-node-utils';
 
-describe('flatten', () => {
+describe('DEPRECATED flatten', () => {
   it('should throw an error if `node` param is missing', () => {
     expect(flattenNodeDescendants).toThrow();
   });
@@ -58,7 +58,7 @@ describe('findChildren', () => {
     const { state } = createEditor(doc(table(row(tdEmpty), row(tdEmpty), row(tdEmpty))));
     const result = findChildren({
       node: state.doc.firstChild,
-      predicate: (node) => node.type === state.schema.nodes.paragraph,
+      predicate: (child) => child.node.type === state.schema.nodes.paragraph,
     });
 
     expect(result.length).toEqual(3);
@@ -68,11 +68,29 @@ describe('findChildren', () => {
     });
   });
 
+  it('should perform the provided action for truthy matches', () => {
+    const mock = jest.fn();
+    const { state } = createEditor(doc(table(row(tdEmpty), row(tdEmpty), row(tdEmpty))));
+
+    findChildren({
+      node: state.doc.firstChild,
+      predicate: (child) => child.node.type === state.schema.nodes.paragraph,
+      action: mock,
+    });
+
+    expect(mock).toHaveBeenCalledTimes(3);
+
+    mock.mock.calls.forEach(([item]) => {
+      expect(item.node.type.name).toEqual('paragraph');
+    });
+  });
+
   it('should return an empty array if `predicate` returns falsy', () => {
     const { state } = createEditor(doc(table(row(tdEmpty))));
+
     const result = findChildren({
       node: state.doc.firstChild,
-      predicate: (node) => node.type === state.schema.nodes.atomInline,
+      predicate: (child) => child.node.type === state.schema.nodes.atomInline,
     });
 
     expect(result.length).toEqual(0);

--- a/packages/@remirror/core-utils/src/prosemirror-node-utils.ts
+++ b/packages/@remirror/core-utils/src/prosemirror-node-utils.ts
@@ -7,7 +7,6 @@ import type {
   PosParameter,
   PredicateParameter,
   ProsemirrorAttributes,
-  ProsemirrorNode,
   ProsemirrorNodeParameter,
 } from '@remirror/core-types';
 
@@ -22,7 +21,7 @@ interface DescendParameter {
   descend: boolean;
 }
 
-type NodePredicateParameter = PredicateParameter<ProsemirrorNode>;
+type NodePredicateParameter = PredicateParameter<NodeWithPosition>;
 
 /**
  * A node with it's start position.
@@ -31,34 +30,45 @@ type NodePredicateParameter = PredicateParameter<ProsemirrorNode>;
  */
 export interface NodeWithPosition extends ProsemirrorNodeParameter, PosParameter {}
 
+/**
+ * @deprecated - This will be removed soon.
+ */
 interface FlattenParameter extends OptionalProsemirrorNodeParameter, Partial<DescendParameter> {}
 
 /**
- * Flattens descendants of a given `node`.
+ * Flattens descendants of a given `node`. In other words a deeply nested
+ * prosemirror tree will be turned into a flat array of [[`NodeWithPosition`]].
  *
  * @remarks
  *
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const children = flatten(node);
  * ```
+ *
+ * @deprecated - use [[`findChildren`]] instead.
  */
 export function flattenNodeDescendants(parameter: FlattenParameter): NodeWithPosition[] {
   const { node, descend = true } = parameter;
 
+  // Ensure that this is a ProsemirrorNode, if it isn't this will throw an
+  // error.
   invariant(isProsemirrorNode(node), {
     code: ErrorConstant.INTERNAL,
     message: 'Invalid "node" parameter".',
   });
 
+  // This is used to keep track of all the node positions.
   const result: NodeWithPosition[] = [];
 
   node.descendants((child, pos) => {
     result.push({ node: child, pos });
 
     if (!descend) {
-      return false; // Prevent diving into descendants.
+      // This prevents ProseMirror from diving deeper into the descendant tree.
+      return false;
     }
 
     return;
@@ -67,75 +77,130 @@ export function flattenNodeDescendants(parameter: FlattenParameter): NodeWithPos
   return result;
 }
 
-interface FindChildrenParameter extends FlattenParameter, NodePredicateParameter {}
+interface NodeActionParameter {
+  /**
+   * A method which is run whenever the provided predicate returns true.
+   *
+   * This avoids the need for multiple passes over the same data, first to
+   * gather and then to process. When viable ,why not just get it done.
+   */
+  action?: (node: NodeWithPosition) => void;
+}
+
+interface BaseFindParameter
+  extends OptionalProsemirrorNodeParameter,
+    Partial<DescendParameter>,
+    NodeActionParameter {}
+
+interface FindChildrenParameter extends BaseFindParameter, NodePredicateParameter {}
 
 /**
- * Iterates over descendants of a given `node`, returning child nodes predicate returns truthy for.
+ * Iterates over descendants of a given `node`, returning child nodes predicate
+ * returns truthy for.
  *
  * @remarks
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ *
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const textNodes = findChildren(node, child => child.isText, false);
  * ```
  */
-export function findChildren(parameter: FindChildrenParameter) {
-  const { node, predicate, descend } = parameter;
+export function findChildren(parameter: FindChildrenParameter): NodeWithPosition[] {
+  const { node, predicate, descend = true, action } = parameter;
 
-  invariant(node, {
+  // Ensure that the node provided is a `ProsemirrorNode`.
+  invariant(isProsemirrorNode(node), {
     code: ErrorConstant.INTERNAL,
     message: 'Invalid "node" parameter passed to "findChildren".',
   });
+
+  // Ensure that the predicate is a function.
   invariant(isFunction(predicate), {
     code: ErrorConstant.INTERNAL,
     message: 'Invalid "predicate" parameter passed to "findChildren".',
   });
 
-  return flattenNodeDescendants({ node, descend }).filter((child) => predicate(child.node));
+  // This is used to keep track of all the node positions.
+  const result: NodeWithPosition[] = [];
+
+  // This return will be false when the descend is set to `false` and thus
+  // prevent ProseMirror from diving any deeper into the descendant tree.
+  const descendantReturnValue = descend ? undefined : descend;
+
+  // Start descending into the provided node. This can be an expensive operation
+  // if the document is very large or deeply nested.
+  node.descendants((child, pos) => {
+    const nodeWithPosition: NodeWithPosition = { node: child, pos };
+
+    // True when this call matches the required condition - returns `true`.
+    const isMatch = predicate(nodeWithPosition);
+
+    if (!isMatch) {
+      // Move onto the next node or descendant depending on the value of
+      // `descend`.
+      return descendantReturnValue;
+    }
+
+    // Store the result and run the provided action if it exists.
+    result.push(nodeWithPosition);
+    action?.(nodeWithPosition);
+
+    return descendantReturnValue;
+  });
+
+  return result;
 }
 
+/**
+ * A utility for creating methods that find a node by a specific condition.
+ */
 function findNodeByPredicate({ predicate }: NodePredicateParameter) {
-  return (parameters: FlattenParameter) => findChildren({ ...parameters, predicate });
+  return (parameter: BaseFindParameter) => findChildren({ ...parameter, predicate });
 }
 
 /**
  * Returns text nodes of a given `node`.
  *
  * @remarks
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const textNodes = findTextNodes(node);
  * ```
  */
-export const findTextNodes = findNodeByPredicate({ predicate: (child) => child.isText });
+export const findTextNodes = findNodeByPredicate({ predicate: (child) => child.node.isText });
 
 /**
  * Returns inline nodes of a given `node`.
  *
  * @remarks
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const inlineNodes = findInlineNodes(node);
  * ```
  */
-export const findInlineNodes = findNodeByPredicate({ predicate: (child) => child.isInline });
+export const findInlineNodes = findNodeByPredicate({ predicate: (child) => child.node.isInline });
 
 /**
  * Returns block descendants of a given `node`.
  *
  * @remarks
  *
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const blockNodes = findBlockNodes(node);
  * ```
  */
-export const findBlockNodes = findNodeByPredicate({ predicate: (child) => child.isBlock });
+export const findBlockNodes = findNodeByPredicate({ predicate: (child) => child.node.isBlock });
 
-interface FindChildrenByAttrParameter extends FlattenParameter {
+interface FindChildrenByAttrParameter extends BaseFindParameter {
   /**
    * Runs a predicate check after receiving the attrs for the found node.
    */
@@ -143,55 +208,66 @@ interface FindChildrenByAttrParameter extends FlattenParameter {
 }
 
 /**
- * Iterates over descendants of a given `node`, returning child nodes predicate returns truthy for.
+ * Iterates over descendants of a given `node`, returning child nodes predicate
+ * returns truthy for.
  *
  * @remarks
  *
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const mergedCells = findChildrenByAttr(table, attrs => attrs.colspan === 2);
  * ```
  */
-export function findChildrenByAttribute(parameter: FindChildrenByAttrParameter) {
-  const { node, predicate, descend } = parameter;
-  return findChildren({ node, predicate: (child) => predicate(child.attrs), descend });
+export function findChildrenByAttribute(
+  parameter: FindChildrenByAttrParameter,
+): NodeWithPosition[] {
+  const { predicate, ...rest } = parameter;
+  return findChildren({ ...rest, predicate: (child) => predicate(child.node.attrs) });
 }
 
-interface FindChildrenByNodeParameter extends FlattenParameter, NodeTypeParameter {}
+interface FindChildrenByNodeParameter extends BaseFindParameter, NodeTypeParameter {}
 
 /**
- * Iterates over descendants of a given `node`, returning child nodes of a given nodeType.
+ * Iterates over descendants of a given `node`, returning child nodes of a given
+ * nodeType.
  *
  * @remarks
  *
- * It doesn't descend into a node when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a node when descend argument is `false` (defaults to
+ * `true`).
  *
  * ```ts
  * const cells = findChildrenByNode(table, schema.nodes.tableCell);
  * ```
  */
-export function findChildrenByNode(parameter: FindChildrenByNodeParameter) {
-  const { node, type, descend } = parameter;
-  return findChildren({ node, predicate: (child) => child.type === type, descend });
+export function findChildrenByNode(parameter: FindChildrenByNodeParameter): NodeWithPosition[] {
+  const { type, ...rest } = parameter;
+  return findChildren({ ...rest, predicate: (child) => child.node.type === type });
 }
 
-interface FindChildrenByMarkParameter extends FlattenParameter, MarkTypeParameter {}
+interface FindChildrenByMarkParameter extends BaseFindParameter, MarkTypeParameter {}
 
 /**
- * Iterates over descendants of a given `node`, returning child nodes that have a mark of a given markType.
+ * Iterates over descendants of a given `node`, returning child nodes that have
+ * a mark of a given markType.
  *
  * @remarks
  *
- * It doesn't descend into a `node` when descend argument is `false` (defaults to `true`).
+ * It doesn't descend into a `node` when descend argument is `false` (defaults
+ * to `true`).
  *
  * ```ts
  * const nodes = findChildrenByMark(state.doc, schema.marks.strong);
  * ```
  */
-export function findChildrenByMark(paramter: FindChildrenByMarkParameter) {
-  const { node, type, descend } = paramter;
-  return findChildren({ node, predicate: (child) => bool(type.isInSet(child.marks)), descend });
+export function findChildrenByMark(paramter: FindChildrenByMarkParameter): NodeWithPosition[] {
+  const { type, ...rest } = paramter;
+  return findChildren({
+    ...rest,
+    predicate: (child) => bool(type.isInSet(child.node.marks)),
+  });
 }
 
 interface ContainsParameter extends ProsemirrorNodeParameter, NodeTypeParameter {}
@@ -207,7 +283,7 @@ interface ContainsParameter extends ProsemirrorNodeParameter, NodeTypeParameter 
  * }
  * ```
  */
-export function containsNodesOfType(parameter: ContainsParameter) {
+export function containsNodesOfType(parameter: ContainsParameter): boolean {
   const { node, type } = parameter;
   return findChildrenByNode({ node, type }).length > 0;
 }

--- a/packages/@remirror/core/src/builtins/__tests__/__snapshots__/schema-extension.spec.ts.snap
+++ b/packages/@remirror/core/src/builtins/__tests__/__snapshots__/schema-extension.spec.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dynamic schema attributes should dynamically add attributes when configured 1`] = `
+<div contenteditable="true"
+     role="textbox"
+     autofocus="false"
+     aria-multiline="true"
+     aria-label
+     class="ProseMirror remirror-editor"
+>
+  <h1>
+    This is a heading
+    <br>
+  </h1>
+  <p id="1">
+    Welcome to the
+    <strong id="1">
+      bold experiment
+    </strong>
+    <br>
+  </p>
+  <p id="2">
+    <br>
+  </p>
+  <p id="3">
+    <br>
+  </p>
+  <p id="4">
+    <br>
+  </p>
+</div>
+`;
+
+exports[`dynamic schema attributes should dynamically add attributes when configured 2`] = `
+Snapshot Diff:
+Compared values have no visual difference.
+`;

--- a/packages/@remirror/core/src/builtins/__tests__/schema-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/schema-extension.spec.ts
@@ -1,5 +1,51 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
+
+import { BlockquoteExtension } from 'remirror/extension/blockquote';
+import { BoldExtension } from 'remirror/extension/bold';
+import { HeadingExtension } from 'remirror/extension/heading';
 
 import { SchemaExtension } from '..';
 
 extensionValidityTest(SchemaExtension);
+
+describe('dynamic schema attributes', () => {
+  it('should dynamically add attributes when configured', () => {
+    let paragraphId = 0;
+    let markId = 0;
+
+    const mark = {
+      paragraph: jest.fn(() => `${++paragraphId}`),
+      marks: jest.fn(() => `${++markId}`),
+    };
+
+    const editor = renderEditor(
+      [new HeadingExtension(), new BlockquoteExtension(), new BoldExtension()],
+      {
+        extraAttributes: [
+          { identifiers: ['paragraph'], attributes: { id: { default: mark.paragraph } } },
+          { identifiers: 'marks', attributes: { id: mark.marks } },
+        ],
+      },
+    );
+
+    const { doc, heading: h } = editor.nodes;
+
+    editor.add(doc(h('This is a heading<cursor>')));
+    expect(mark.paragraph).not.toHaveBeenCalled();
+    expect(mark.marks).not.toHaveBeenCalled();
+
+    editor.insertText('\nWelcome to the **bold** experiment\n\n\n');
+    expect(mark.marks).toHaveBeenCalledTimes(1);
+    expect(mark.paragraph).toHaveBeenCalledTimes(4);
+
+    const outerHtml = editor.dom.outerHTML;
+    expect(editor.dom.outerHTML).toMatchSnapshot();
+
+    editor.selectText(1);
+
+    // Nothing should have changed.
+    expect(mark.marks).toHaveBeenCalledTimes(1);
+    expect(mark.paragraph).toHaveBeenCalledTimes(4);
+    expect(outerHtml).toMatchDiffSnapshot(editor.dom.outerHTML);
+  });
+});

--- a/packages/@remirror/core/src/builtins/keymap-extension.ts
+++ b/packages/@remirror/core/src/builtins/keymap-extension.ts
@@ -171,8 +171,9 @@ export class KeymapExtension extends PlainExtension<KeymapOptions> {
   };
 
   /**
-   * TODO think about the case where bindings are being disposed and then added
-   * in a different position in the `extraKeyBindings` array.
+   * @internalremarks Think about the case where bindings are disposed of and then
+   * added in a different position in the `extraKeyBindings` array. This is
+   * especially pertinent when using hooks.
    */
   protected onAddCustomHandler: AddCustomHandler<KeymapOptions> = ({ keymap }) => {
     if (!keymap) {

--- a/packages/@remirror/core/src/builtins/schema-extension.ts
+++ b/packages/@remirror/core/src/builtins/schema-extension.ts
@@ -3,6 +3,7 @@ import {
   entries,
   invariant,
   isArray,
+  isEmptyObject,
   isFunction,
   isNullOrUndefined,
   isString,
@@ -11,6 +12,7 @@ import {
 } from '@remirror/core-helpers';
 import type {
   ApplySchemaAttributes,
+  DynamicAttributeCreator,
   EditorSchema,
   Mark,
   MarkExtensionSpec,
@@ -21,8 +23,16 @@ import type {
   SchemaAttributes,
   SchemaAttributesObject,
   Static,
+  Transaction,
 } from '@remirror/core-types';
-import { isElementDomNode, isProsemirrorMark, isProsemirrorNode } from '@remirror/core-utils';
+import {
+  findChildren,
+  getMarkRange,
+  isElementDomNode,
+  isProsemirrorMark,
+  isProsemirrorNode,
+  NodeWithPosition,
+} from '@remirror/core-utils';
 import { Schema } from '@remirror/pm/model';
 
 import { extensionDecorator } from '../decorators';
@@ -36,10 +46,47 @@ import {
   SchemaFromExtensionUnion,
 } from '../extension';
 import type { AnyCombinedUnion, InferCombinedExtensions } from '../preset';
+import type { CreatePluginReturn } from '../types';
 
 /**
- * This extension creates the schema and provides extra attributes as defined in
- * the manager or the extension settings.
+ * This is the schema extension which creates the schema and provides extra
+ * attributes as defined in the manager or the extension settings.
+ *
+ * @remarks
+ *
+ * The schema is the most important part of the remirror editor. This is the
+ * extension responsible for creating it, injecting extra attributes and
+ * managing the plugin which is responsible for making sure dynamically created
+ * attributes are updated.
+ *
+ * In order to add extra attributes the following would work.
+ *
+ * ```ts
+ * import { RemirrorManager } from 'remirror/core';
+ * import uuid from 'uuid';
+ * import hash from 'made-up-hasher';
+ *
+ * const manager = RemirrorManager.create([], {
+ *   extraAttributes: [
+ *     {
+ *       identifiers: 'nodes',
+ *       attributes: {
+ *         awesome: {
+ *           default: 'awesome',
+ *           parseDOM: (domNode) => domNode.getAttribute('data-awesome'),
+ *           toDOM: (node) => ({ 'data-awesome': node.attrs.awesome })
+ *         },
+ *       },
+ *     },
+ *     { identifiers: ['paragraph'], attributes: { id: { default: () => uuid() } } },
+ *     { identifiers: ['bold'], attributes: { hash: (mark) => hash(JSON.stringify(mark.attrs)) } },
+ *   ],
+ * })
+ * ```
+ *
+ * It is an array of identifiers and attributes. Setting the default to a
+ * function allows you to set up a dynamic attribute which is updated with the
+ * synchronous function that you provide to it.
  *
  * @builtin
  */
@@ -49,64 +96,279 @@ export class SchemaExtension extends PlainExtension {
     return 'schema' as const;
   }
 
-  onCreate() {
+  /**
+   * The dynamic attributes for each node and mark extension.
+   *
+   * The structure will look like the following.
+   *
+   * ```ts
+   * {
+   *   paragraph: { id: () => uid(), hash: (node) => hash(node) },
+   *   bold: { random: () => Math.random(), created: () => Date.now() },
+   * };
+   * ```
+   *
+   * This object is used by the created plugin to listen for changes to the doc,
+   * and check for new nodes and marks which haven't yet applied the dynamic
+   * attribute and add the attribute.
+   */
+  #dynamicAttributes: DynamicSchemaAttributeCreators = { marks: object(), nodes: object() };
+
+  /**
+   * This method is responsible for creating, configuring and adding the
+   * `schema` to the editor. `Schema` is a special type in ProseMirror editors
+   * and with `remirror` it's all just handled for you.
+   *
+   * TODO: Add support for using a custom schema #460
+   */
+  onCreate(): void {
     const { managerSettings } = this.store;
+
+    // This nodes object is built up for each extension and then at the end it
+    // will be passed to the `Schema` constructor to create a new `schema`.
     const nodes: Record<string, NodeExtensionSpec> = object();
+
+    // Similar to the `nodes` object above this is passed to the `Schema`.
     const marks: Record<string, MarkExtensionSpec> = object();
-    const namedExtraAttributes = transformExtraAttributes({
+
+    // Get the named extra attributes from the manager. This allows each extra
+    // attribute group added to the manager to be applied to the individual
+    // extensions which specified.
+    const namedExtraAttributes = getNamedSchemaAttributes({
       settings: managerSettings,
       gatheredSchemaAttributes: this.gatherExtraAttributes(this.store.extensions),
       nodeNames: this.store.nodeNames,
       markNames: this.store.markNames,
     });
 
-    // Skip the for loop by setting the list to empty when extra attributes are
-    // disabled
-
     for (const extension of this.store.extensions) {
-      const currentAttributes = namedExtraAttributes[extension.name] ?? object();
-
+      // Pick the current attributes from the named attributes and merge them
+      // with the extra attributes which were added to the extension. Extra
+      // attributes added to the extension are prioritized.
       namedExtraAttributes[extension.name] = {
-        ...currentAttributes,
-        ...(extension.options.extraAttributes ?? object()),
+        ...namedExtraAttributes[extension.name],
+        ...extension.options.extraAttributes,
       };
 
+      // There are several places that extra attributes can be ignored. This
+      // checks them all.
       const ignoreExtraAttributes =
         managerSettings.disableExtraAttributes === true ||
         extension.options.disableExtraAttributes === true ||
         extension.constructor.disableExtraAttributes === true;
 
       if (isNodeExtension(extension)) {
-        const spec = createSpec({
+        // Create the spec and gather dynamic attributes for this node
+        // extension.
+        const { spec, dynamic } = createSpec({
           createExtensionSpec: (extra) => extension.createNodeSpec(extra),
           extraAttributes: namedExtraAttributes[extension.name],
           ignoreExtraAttributes,
           name: extension.constructor.name,
         });
 
+        // Store the node spec on the extension for future reference.
         extension.spec = spec;
+
+        // Add the spec to the nodes object which is used to create the schema
+        // with the same name as the extension name.
         nodes[extension.name] = spec;
+
+        // Keep track of the dynamic attributes. The `extension.name` is the
+        // same name of the `NodeType` and is used by the plugin in this
+        // extension to dynamically generate attributes for the correct nodes.
+        this.#dynamicAttributes.nodes[extension.name] = dynamic;
       }
 
+      // Very similar to the previous conditional block except for marks rather
+      // than nodes.
       if (isMarkExtension(extension)) {
-        const spec = createSpec({
+        // Create the spec and gather dynamic attributes for this mark
+        // extension.
+        const { spec, dynamic } = createSpec({
           createExtensionSpec: (extra) => extension.createMarkSpec(extra),
           extraAttributes: namedExtraAttributes[extension.name],
           ignoreExtraAttributes,
           name: extension.constructor.name,
         });
 
+        // Store the mark spec on the extension for future reference.
         extension.spec = spec;
+
+        // Add the spec to the `marks` object which is used to create the schema
+        // with the same name as the extension name.
         marks[extension.name] = spec;
+        this.#dynamicAttributes.marks[extension.name] = dynamic;
       }
     }
 
+    // Create the schema from the gathered nodes and marks.
     const schema = new Schema({ nodes, marks });
 
+    // Store the `nodes`, `marks` and `schema` on the manager store. For example
+    // the `schema` can be accessed via `manager.store.schema`.
     this.store.setStoreKey('nodes', nodes);
     this.store.setStoreKey('marks', marks);
     this.store.setStoreKey('schema', schema);
+
+    // Add the schema to the extension store, so that all extension from this
+    // point have access to the schema via `this.store.schema`.
     this.store.setExtensionStore('schema', schema);
+  }
+
+  /**
+   * This creates the plugin that is used to automatically create the dynamic
+   * attributes defined in the extra attributes object.
+   */
+  createPlugin(): CreatePluginReturn {
+    return {
+      appendTransaction: (transactions, _, nextState) => {
+        // This creates a new transaction which will be used to update the
+        // attributes of any node and marks which
+        const { tr } = nextState;
+
+        // The dynamic attribute updates only need to be run if the document has
+        // been modified in a transaction.
+        const documentHasChanged = transactions.some((tr) => tr.docChanged);
+
+        if (!documentHasChanged) {
+          // The document has not been changed therefore no updates are
+          // required.
+          return null;
+        }
+
+        // The find children method could potentially be quite expensive. Before
+        // committing to that level of work let's check that there user has
+        // actually defined some dynamic attributes.
+        if (
+          isEmptyObject(this.#dynamicAttributes.nodes) ||
+          isEmptyObject(this.#dynamicAttributes.marks)
+        ) {
+          return null;
+        }
+
+        // This function loops through every node in the document and add the
+        // dynamic attributes when any relevant nodes have been added.
+        findChildren({
+          // The parent node is the entire document.
+          node: tr.doc,
+
+          // This means that all nodes will be checked since it always returns
+          // true.
+          predicate: () => true,
+
+          // An action handler which is called whenever the predicate is truthy,
+          // which in this case is all the time.
+          action: (child) => {
+            this.checkAndUpdateDynamicNodes(child, tr);
+            this.checkAndUpdateDynamicMarks(child, tr);
+          },
+        });
+
+        // If the transaction has any `steps` then it has been modified and
+        // should be returned i.e. appended to the additional transactions.
+        // However, if there are no steps then ignore and return `null`.
+        return tr.steps.length > 0 ? tr : null;
+      },
+    };
+  }
+
+  /**
+   * Check the dynamic nodes to see if the provided node:
+   *
+   * - a) is dynamic and therefore can be updated.
+   * - b) has just been created and does not yet have a value for the dynamic
+   *   node.
+   *
+   * @param child - the node and its position.
+   * @param tr - the mutable ProseMirror transaction which is applied to create
+   * the next editor state
+   */
+  private checkAndUpdateDynamicNodes(child: NodeWithPosition, tr: Transaction) {
+    const { node, pos } = child;
+
+    // Check for matching nodes.
+    for (const [name, dynamic] of entries(this.#dynamicAttributes.nodes)) {
+      if (node.type.name !== name) {
+        continue;
+      }
+
+      for (const [attributeName, attributeCreator] of entries(dynamic)) {
+        if (!isNullOrUndefined(node.attrs[attributeName])) {
+          continue;
+        }
+
+        // The new attributes which will be added to the node.
+        const attrs = { ...node.attrs, [attributeName]: attributeCreator(node) };
+
+        // Apply the new dynamic attribute to the node via the transaction.
+        tr.setNodeMarkup(pos, undefined, attrs);
+      }
+    }
+  }
+
+  /**
+   * Loop through the dynamic marks to see if the provided node:
+   *
+   * - a) is wrapped by a matching mark.
+   * - b) has just been added and doesn't yet have the dynamic attribute
+   *   applied.
+   *
+   * @param child - the node and its position.
+   * @param tr - the mutable ProseMirror transaction which is applied to create
+   * the next editor state.
+   */
+  private checkAndUpdateDynamicMarks(child: NodeWithPosition, tr: Transaction) {
+    const { node, pos } = child;
+
+    // Check for matching marks.
+    for (const [name, dynamic] of entries(this.#dynamicAttributes.marks)) {
+      // This is needed to create the new mark. Even though a mark may already
+      // exist ProseMirror requires that a new one is created and added in
+      // order. More details available
+      // [here](https://discuss.prosemirror.net/t/updating-mark-attributes/776/2?u=ifi).
+      const type = this.store.schema.marks[name];
+
+      // Get the attrs from the mark.
+      const mark = node.marks.find((mark) => mark.type.name === name);
+
+      // If the mark doesn't exist within the set then move to the next
+      // dynamically updated mark.
+      if (!mark) {
+        continue;
+      }
+
+      // Loop through to find if any of the required matches are missing from
+      // the dynamic attribute;
+      for (const [attributeName, attributeCreator] of entries(dynamic)) {
+        // When the attributes for this dynamic attributeName are already
+        // defined we should move onto the next item;
+        if (!isNullOrUndefined(mark.attrs[attributeName])) {
+          continue;
+        }
+
+        // Use the position to calculate the range range of the current mark.
+        const range = getMarkRange(tr.doc.resolve(pos), type);
+
+        if (!range) {
+          continue;
+        }
+
+        // The { from, to } range which will be used to update the mark id
+        // attribute.
+        const { from, to } = range;
+
+        // Create the new mark with all the existing dynamic attributes applied.
+        const newMark = type.create({
+          ...mark.attrs,
+          [attributeName]: attributeCreator(mark),
+        });
+
+        // Update the value of the mark. The only way to do this right now is to
+        // remove and then add it back again.
+        tr.removeMark(from, to, type).addMark(from, to, newMark);
+      }
+    }
   }
 
   /**
@@ -129,6 +391,8 @@ export class SchemaExtension extends PlainExtension {
 
 /**
  * The extra identifiers that can be used.
+ *
+ * TODO: Add support for tags #463
  */
 export type Identifiers = 'nodes' | 'marks' | 'all' | readonly string[];
 
@@ -155,24 +419,56 @@ export interface IdentifierSchemaAttributes {
   attributes: SchemaAttributes;
 }
 
+/**
+ * An object of `mark` and `node` dynamic schema attribute creators.
+ */
+interface DynamicSchemaAttributeCreators {
+  /**
+   * The dynamic schema attribute creators for all marks in the editor.
+   */
+  marks: Record<string, Record<string, DynamicAttributeCreator>>;
+
+  /**
+   * The dynamic schema attribute creators for all nodes in the editor.
+   */
+  nodes: Record<string, Record<string, DynamicAttributeCreator>>;
+}
+
+/**
+ * The schema attributes mapped to the names of the extension they belong to.
+ */
 type NamedSchemaAttributes = Record<string, SchemaAttributes>;
 
 interface TransformSchemaAttributesParameter {
+  /**
+   * The manager settings at the point of creation.
+   */
   settings: Remirror.ManagerSettings;
+
+  /**
+   * The schema attributes which were added to the `manager`.
+   */
   gatheredSchemaAttributes: IdentifierSchemaAttributes[];
+
+  /**
+   * The names of all the nodes within the editor.
+   */
   nodeNames: readonly string[];
+
+  /**
+   * The names of all the marks within the editor.
+   */
   markNames: readonly string[];
 }
 
 /**
- * Get the extension extra attributes
+ * Get the extension extra attributes created via the manager and convert into a
+ * named object which can be added to each node and mark spec.
  */
-function transformExtraAttributes({
-  settings,
-  gatheredSchemaAttributes: gatheredExtraAttributes,
-  nodeNames,
-  markNames,
-}: TransformSchemaAttributesParameter) {
+function getNamedSchemaAttributes(
+  parameter: TransformSchemaAttributesParameter,
+): NamedSchemaAttributes {
+  const { settings, gatheredSchemaAttributes, nodeNames, markNames } = parameter;
   const extraAttributes: NamedSchemaAttributes = object();
 
   if (settings.disableExtraAttributes) {
@@ -180,7 +476,7 @@ function transformExtraAttributes({
   }
 
   const extraSchemaAttributes: IdentifierSchemaAttributes[] = [
-    ...gatheredExtraAttributes,
+    ...gatheredSchemaAttributes,
     ...(settings.extraAttributes ?? []),
   ];
 
@@ -224,23 +520,70 @@ function getIdentifiers(parameter: GetIdentifiersParameter): readonly string[] {
 }
 
 interface CreateSpecParameter<Type> {
-  createExtensionSpec: (extra: ApplySchemaAttributes) => Type;
-  extraAttributes: SchemaAttributes;
-  ignoreExtraAttributes: boolean;
   /**
-   * The name for displaying in an error message (prefer the constructor name)
+   * The node or mark creating function.
+   */
+  createExtensionSpec: (extra: ApplySchemaAttributes) => Type;
+
+  /**
+   * The extra attributes object which has been passed through for this
+   * extension.
+   */
+  extraAttributes: SchemaAttributes;
+
+  /**
+   * This is true when the extension is set to ignore extra attributes.
+   */
+  ignoreExtraAttributes: boolean;
+
+  /**
+   * The name for displaying in an error message. The name of the constructor is
+   * used since it's more descriptive and easier to debug the error that may be
+   * thrown if extra attributes are not applied correctly.
    */
   name: string;
 }
 
-function createSpec<Type>(parameter: CreateSpecParameter<Type>): Type {
+interface CreateSpecReturn<Type> {
+  /** The created spec. */
+  spec: Type;
+
+  /** The dynamic attribute creators for this spec */
+  dynamic: Record<string, DynamicAttributeCreator>;
+}
+
+/**
+ * Create the scheme spec for a node or mark extension.
+ *
+ * @typeParam Type - either a [[Mark]] or a [[ProsemirrorNode]]
+ * @param parameter - the options object [[CreateSpecParameter]]
+ */
+function createSpec<Type>(parameter: CreateSpecParameter<Type>): CreateSpecReturn<Type> {
   const { createExtensionSpec, extraAttributes, ignoreExtraAttributes, name } = parameter;
 
+  // Keep track of the dynamic attributes which are a part of this spec.
+  const dynamic: Record<string, DynamicAttributeCreator> = object();
+
+  /** Called for every dynamic creator to track the dynamic attributes */
+  function addDynamic(attributeName: string, creator: DynamicAttributeCreator) {
+    dynamic[attributeName] = creator;
+  }
+
+  // Used to track whether the method has been called. If not called when the
+  // extension spec is being set up then an error is thrown.
   let defaultsCalled = false;
 
-  const defaults = createDefaults(extraAttributes, ignoreExtraAttributes, () => {
+  /** Called by createDefaults to track when the `defaults` has been called. */
+  function onDefaultsCalled() {
     defaultsCalled = true;
-  });
+  }
+
+  const defaults = createDefaults(
+    extraAttributes,
+    ignoreExtraAttributes,
+    onDefaultsCalled,
+    addDynamic,
+  );
 
   const parse = createParseDOM(extraAttributes, ignoreExtraAttributes);
   const dom = createToDOM(extraAttributes, ignoreExtraAttributes);
@@ -251,14 +594,19 @@ function createSpec<Type>(parameter: CreateSpecParameter<Type>): Type {
     message: `When creating a node specification you must call the 'defaults', and parse, and 'dom' methods. To avoid this error you can set the static property 'disableExtraAttributes' of '${name}' to 'true'.`,
   });
 
-  return spec;
+  return { spec, dynamic };
 }
 
 /**
  * Get the value of the extra attribute as an object.
+ *
+ * This is needed because the SchemaAttributes object can be configured as a
+ * string or as an object.
  */
-function getExtraAttributesObject(value: string | SchemaAttributesObject): SchemaAttributesObject {
-  if (isString(value)) {
+function getExtraAttributesObject(
+  value: DynamicAttributeCreator | string | SchemaAttributesObject,
+): SchemaAttributesObject {
+  if (isString(value) || isFunction(value)) {
     return { default: value };
   }
 
@@ -272,26 +620,48 @@ function getExtraAttributesObject(value: string | SchemaAttributesObject): Schem
 
 /**
  * Create the `defaults()` method which is used for setting the property.
+ *
+ * @param extraAttributes - the extra attributes for this particular node
+ * @param shouldIgnore - whether this attribute should be ignored
+ * @param onCalled - the function which is called when this is run, to check
+ * that it has been added to the attrs
+ * @param addDynamic - A function called to add the dynamic creator and name to
+ * the store
  */
 function createDefaults(
   extraAttributes: SchemaAttributes,
   shouldIgnore: boolean,
   onCalled: () => void,
+  addDynamicCreator: (name: string, creator: DynamicAttributeCreator) => void,
 ) {
-  // Store all the default attributes here.
-
   return () => {
     onCalled();
-    const attributes: Record<string, { default: string | null }> = object();
+    const attributes: Record<string, { default?: string | null }> = object();
 
+    // Extra attributes can be ignored by the extension, check if that's the
+    // case here.
     if (shouldIgnore) {
       return attributes;
     }
 
     // Loop through the extra attributes and attach to the attributes object.
     for (const [name, config] of entries(extraAttributes)) {
-      const value = getExtraAttributesObject(config);
-      attributes[name] = { default: value.default ?? null };
+      // Make sure this is an object and not a string.
+      const attributesObject = getExtraAttributesObject(config);
+      let defaultValue = attributesObject.default;
+
+      // When true this is a dynamic attribute creator.
+      if (isFunction(defaultValue)) {
+        // Store the name and method of the dynamic creator.
+        addDynamicCreator(name, defaultValue);
+
+        // Set the attributes for this dynamic creator to be null by default.
+        defaultValue = null;
+      }
+
+      // When the `defaultValue` is set to `undefined`, it is set as an empty
+      // object in order for ProseMirror to set it as a required attribute.
+      attributes[name] = defaultValue === undefined ? {} : { default: defaultValue };
     }
 
     return attributes;
@@ -510,18 +880,17 @@ declare global {
        *
        * @remarks
        *
-       * The type is available when the manager initializes. So it can be used
-       * in the outer scope of `createCommands`, `createHelpers`, `createKeymap`
-       * and most of the creator methods.
-       *
-       * Available: *return function* - `onCreate`
+       * The value is created when the manager initializes. So it can be used in
+       * `createCommands`, `createHelpers`, `createKeymap` and most of the
+       * creator methods.
        */
       schema: EditorSchema;
     }
 
     interface StaticExtensionOptions {
       /**
-       * When true will disable extra attributes for all instances of this extension.
+       * When true will disable extra attributes for all instances of this
+       * extension.
        *
        * @defaultValue `false`
        */

--- a/support/root/.eslintrc.js
+++ b/support/root/.eslintrc.js
@@ -191,7 +191,17 @@ module.exports = {
         },
       },
     ],
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
+
+    // @todo Set `explicit-module-boundary-types` lint rule to `error` once all
+    // issues are resolve @block All exported methods that are exposed to end
+    // users should be explicitly typed. It makes for better readability when
+    // contributing since inference requires more work to determine the return
+    // types, and also it forces deliberate planning.
+    '@typescript-eslint/explicit-module-boundary-types': [
+      'warn',
+      { allowedNames: ['name', 'createHelpers', 'createCommands'] },
+    ],
+
     // Turning off as it leads to code with bad patterns, where implementation
     // details are placed before the actual meaningful code.
     '@typescript-eslint/no-use-before-define': ['off', { typedefs: false }],

--- a/support/tsconfig.main.json
+++ b/support/tsconfig.main.json
@@ -1,7 +1,14 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "types": ["node", "jest", "jest-extended", "jest-axe", "@testing-library/jest-dom"],
+    "types": [
+      "node",
+      "jest",
+      "jest-extended",
+      "jest-axe",
+      "@testing-library/jest-dom",
+      "snapshot-diff"
+    ],
     "noEmit": true,
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,


### PR DESCRIPTION
### Description

🚀 Now featuring support for `DynamicExtraAttributes` which fixes #387.

- Also add support for `action` method being passed to `findChildren`, `findTextNodes`, `findInlineNodes`, `findBlockNodes`, `findChildrenByAttribute`, `findChildrenByNode`, `findChildrenByMark` and `containsNodesOfType`.
- Deprecate `flattenNodeDescendants`. `findChildren` is now the preferred method and automatically flattens the returned output.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
