### PR TITLE
Make `focus` context method chainable

### DIFF
--- a/.changeset/eight-snails-hope.md
+++ b/.changeset/eight-snails-hope.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-constants': patch
+---
+
+Fix missing version bump from last release.

--- a/.changeset/new-apricots-travel.md
+++ b/.changeset/new-apricots-travel.md
@@ -16,7 +16,7 @@ import { WysiwygPreset } from 'remirror/preset/wysiwyg';
 const EditorWrapper = () => {
   const onError: InvalidContentHandler = useCallback(({ json, invalidContent, transformers }) => {
     // Automatically remove all invalid nodes and marks.
-    return transformer.remove(json, invalidContent);
+    return transformers.remove(json, invalidContent);
   }, []);
 
   const manager = useManager([new WysiwygPreset()]);

--- a/.changeset/silver-lizards-know.md
+++ b/.changeset/silver-lizards-know.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': minor
+'@remirror/core-helpers': minor
+---
+
+Make `focus` command chainable and add `manager.tr` property for creating chainable commands. This means that the `focus` method returned by `useRemirror()` can now be safely used within a controlled editor. It uses the shared chainable transaction so that the state update does not override other state updates.

--- a/packages/@remirror/core-helpers/src/core-helpers.ts
+++ b/packages/@remirror/core-helpers/src/core-helpers.ts
@@ -827,14 +827,14 @@ export function last<Type>(array: Type[]): Type {
  * index is placed first hence retaining the original order.
  *
  * @param array - the array to sort
- * @param compareFn - compare the two value arguments `a` and `b` - return 0 for
- *                  equal - return number > 0 for a > b - return number < 0 for
- *                  b > a
+ * @param compareFn - compare the two value arguments `a` and `z` - return 0 for
+ *                  equal - return number > 0 for a > z - return number < 0 for
+ *                  z > a
  */
-export function sort<Type>(array: Type[], compareFn: (a: Type, b: Type) => number): Type[] {
+export function sort<Type>(array: Type[], compareFn: (a: Type, z: Type) => number): Type[] {
   return [...array]
     .map((value, index) => ({ value, index }))
-    .sort((a, b) => compareFn(a.value, b.value) || a.index - b.index)
+    .sort((a, z) => compareFn(a.value, z.value) || a.index - z.index)
     .map(({ value }) => value);
 }
 
@@ -895,7 +895,11 @@ function setClone(obj: any, key: string | number, value: any) {
  * Set the value of a given path for the provided object. Does not mutate the
  * original object.
  */
-export function set(path: number | string | Array<string | number>, obj: Shape, value: unknown) {
+export function set(
+  path: number | string | Array<string | number>,
+  obj: Shape,
+  value: unknown,
+): Shape {
   if (isNumber(path)) {
     return setClone(obj, path, value);
   }
@@ -910,9 +914,9 @@ export function set(path: number | string | Array<string | number>, obj: Shape, 
 /**
  * Unset the value of a given path within an object.
  */
-export function unset(path: Array<string | number>, obj: Shape) {
-  const newObj = clone(obj);
-  let value = newObj;
+export function unset(path: Array<string | number>, target: Shape): Shape {
+  const clonedObject = clone(target);
+  let value = clonedObject;
 
   for (const [index, key] of path.entries()) {
     const shouldDelete = index >= path.length - 1;
@@ -929,11 +933,11 @@ export function unset(path: Array<string | number>, obj: Shape) {
         Reflect.deleteProperty(value, key);
       }
 
-      return newObj;
+      return clonedObject;
     }
 
     if (isPrimitive(item)) {
-      return newObj;
+      return clonedObject;
     }
 
     if (isArray(item)) {
@@ -946,7 +950,7 @@ export function unset(path: Array<string | number>, obj: Shape) {
     value = item;
   }
 
-  return newObj;
+  return clonedObject;
 }
 
 function makeFunctionForUniqueBy<Item = any, Key = any>(value: string | Array<string | number>) {

--- a/packages/@remirror/core/src/editor-wrapper.ts
+++ b/packages/@remirror/core/src/editor-wrapper.ts
@@ -493,7 +493,10 @@ export abstract class EditorWrapper<
       return;
     }
 
-    const { selection, doc, tr } = this.getState();
+    // By using the transaction which is shared by all the commands we can make
+    // the focus method, chainable.
+    const { tr } = this.manager;
+    const { selection, doc } = tr;
     const { from = 0, to = from } = selection;
 
     if (position === undefined || position === true) {
@@ -531,11 +534,13 @@ export abstract class EditorWrapper<
 
     // Wait for the next event loop to set the focus.
     requestAnimationFrame(() => {
+      // Use the built in focus method to refocus the editor.
       this.view.focus();
+
       // This has to be called again in order for Safari to scroll into view
       // after the focus. Perhaps there's a better way though or maybe place
       // behind a flag.
-      this.view.dispatch(this.view.state.tr.scrollIntoView());
+      this.view.dispatch(this.manager.tr);
     });
   }
 

--- a/packages/@remirror/core/src/manager/remirror-manager.ts
+++ b/packages/@remirror/core/src/manager/remirror-manager.ts
@@ -25,6 +25,7 @@ import type {
   NodeExtensionSpec,
   ProsemirrorNode,
   Replace,
+  Transaction,
 } from '@remirror/core-types';
 import {
   createDocumentNode,
@@ -244,6 +245,27 @@ export class RemirrorManager<Combined extends AnyCombinedUnion> {
    */
   get store(): Remirror.ManagerStore<Combined> {
     return freeze(this.#store);
+  }
+
+  /**
+   * Provides access to the extension store.
+   */
+  get extensionStore(): Remirror.ExtensionStore {
+    return freeze(this.#extensionStore);
+  }
+
+  /**
+   * Shorthand access to the active transaction from the manager. This is the
+   * shared transaction available to all commands and should be used when you
+   * need to make your commands chainable.
+   *
+   * If working with react and setting up your editor as a controlled component
+   * then this is the preferred way to run custom commands, otherwise your
+   * commands will end up being non-chainable and be overwritten by anything
+   * that comes after.
+   */
+  get tr(): Transaction<SchemaFromCombined<Combined>> {
+    return this.extensionStore.getTransaction();
   }
 
   /**
@@ -514,7 +536,7 @@ export class RemirrorManager<Combined extends AnyCombinedUnion> {
    * Create the editor state from content passed to this extension manager.
    */
   createState(
-    parameter: Omit<CreateDocumentNodeParameter, 'schema'>,
+    parameter: Omit<CreateDocumentNodeParameter, 'schema' | 'attempts'>,
   ): EditorState<SchemaFromCombined<Combined>> {
     const { content, doc: d, stringHandler, onError, selection } = parameter;
     const { schema, plugins } = this.store;

--- a/packages/@remirror/testing/package.json
+++ b/packages/@remirror/testing/package.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.11.0",
+    "@react-spring/mock-raf": "^1.1.1",
     "@remirror/core": "1.0.0-next.31",
     "@remirror/extension-blockquote": "1.0.0-next.31",
     "@remirror/extension-bold": "1.0.0-next.31",

--- a/packages/@remirror/testing/src/index.ts
+++ b/packages/@remirror/testing/src/index.ts
@@ -1,3 +1,4 @@
+import createMockRaf from '@react-spring/mock-raf';
 import diff from 'jest-diff';
 
 export const initialJson = {
@@ -41,9 +42,21 @@ export function hideConsoleError(hide: boolean): jest.SpyInstance {
   return spy;
 }
 
+/**
+ * Mock the `requestAnimationFrame`.
+ */
+export function rafMock() {
+  const mockRaf = createMockRaf();
+  const spy = jest.spyOn(window, 'requestAnimationFrame').mockImplementation(mockRaf.raf);
+
+  return { ...mockRaf, cleanup: () => spy.mockRestore() };
+}
+
 export { diff };
 
 export { default as minDocument } from 'min-document';
+
+export type { FrameRequestCallback, MockRaf } from '@react-spring/mock-raf';
 
 export { BuiltinPreset } from '@remirror/core';
 export * from '@remirror/preset-core';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1394,6 +1394,7 @@ importers:
   packages/@remirror/testing:
     dependencies:
       '@babel/runtime': 7.11.2
+      '@react-spring/mock-raf': 1.1.1
       '@remirror/core': 'link:../core'
       '@remirror/extension-blockquote': 'link:../extension-blockquote'
       '@remirror/extension-bold': 'link:../extension-bold'
@@ -1418,6 +1419,7 @@ importers:
       react: 16.13.1
     specifiers:
       '@babel/runtime': ^7.11.0
+      '@react-spring/mock-raf': ^1.1.1
       '@remirror/core': 1.0.0-next.31
       '@remirror/extension-blockquote': 1.0.0-next.31
       '@remirror/extension-bold': 1.0.0-next.31
@@ -6108,6 +6110,10 @@ packages:
       react-dom: ^16.8.0
     resolution:
       integrity: sha512-A7Ofr1Biq4vUeTBYhbZ/YiLq1B/lEObbEoR2UiuQqCO1r093N95hZNcKqfFwpkRScjD87uob3wSYYGxvq9y/+w==
+  /@react-spring/mock-raf/1.1.1:
+    dev: false
+    resolution:
+      integrity: sha512-SPgq9cenqdkqzxg1zYKEOkao5Boob2sG8QTxiSoHT7NyZoTZKnDcalvRtW9AmZBcbUHy8UtqCKfBWKyB2PSlmQ==
   /@rollup/plugin-alias/3.1.1_rollup@1.32.1:
     dependencies:
       rollup: 1.32.1


### PR DESCRIPTION
### Description

Focus can now be used in controlled editors without overriding any previous commands.

Fixes #627

- Fix missing version bump from last release of `@remirror/core-constants`.
- Make `focus` command chainable and add `manager.tr` property for creating chainable commands. This means that the `focus` method returned by `useRemirror()` can now be safely used within a controlled editor. It uses the shared chainable transaction so that the state update does not override other state updates.

**Also**

Fix a bunch of incorrect tests `focus` tests using a mock `raf` library.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

