### PR TITLE
Prevent generating decorations without a class

### DIFF
--- a/.changeset/three-snakes-design.md
+++ b/.changeset/three-snakes-design.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-code-block': minor
+---
+
+The code-block extension will only decorate top-level 'text' nodes when the `plainTextClassName` option is set

--- a/packages/@remirror/extension-code-block/src/__tests__/__snapshots__/code-block-extension.spec.ts.snap
+++ b/packages/@remirror/extension-code-block/src/__tests__/__snapshots__/code-block-extension.spec.ts.snap
@@ -5,13 +5,9 @@ exports[`commands updateCodeBlock  updates the language 1`] = `
   <span class="token keyword">
     const
   </span>
-  <span>
-    a
-  </span>
+  a
   <span class="token operator">
     =
-  </span>
-  <span>
   </span>
   <span class="token string">
     'test'
@@ -22,17 +18,81 @@ exports[`commands updateCodeBlock  updates the language 1`] = `
 </code>
 `;
 
-exports[`plugin can be updated 1`] = `
+exports[`plain text nodes renders decorations on plain text based on configuration {"plainTextClassName":""} 1`] = `
 <span class="token keyword">
   const
 </span>
-<span>
+a
+<span class="token operator">
+  =
+</span>
+<span class="token string">
+  'test'
+</span>
+<span class="token punctuation">
+  ;
+</span>
+`;
+
+exports[`plain text nodes renders decorations on plain text based on configuration {"plainTextClassName":"text"} 1`] = `
+<span class="token keyword">
+  const
+</span>
+<span class="text">
   a
 </span>
 <span class="token operator">
   =
 </span>
-<span>
+<span class="text">
+</span>
+<span class="token string">
+  'test'
+</span>
+<span class="token punctuation">
+  ;
+</span>
+`;
+
+exports[`plain text nodes renders decorations on plain text based on configuration {} 1`] = `
+<span class="token keyword">
+  const
+</span>
+a
+<span class="token operator">
+  =
+</span>
+<span class="token string">
+  'test'
+</span>
+<span class="token punctuation">
+  ;
+</span>
+`;
+
+exports[`plain text nodes renders decorations on plain text based on configuration {} 2`] = `
+<span class="token keyword">
+  const
+</span>
+a
+<span class="token operator">
+  =
+</span>
+<span class="token string">
+  'test'
+</span>
+<span class="token punctuation">
+  ;
+</span>
+`;
+
+exports[`plugin can be updated 1`] = `
+<span class="token keyword">
+  const
+</span>
+a
+<span class="token operator">
+  =
 </span>
 <span class="token string">
   'test'
@@ -46,13 +106,9 @@ exports[`plugin can be updated 2`] = `
 <span class="token keyword">
   const
 </span>
-<span>
-  a
-</span>
+a
 <span class="token operator">
   =
-</span>
-<span>
 </span>
 <span class="token string">
   'test'
@@ -60,17 +116,13 @@ exports[`plugin can be updated 2`] = `
 <span class="token punctuation">
   ;
 </span>
-<span>
-</span>
 <span class="token function">
   log
 </span>
 <span class="token punctuation">
   (
 </span>
-<span>
-  a
-</span>
+a
 <span class="token punctuation">
   )
 </span>
@@ -83,13 +135,9 @@ exports[`plugin changes markup when the language changes 1`] = `
 <span class="token keyword">
   const
 </span>
-<span>
-  a
-</span>
+a
 <span class="token operator">
   =
-</span>
-<span>
 </span>
 <span class="token string">
   'test'
@@ -103,13 +151,9 @@ exports[`plugin renders the correct decorations 1`] = `
 <span class="token keyword">
   const
 </span>
-<span>
-  a
-</span>
+a
 <span class="token operator">
   =
-</span>
-<span>
 </span>
 <span class="token string">
   'test'
@@ -125,13 +169,9 @@ exports[`plugin updates when multiple changes occur 1`] = `
     <span class="token keyword">
       const
     </span>
-    <span>
-      a
-    </span>
+    a
     <span class="token operator">
       =
-    </span>
-    <span>
     </span>
     <span class="token string">
       'test'
@@ -146,9 +186,7 @@ exports[`plugin updates when multiple changes occur 1`] = `
     <span class="token keyword">
       let
     </span>
-    <span>
-      b
-    </span>
+    b
     <span class="token punctuation">
       ;
     </span>
@@ -162,13 +200,9 @@ exports[`plugin updates when multiple changes occur 2`] = `
     <span class="token keyword">
       const
     </span>
-    <span>
-      c
-    </span>
+    c
     <span class="token operator">
       =
-    </span>
-    <span>
     </span>
     <span class="token string">
       'test'
@@ -183,9 +217,7 @@ exports[`plugin updates when multiple changes occur 2`] = `
     <span class="token keyword">
       let
     </span>
-    <span>
-      d
-    </span>
+    d
     <span class="token punctuation">
       ;
     </span>

--- a/packages/@remirror/extension-code-block/src/__tests__/code-block-extension.spec.ts
+++ b/packages/@remirror/extension-code-block/src/__tests__/code-block-extension.spec.ts
@@ -52,6 +52,7 @@ describe('constructor', () => {
 
     expect(codeBlock.options.syntaxTheme).toEqual('a11yDark');
     expect(codeBlock.options.defaultLanguage).toEqual('markup');
+    expect(codeBlock.options.plainTextClassName).toEqual('');
   });
 });
 
@@ -437,5 +438,31 @@ describe('language', () => {
 
   it('handles unknown', () => {
     expect(getLang(`this_language_does_not_exist`)).toEqual('');
+  });
+});
+
+describe('plain text nodes', () => {
+  [
+    {},
+    { plainTextClassName: undefined },
+    { plainTextClassName: '' },
+    { plainTextClassName: 'text' },
+  ].forEach((plainTextClassNameConfiguration) => {
+    it(`renders decorations on plain text based on configuration ${JSON.stringify(
+      plainTextClassNameConfiguration,
+    )}`, () => {
+      const {
+        view: { dom },
+        add,
+        attributeNodes: { codeBlock },
+        nodes: { doc },
+      } = create({ ...plainTextClassNameConfiguration });
+
+      const tsBlock = codeBlock({ language: 'typescript' });
+
+      add(doc(tsBlock(`const a = 'test';`)));
+
+      expect(dom.querySelector('.language-typescript code')!.innerHTML).toMatchSnapshot();
+    });
   });
 });

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -47,6 +47,8 @@ import {
     formatter: ({ source }) => ({ cursorOffset: 0, formatted: source }),
     syntaxTheme: 'atomDark',
     defaultLanguage: 'markup',
+    // See https://github.com/remirror/remirror/issues/624 for the ''
+    plainTextClassName: '',
   },
 })
 export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {

--- a/packages/@remirror/extension-code-block/src/code-block-plugin.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-plugin.ts
@@ -68,6 +68,7 @@ export class CodeBlockState {
       blocks,
       skipLast: this.#deleted,
       defaultLanguage: this.#extension.options.defaultLanguage,
+      plainTextClassName: this.#extension.options.plainTextClassName ?? undefined,
     });
     this.decorationSet = DecorationSet.create(node, decorations);
     this.#blocks = blocks;
@@ -169,6 +170,7 @@ export class CodeBlockState {
         blocks: [{ node, pos }],
         skipLast: this.#deleted,
         defaultLanguage: this.#extension.options.defaultLanguage,
+        plainTextClassName: this.#extension.options.plainTextClassName ?? undefined,
       }),
     );
   }

--- a/packages/@remirror/extension-code-block/src/code-block-types.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-types.ts
@@ -102,6 +102,19 @@ export interface CodeBlockOptions {
    * @default 'paragraph'
    */
   toggleName?: string;
+
+  /**
+   * Class to use in decorations of plain `text` nodes.
+   *
+   * @remarks
+   *
+   * refractor highlighting produces `elements` to indicate the type of a part
+   * of the code. These elements get translated into decorations by this plugin.
+   *
+   * For all other parts of the code the decoration will use this class name if
+   * it is set to a non-empty value, otherwise no decoration will be produced.
+   */
+  plainTextClassName?: string;
 }
 
 /**


### PR DESCRIPTION
## Description

The refractor highlighting produces two types of nodes:
* 'element' nodes indicate the type of the code snippet with the class
  ("token", as well as the specific thing such as "operator")
* 'text' nodes as children of the 'element' nodes that then contain the
  actual text of the snippet.

Depending on the language there can also be 'text' nodes outside of the context
of an 'element' node, for example in the TypeScript language a global variable
references would simply appear as a top-level 'text' node. As there are no classes
known for these nodes they should not get a decoration.

This commit introduces an option for the code-block extension to control this
behavior:
- { plainTextClassName: undefined } (the default): top-level 'text' nodes do not get decorated
- { plainTextClassName: 'some-class' }: top-level 'text' nodes get decorated with 'some-class'

This is a work-around for the issue described in https://github.com/remirror/remirror/pull/616#issuecomment-685902419

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
