### PR TITLE
Make the storybook package start up

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "reset": "pnpm clean:all; rm pnpm-lock.yaml; pnpm symlink:root; pnpm install;",
     "run:prettier": "prettier --ignore-path .eslintignore \"**/*.{js,jsx,ts,tsx,md,mdx,json,html,css,yml,yaml,graphql}\"",
     "size": "size-limit",
-    "storybook": "manypkg run support/storybook storybook",
+    "storybook": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\"}' manypkg run support/storybook storybook",
     "symlink:root": "node support/scripts/symlink-root.js",
     "test": "jest --verbose",
     "test:build": "cross-env TEST_BUILD=true jest --verbose --coverage=false",

--- a/support/storybook/main.ts
+++ b/support/storybook/main.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-default-export
 export default {
   stories: ['./stories/*.stories.tsx'],
   addons: ['@storybook/addon-actions', '@storybook/addon-links'],


### PR DESCRIPTION
### Description

* Explicitly switch ts-node into commonjs mode, which seems to be required by
  the specific configuration of storybook here
* Disable an eslint issue about not having default exports on the main
  storybook module

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] ~New code is unit tested and all current tests pass when running `pnpm test`.~: No new code.
