### PR TITLE
Fix focus issue when dispatching a command

### DIFF
--- a/.changeset/silly-bears-hammer.md
+++ b/.changeset/silly-bears-hammer.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Fix issue with focusing the editor after every command.

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -319,9 +319,6 @@ export class CommandsExtension extends PlainExtension {
 
       if (shouldDispatch) {
         dispatch = view.dispatch;
-
-        // TODO make this be configurable?
-        view.focus();
       }
 
       return command(...args)({ state, dispatch, view, tr: this.transaction });

--- a/packages/@remirror/dom/src/__tests__/dom.spec.ts
+++ b/packages/@remirror/dom/src/__tests__/dom.spec.ts
@@ -21,7 +21,7 @@ test('can be added to the dom', () => {
       aria-label=""
       aria-multiline="true"
       autofocus="false"
-      class="ProseMirror remirror-editor ProseMirror-focused"
+      class="ProseMirror remirror-editor"
       contenteditable="true"
       role="textbox"
     >

--- a/packages/@remirror/extension-bidi/src/__tests__/__snapshots__/bidi-extension.spec.ts.snap
+++ b/packages/@remirror/extension-bidi/src/__tests__/__snapshots__/bidi-extension.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`options can make use of \`excludedNodes\` 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -63,7 +63,7 @@ exports[`options can turn off \`autoUpdate\` 2`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -106,7 +106,7 @@ exports[`updates the direction based on typing 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -123,7 +123,7 @@ exports[`updates the direction based on typing 2`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -140,7 +140,7 @@ exports[`updates to the default direction affect the attributes 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   dir="rtl"
   role="textbox"

--- a/packages/@remirror/extension-diff/src/__tests__/__snapshots__/diff-extension.spec.ts.snap
+++ b/packages/@remirror/extension-diff/src/__tests__/__snapshots__/diff-extension.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`#highlightCommit can highlight and remove highlights from commits 1`] =
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -26,7 +26,7 @@ exports[`#highlightCommit can highlight and remove highlights from commits 2`] =
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -51,7 +51,7 @@ exports[`#highlightCommit can highlight and remove highlights from commits 3`] =
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >

--- a/packages/@remirror/extension-search/src/__tests__/__snapshots__/search-extension.spec.ts.snap
+++ b/packages/@remirror/extension-search/src/__tests__/__snapshots__/search-extension.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`commands #clearSearch 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -29,7 +29,7 @@ exports[`commands #find 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -62,7 +62,7 @@ exports[`commands #find 2`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -95,7 +95,7 @@ exports[`commands #find 3`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -128,7 +128,7 @@ exports[`commands #findNext, #replace 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -152,7 +152,7 @@ exports[`commands #replace 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >
@@ -181,7 +181,7 @@ exports[`commands #replaceAll 1`] = `
   aria-label=""
   aria-multiline="true"
   autofocus="false"
-  class="ProseMirror remirror-editor ProseMirror-focused"
+  class="ProseMirror remirror-editor"
   contenteditable="true"
   role="textbox"
 >


### PR DESCRIPTION
### Description


Fix issue with focusing the editor after every command.

Fixes #592

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-08-27 11 53 16](https://user-images.githubusercontent.com/1160934/91434220-68234a80-e85c-11ea-88e2-fc0f1dcc7e19.gif)