### PR TITLE
Add the persistent-selection extension

### DIFF
--- a/.changeset/unlucky-pets-melt.md
+++ b/.changeset/unlucky-pets-melt.md
@@ -1,0 +1,9 @@
+---
+'@remirror/core': minor
+---
+
+Optionally allow to style the currently selected text
+
+This adds a new option for the builtin preset, `persistentSelectionClass`. If that is set to a valid CSS class name any selection in the editor will be decorated with this class.
+
+This can be used to keep an indication for the current selection even when the focus changes away from the editor.

--- a/packages/@remirror/core/src/builtins/__tests__/__snapshots__/persistent-selection-extension.spec.ts.snap
+++ b/packages/@remirror/core/src/builtins/__tests__/__snapshots__/persistent-selection-extension.spec.ts.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`configuration uses provided configuration ({"persistentSelectionClass":""}) 1`] = `
+<div contenteditable="true"
+     role="textbox"
+     aria-multiline="true"
+     aria-label
+     class="ProseMirror remirror-editor"
+>
+  <p>
+    Some text
+  </p>
+</div>
+`;
+
+exports[`configuration uses provided configuration ({"persistentSelectionClass":"selection"}) 1`] = `
+<div contenteditable="true"
+     role="textbox"
+     aria-multiline="true"
+     aria-label
+     class="ProseMirror remirror-editor"
+>
+  <p>
+    Som
+    <span class="selection">
+      e tex
+    </span>
+    t
+  </p>
+</div>
+`;
+
+exports[`configuration uses provided configuration ({}) 1`] = `
+<div contenteditable="true"
+     role="textbox"
+     aria-multiline="true"
+     aria-label
+     class="ProseMirror remirror-editor"
+>
+  <p>
+    Som
+    <span class="selection">
+      e tex
+    </span>
+    t
+  </p>
+</div>
+`;
+
+exports[`configuration uses provided configuration ({}) 2`] = `
+<div contenteditable="true"
+     role="textbox"
+     aria-multiline="true"
+     aria-label
+     class="ProseMirror remirror-editor"
+>
+  <p>
+    Some text
+  </p>
+</div>
+`;
+
+exports[`focus retains selection and decoration 1`] = `
+<div contenteditable="true"
+     role="textbox"
+     aria-multiline="true"
+     aria-label
+     class="ProseMirror remirror-editor"
+>
+  <p>
+    Som
+    <span class="selection">
+      e tex
+    </span>
+    t
+  </p>
+</div>
+`;

--- a/packages/@remirror/core/src/builtins/__tests__/persistent-selection-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/persistent-selection-extension.spec.ts
@@ -1,0 +1,53 @@
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
+
+import { PersistentSelectionExtension } from '..';
+
+extensionValidityTest(PersistentSelectionExtension);
+
+describe('configuration', () => {
+  it.each([
+    {},
+    { persistentSelectionClass: undefined },
+    { persistentSelectionClass: '' },
+    { persistentSelectionClass: 'selection' },
+  ])('uses provided configuration (%j)', (configuration) => {
+    const {
+      add,
+      dom,
+      selectText,
+      nodes: { p, doc },
+    } = renderEditor([], { builtin: configuration });
+
+    add(doc(p('Some text')));
+    selectText({ from: 4, to: 9 });
+
+    expect(dom.outerHTML).toMatchSnapshot();
+  });
+});
+
+describe('focus', () => {
+  it('retains selection and decoration', () => {
+    const builtin = { persistentSelectionClass: 'selection' };
+    const editor = renderEditor([], { builtin });
+    const {
+      add,
+      dom,
+      selectText,
+      nodes: { p, doc },
+    } = editor;
+
+    add(doc(p('Some text')));
+    const range = { from: 4, to: 9 };
+    selectText(range);
+
+    // Verify that the selection has been applied
+    expect(editor.state.selection.from).toBe(range.from);
+    expect(editor.state.selection.to).toBe(range.to);
+
+    (editor.view.dom as HTMLElement).blur();
+
+    expect(dom.outerHTML).toMatchSnapshot();
+    expect(editor.state.selection.from).toBe(range.from);
+    expect(editor.state.selection.to).toBe(range.to);
+  });
+});

--- a/packages/@remirror/core/src/builtins/builtin-preset.ts
+++ b/packages/@remirror/core/src/builtins/builtin-preset.ts
@@ -11,12 +11,16 @@ import { InputRulesExtension } from './input-rules-extension';
 import { KeymapExtension, KeymapOptions } from './keymap-extension';
 import { NodeViewExtension } from './node-views-extension';
 import { PasteRulesExtension } from './paste-rules-extension';
+import {
+  PersistentSelectionExtension,
+  PersistentSelectionOptions,
+} from './persistent-selection-extension';
 import { PluginsExtension } from './plugins-extension';
 import { SchemaExtension } from './schema-extension';
 import { SuggestExtension, SuggestOptions } from './suggest-extension';
 import { TagsExtension } from './tags-extension';
 
-export interface BuiltinOptions extends SuggestOptions, KeymapOptions {}
+export interface BuiltinOptions extends SuggestOptions, KeymapOptions, PersistentSelectionOptions {}
 
 /**
  * Provides all the builtin extensions to the editor.
@@ -78,6 +82,7 @@ export class BuiltinPreset extends Preset<BuiltinOptions> {
       'selectParentNodeOnEscape',
       'undoInputRuleOnBackspace',
     ]);
+    const persistentSelectionOptions = pick(this.options, ['persistentSelectionClass']);
 
     return [
       // The order of these extension is important.
@@ -92,6 +97,7 @@ export class BuiltinPreset extends Preset<BuiltinOptions> {
       new CommandsExtension(),
       new HelpersExtension(),
       new KeymapExtension(keymapOptions),
+      new PersistentSelectionExtension(persistentSelectionOptions),
     ];
   }
 }

--- a/packages/@remirror/core/src/builtins/index.ts
+++ b/packages/@remirror/core/src/builtins/index.ts
@@ -7,6 +7,7 @@ export * from './keymap-extension';
 export * from './node-views-extension';
 export * from './paste-rules-extension';
 export * from './plugins-extension';
+export * from './persistent-selection-extension';
 export * from './schema-extension';
 export * from './suggest-extension';
 export * from './tags-extension';

--- a/packages/@remirror/core/src/builtins/persistent-selection-extension.ts
+++ b/packages/@remirror/core/src/builtins/persistent-selection-extension.ts
@@ -1,0 +1,58 @@
+import { ExtensionPriority } from '@remirror/core-constants';
+import type { Static } from '@remirror/core-types';
+import { isNodeSelection } from '@remirror/core-utils';
+import { Decoration, DecorationSet } from '@remirror/pm/view';
+
+import { extensionDecorator } from '../decorators';
+import { PlainExtension } from '../extension';
+import type { CreatePluginReturn } from '../types';
+
+export interface PersistentSelectionOptions {
+  persistentSelectionClass?: Static<string>;
+}
+
+export const DEFAULT_PERSISTENT_SELECTION_CLASS = 'selection';
+
+@extensionDecorator<PersistentSelectionOptions>({
+  defaultOptions: {
+    persistentSelectionClass: DEFAULT_PERSISTENT_SELECTION_CLASS,
+  },
+  defaultPriority: ExtensionPriority.Medium,
+  staticKeys: ['persistentSelectionClass'],
+})
+export class PersistentSelectionExtension extends PlainExtension<PersistentSelectionOptions> {
+  get name() {
+    return 'persistentSelection' as const;
+  }
+
+  createPlugin(): CreatePluginReturn {
+    return {
+      props: {
+        decorations: ({ doc, selection }) => {
+          // Do not run the extension at all when there is no actual decoration
+          // to be done.
+          if (!this.options.persistentSelectionClass) {
+            return;
+          }
+
+          if (selection.empty) {
+            return;
+          }
+
+          const decorationAttrs = {
+            class: this.options.persistentSelectionClass,
+          };
+          let decoration: Decoration;
+
+          if (isNodeSelection(selection)) {
+            decoration = Decoration.node(selection.from, selection.to, decorationAttrs);
+          } else {
+            decoration = Decoration.inline(selection.from, selection.to, decorationAttrs);
+          }
+
+          return DecorationSet.create(doc, [decoration]);
+        },
+      },
+    };
+  }
+}

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -22,14 +22,14 @@ describe('commands', () => {
     commands.addAnnotation({ id: '1' });
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            An
-            <span class="annotation">
-              important
-            </span>
-            note
-          </p>
-        `);
+      <p>
+        An
+        <span class="selection annotation">
+          important
+        </span>
+        note
+      </p>
+    `);
   });
 
   it('#updateAnnotation', () => {
@@ -40,28 +40,28 @@ describe('commands', () => {
 
     // Pre-condition
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            An
-            <span class="annotation">
-              important
-            </span>
-            note
-          </p>
-        `);
+      <p>
+        An
+        <span class="selection annotation">
+          important
+        </span>
+        note
+      </p>
+    `);
 
     commands.updateAnnotation(id, {
       className: 'updated',
     });
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            An
-            <span class="annotation updated">
-              important
-            </span>
-            note
-          </p>
-        `);
+      <p>
+        An
+        <span class="selection annotation updated">
+          important
+        </span>
+        note
+      </p>
+    `);
   });
 
   it('#setAnnotations', () => {
@@ -93,22 +93,26 @@ describe('commands', () => {
     commands.addAnnotation({ id });
     // Pre-condition
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            An
-            <span class="annotation">
-              important
-            </span>
-            note
-          </p>
-        `);
+      <p>
+        An
+        <span class="selection annotation">
+          important
+        </span>
+        note
+      </p>
+    `);
 
     commands.removeAnnotations([id]);
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            An important note
-          </p>
-        `);
+      <p>
+        An
+        <span class="selection">
+          important
+        </span>
+        note
+      </p>
+    `);
   });
 });
 
@@ -126,7 +130,7 @@ describe('styling', () => {
 
     expect(dom.innerHTML).toMatchInlineSnapshot(`
       <p>
-        <span class="test-class-name">
+        <span class="selection test-class-name">
           Hello
         </span>
       </p>
@@ -146,7 +150,7 @@ describe('styling', () => {
 
     expect(dom.innerHTML).toMatchInlineSnapshot(`
       <p>
-        <span class="annotation custom-annotation">
+        <span class="selection annotation custom-annotation">
           Hello
         </span>
       </p>
@@ -259,10 +263,10 @@ describe('custom annotations', () => {
         <span class="annotation">
           Hell
         </span>
-        <span class="annotation custom">
+        <span class="annotation selection custom">
           o
         </span>
-        <span class="annotation custom">
+        <span class="selection annotation custom">
           my frie
         </span>
         nd

--- a/packages/@remirror/extension-bold/src/__tests__/bold-extension.spec.ts
+++ b/packages/@remirror/extension-bold/src/__tests__/bold-extension.spec.ts
@@ -128,14 +128,16 @@ describe('commands', () => {
     commands.toggleBold();
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            Hello
-            <strong>
-              friend
-            </strong>
-            , lets dance.
-          </p>
-        `);
+      <p>
+        Hello
+        <strong>
+          <span class="selection">
+            friend
+          </span>
+        </strong>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(
       doc(p('Hello ', bold('friend'), ', lets dance.')),
     );
@@ -143,10 +145,14 @@ describe('commands', () => {
     commands.toggleBold();
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            Hello friend, lets dance.
-          </p>
-        `);
+      <p>
+        Hello
+        <span class="selection">
+          friend
+        </span>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello friend, lets dance.')));
   });
 
@@ -155,13 +161,16 @@ describe('commands', () => {
     commands.setBold({ from: 1, to: 6 });
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-        <p>
-          <strong>
-            Hello
-          </strong>
-          friend, lets dance.
-        </p>
-      `);
+      <p>
+        <strong>
+          Hello
+        </strong>
+        <span class="selection">
+          friend
+        </span>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(doc(p(bold('Hello'), ' friend, lets dance.')));
   });
 

--- a/packages/@remirror/extension-code/src/__tests__/code-extension.spec.ts
+++ b/packages/@remirror/extension-code/src/__tests__/code-extension.spec.ts
@@ -78,23 +78,29 @@ describe('commands', () => {
     commands.toggleCode();
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            Hello
-            <code>
-              code
-            </code>
-            , lets dance.
-          </p>
-        `);
+      <p>
+        Hello
+        <code>
+          <span class="selection">
+            code
+          </span>
+        </code>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello ', code('code'), ', lets dance.')));
 
     commands.toggleCode();
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            Hello code, lets dance.
-          </p>
-        `);
+      <p>
+        Hello
+        <span class="selection">
+          code
+        </span>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello code, lets dance.')));
   });
 });

--- a/packages/@remirror/extension-strike/src/__tests__/strike-extension.spec.ts
+++ b/packages/@remirror/extension-strike/src/__tests__/strike-extension.spec.ts
@@ -44,24 +44,30 @@ describe('commands', () => {
     commands.toggleStrike();
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            Hello
-            <s>
-              strike
-            </s>
-            , lets dance.
-          </p>
-        `);
+      <p>
+        Hello
+        <s>
+          <span class="selection">
+            strike
+          </span>
+        </s>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(
       doc(p('Hello ', strike('strike'), ', lets dance.')),
     );
 
     commands.toggleStrike();
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
-          <p>
-            Hello strike, lets dance.
-          </p>
-        `);
+      <p>
+        Hello
+        <span class="selection">
+          strike
+        </span>
+        , lets dance.
+      </p>
+    `);
     expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello strike, lets dance.')));
   });
 });

--- a/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
@@ -111,7 +111,9 @@ class CustomExtension extends PlainExtension {
 }
 
 function create() {
-  return renderEditor([new BoldExtension(), new CustomExtension()]);
+  return renderEditor([new BoldExtension(), new CustomExtension()], {
+    builtin: { persistentSelectionClass: undefined },
+  });
 }
 
 describe('add', () => {

--- a/support/e2e/src/__snapshots__/positioner.e2e.test.ts.snap
+++ b/support/e2e/src/__snapshots__/positioner.e2e.test.ts.snap
@@ -9,7 +9,9 @@ exports[`Positioner Bubble menu should show the bubble menu 1`] = `
 exports[`Positioner Bubble menu should show the bubble menu 2`] = `
 <p class>
   <strong>
-    This is text
+    <span class="selection">
+      This is text
+    </span>
   </strong>
 </p>
 `;


### PR DESCRIPTION
### Description

Fixes #601 by adding a default extension to decorate the current selection, IFF the `persistentSelectionClass` builtin configuration is provided. 

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
