### PR TITLE
Remove error in custom react manager without core or react preset

### DIFF
--- a/.changeset/rude-brooms-refuse.md
+++ b/.changeset/rude-brooms-refuse.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react': patch
+---
+
+Remove requirement for `CorePreset` and `ReactPreset` when using the `React` framework.

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -92,8 +92,7 @@ describe('commands', () => {
     add(doc(p('An <start>important<end> note')));
     commands.addAnnotation({ id });
     // Pre-condition
-    expect(view.dom.innerHTML).toMatchInlineSnapshot(
-      `
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
           <p>
             An
             <span class="annotation">
@@ -101,8 +100,7 @@ describe('commands', () => {
             </span>
             note
           </p>
-        `,
-    );
+        `);
 
     commands.removeAnnotations([id]);
 
@@ -214,28 +212,61 @@ describe('helpers', () => {
   });
 });
 
-describe('custom annotation type', () => {
+describe('custom annotations', () => {
   interface MyAnnotation extends Annotation {
     tag: string;
   }
 
-  const {
-    add,
-    helpers,
-    nodes: { p, doc },
-    commands,
-  } = renderEditor([new AnnotationExtension<MyAnnotation>()]);
+  it('should support custom annotations', () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = renderEditor([new AnnotationExtension<MyAnnotation>()]);
 
-  add(doc(p('<start>Hello<end>')));
-  commands.addAnnotation({ id: '1', tag: 'tag' });
+    add(doc(p('<start>Hello<end>')));
+    commands.addAnnotation({ id: '1', tag: 'tag' });
 
-  expect(helpers.getAnnotations()).toEqual([
-    {
-      id: '1',
-      from: 1,
-      to: 6,
-      tag: 'tag',
-      text: 'Hello',
-    },
-  ]);
+    expect(helpers.getAnnotations()).toEqual([
+      {
+        id: '1',
+        from: 1,
+        to: 6,
+        tag: 'tag',
+        text: 'Hello',
+      },
+    ]);
+  });
+
+  it('should support overlapping custom annotations', () => {
+    const {
+      dom,
+      selectText,
+      add,
+      nodes: { p, doc },
+      commands,
+    } = renderEditor([new AnnotationExtension<MyAnnotation>()]);
+
+    add(doc(p('<start>Hello<end> my friend')));
+
+    commands.addAnnotation({ id: '1', tag: 'tag' });
+    selectText(5, 14);
+    commands.addAnnotation({ id: '2', tag: 'awesome', className: 'custom' });
+
+    expect(dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <span class="annotation">
+          Hell
+        </span>
+        <span class="annotation custom">
+          o
+        </span>
+        <span class="annotation custom">
+          my frie
+        </span>
+        nd
+      </p>
+    `);
+  });
 });

--- a/packages/@remirror/react/src/react-helpers.tsx
+++ b/packages/@remirror/react/src/react-helpers.tsx
@@ -1,11 +1,4 @@
-import {
-  AnyCombinedUnion,
-  ErrorConstant,
-  getLazyArray,
-  invariant,
-  isRemirrorManager,
-  RemirrorManager,
-} from '@remirror/core';
+import { AnyCombinedUnion, getLazyArray, isRemirrorManager, RemirrorManager } from '@remirror/core';
 import { CorePreset } from '@remirror/preset-core';
 import { ReactPreset } from '@remirror/preset-react';
 
@@ -21,12 +14,6 @@ export function createReactManager<Combined extends AnyCombinedUnion>(
   const { core, react, ...settings } = options;
 
   if (isRemirrorManager<ReactCombinedUnion<Combined>>(combined)) {
-    invariant(combined.includes(['ReactPreset', 'CorePreset']), {
-      code: ErrorConstant.INVALID_MANAGER_EXTENSION,
-      message:
-        "The extensions and presets provided to the manager don't include the `CorePreset` or the `ReactPreset`. Please either create a manager which includes both, or use the `useManager` hook / `createReact` function.",
-    });
-
     return combined;
   }
 


### PR DESCRIPTION
### Description

Remove requirement for `CorePreset` and `ReactPreset` when using the `React` framework.

Fixes #602

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
