### PR TITLE
Add `onError` method to `Remirror.ManagerSettings`

### DIFF
--- a/.changeset/little-walls-drive.md
+++ b/.changeset/little-walls-drive.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': minor
+'@remirror/core-utils': minor
+---
+
+Add `onError` and `stringHandler` methods to the `Remirror.ManagerSettings`.

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -563,7 +563,7 @@ export interface CreateDocumentNodeParameter
   content: RemirrorContentType;
 
   /**
-   * The fallback object node to use if unable to convert the value correctly
+   * The error handler which is called when the JSON passed is invalid.
    */
   onError?: InvalidContentHandler;
 
@@ -629,6 +629,11 @@ export function getTextSelection(
   return TextSelection.create(doc, start, end);
 }
 
+/**
+ * A function that converts a string into a `ProsemirrorNode`.
+ */
+export type StringHandler = (params: FromStringParameter) => ProsemirrorNode;
+
 export interface StringHandlerParameter {
   /**
    * A function which transforms a string into a prosemirror node.
@@ -637,9 +642,9 @@ export interface StringHandlerParameter {
    * Can be used to transform markdown / html or any other string format into a
    * prosemirror node.
    *
-   * See {@link fromHTML} for an example of how this could work.
+   * See [[`fromHTML`]] for an example of how this could work.
    */
-  stringHandler?: (params: FromStringParameter) => ProsemirrorNode;
+  stringHandler?: StringHandler;
 }
 
 // The maximum attempts to check invalid content before throwing an an error.

--- a/packages/@remirror/core-utils/src/index.ts
+++ b/packages/@remirror/core-utils/src/index.ts
@@ -14,8 +14,10 @@ export {
 
 export type {
   CreateDocumentNodeParameter,
+  InvalidContentBlock,
   InvalidContentHandler,
   InvalidContentHandlerParameter,
+  StringHandler,
   StringHandlerParameter,
 } from './core-utils';
 export {

--- a/packages/@remirror/core/src/editor-wrapper.ts
+++ b/packages/@remirror/core/src/editor-wrapper.ts
@@ -735,6 +735,32 @@ export interface EditorWrapperProps<Combined extends AnyCombinedUnion>
 
   /**
    * This is called when the editor has invalid content.
+   *
+   * @remarks
+   *
+   * To add this to the editor the following is needed.
+   *
+   * ```tsx
+   * import React from 'react';
+   * import { RemirrorProvider, InvalidContentHandler } from 'remirror/core';
+   * import { RemirrorProvider, useManager } from 'remirror/react';
+   * import { WysiwygPreset } from 'remirror/preset/wysiwyg';
+   *
+   * const EditorWrapper = () => {
+   *   const onError: InvalidContentHandler = useCallback(({ json, invalidContent, transformers }) => {
+   *     // Automatically remove all invalid nodes and marks.
+   *     return transformers.remove(json, invalidContent);
+   *   }, []);
+   *
+   *   const manager = useManager(() => [new WysiwygPreset()]);
+   *
+   *   return (
+   *     <RemirrorProvider manager={manager} onError={onError}>
+   *       <div />
+   *     </RemirrorProvider>
+   *   );
+   * };
+   * ```
    */
   onError?: InvalidContentHandler;
 }


### PR DESCRIPTION


### Description

Add `onError` and `stringHandler` methods to the `Remirror.ManagerSettings`.

Fixes #626

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
