### PR TITLE
Avoid calling `getForcedUpdates` twice

### DIFF
--- a/packages/@remirror/core/src/editor-wrapper.ts
+++ b/packages/@remirror/core/src/editor-wrapper.ts
@@ -343,7 +343,7 @@ export abstract class EditorWrapper<
     const forcedUpdates = this.manager.store.getForcedUpdates(tr);
 
     if (!isEmptyArray(forcedUpdates)) {
-      this.updateViewProps(...this.manager.store.getForcedUpdates(tr));
+      this.updateViewProps(...forcedUpdates);
     }
   };
 


### PR DESCRIPTION
### Description

Use the result from the previous call rather than calling the same function again.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] ~I have updated the documentation where necessary.~ Internal refactoring.
- [x] ~New code is unit tested and all current tests pass when running `pnpm test`.~ No new code.
