### PR TITLE
Add link to current remirror homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,6 +4,13 @@ fullWidth: true
 ---
 
 import { Banner, BannerLinks, BannerSection } from './src/components/banner';
+import { Note } from './src/components/note';
+
+<Note>
+
+This is the documentation homepage for remirror 0.x. For the current version of remirror please visit <https://remirror.io>.
+
+</Note>
 
 <Banner>
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -6,6 +6,8 @@ title: Introduction
 
 Thanks for taking the time to explore this project.
 
+**Note: This site documents the 0.x versions of remirror. For the current documentation please visit <https://remirror.io>.**
+
 At the moment the focus is on releasing a stable API and while this is ongoing documentation has slipped from
 being the priority.
 


### PR DESCRIPTION
Fixes https://github.com/remirror/remirror/issues/613

### Description

Added a note on the homepage and the first page that opens when you click "Documentation" to inform people that they should only be here if they want to be here.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] ~My code follows the code style of this project and `pnpm fix` completed successfully.~ (docs on old branch: `pnpm fix` wants to do a lot of changes that are unrelated and blow up the diff)
- [x] I have updated the documentation where necessary.
- [ ] ~New code is unit tested and all current tests pass when running `pnpm test`.~
