### PR TITLE
Fix `commands.insertHorizontalRule` positioning

### DIFF
--- a/.changeset/good-bulldogs-call.md
+++ b/.changeset/good-bulldogs-call.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core-utils': minor
+'@remirror/extension-positioner': patch
+---
+
+Move `isEmptyBlockNode` function from `@remirror/extension-positioner` to `@remirror/core-utils`. Re-export to prevent breaking change.

--- a/.changeset/happy-news-repeat.md
+++ b/.changeset/happy-news-repeat.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-horizontal-rule': patch
+---
+
+Fix `commands.insertHorizontalRule` inserting the line in the wrong position.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "remirror-monorepo",
   "private": true,
   "homepage": "https://remirror.io",
   "repository": "https://github.com/remirror/remirror",
@@ -17,6 +17,7 @@
     "checks:ci": "run-s lint typecheck",
     "checks:disable": "rimraf ./.config.json",
     "checks:enable": "cpy support/.config.sample.json ./ --rename=\".config.json\"",
+    "checks:fix": "run-s -c fix typecheck test",
     "checks:release": "run-s checks build test:e2e",
     "ci:version": "run-s ci:version:changeset ci:version:date ci:version:repo fix:prettier ci:version:install",
     "ci:version:changeset": "changeset version",

--- a/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
@@ -40,6 +40,7 @@ import {
   isDocNode,
   isDocNodeEmpty,
   isElementDomNode,
+  isEmptyBlockNode,
   isMarkActive,
   isNodeSelection,
   isProsemirrorNode,
@@ -51,6 +52,18 @@ import {
   toDom,
   toHtml,
 } from '../core-utils';
+
+describe('isEmptyBlockNode', () => {
+  it('should be true for empty nodes', () => {
+    const { state } = createEditor(doc(p('<cursor>')));
+    expect(isEmptyBlockNode(state.selection.$from.node())).toBeTrue();
+  });
+
+  it('should be false for non-empty nodes', () => {
+    const { state } = createEditor(doc(p('abc<cursor>')));
+    expect(isEmptyBlockNode(state.selection.$from.node())).toBeFalse();
+  });
+});
 
 describe('markActive', () => {
   it('shows active when within an active region', () => {

--- a/packages/@remirror/core-utils/src/command-utils.ts
+++ b/packages/@remirror/core-utils/src/command-utils.ts
@@ -173,8 +173,6 @@ function isList(node: ProsemirrorNode, schema: EditorSchema) {
  *
  * @param type - the list node type
  * @param itemType - the list item type (must be in the schema)
- *
- * @public
  */
 export function toggleList(type: NodeType, itemType: NodeType): CommandFunction {
   return (parameter) => {

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -236,6 +236,15 @@ export function isDocNodeEmpty(node: ProsemirrorNode): boolean {
 }
 
 /**
+ * Checks if the current node is a block node and empty.
+ *
+ * @param node - the prosemirror node
+ */
+export function isEmptyBlockNode(node: ProsemirrorNode | null | undefined): boolean {
+  return bool(node) && node.type.isBlock && !node.textContent && !node.childCount;
+}
+
+/**
  * Retrieve the attributes for a mark.
  *
  * @param trState - the editor state or a transaction

--- a/packages/@remirror/core-utils/src/index.ts
+++ b/packages/@remirror/core-utils/src/index.ts
@@ -22,6 +22,7 @@ export type {
 } from './core-utils';
 export {
   areSchemasCompatible,
+  isEmptyBlockNode,
   atDocEnd,
   atDocStart,
   canInsertNode,

--- a/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
+++ b/packages/@remirror/extension-horizontal-rule/src/__tests__/horizontal-rule-extension.spec.ts
@@ -7,7 +7,18 @@ import { HorizontalRuleExtension } from '..';
 extensionValidityTest(HorizontalRuleExtension);
 
 describe('insertHorizontalRule', () => {
-  it('adds a trailing node by default', () => {
+  it('can insert into the middle of content', () => {
+    const { add, nodes, commands, view } = renderEditor([new HorizontalRuleExtension()]);
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('This <cursor>is content')));
+    commands.insertHorizontalRule();
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('This '), hr(), p('is content')));
+    expect(isTextSelection(view.state.selection)).toBe(true);
+  });
+
+  it('adds a trailing node when at the end of a block node', () => {
     const { add, nodes, commands, view } = renderEditor([new HorizontalRuleExtension()]);
     const { doc, horizontalRule: hr, p } = nodes;
 
@@ -46,12 +57,29 @@ describe('insertHorizontalRule', () => {
     const initialExpected = doc(p('This is content'), hr(), hr(), hr(), hr(), p());
     const finalExpected = doc(p('This is content'), hr(), hr(), hr(), hr(), p(' amazing!'));
 
-    expect(view.state.doc.toJSON()).toEqual(initialExpected.toJSON());
+    expect(view.state.doc).toEqualRemirrorDocument(initialExpected);
     expect(view.state.selection.$anchor.parent.type.name).toBe('paragraph');
     expect(view.state.selection.anchor).toBe(22);
 
     insertText(' amazing!');
-    expect(view.state.doc.toJSON()).toEqual(finalExpected.toJSON());
+    expect(view.state.doc).toEqualRemirrorDocument(finalExpected);
+  });
+
+  it('does not split content when adding the hr', () => {
+    const editor = renderEditor([new HorizontalRuleExtension()]);
+    const { add, nodes, view } = editor;
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('Hello'), p('<cursor>'), p('ABC'), p('123'))).commands.insertHorizontalRule();
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p('Hello'), hr(), p(), p('ABC'), p('123')));
+    expect(view.state.selection.from).toBe(9);
+
+    editor.insertText('More');
+
+    expect(view.state.doc).toEqualRemirrorDocument(
+      doc(p('Hello'), hr(), p('More'), p('ABC'), p('123')),
+    );
   });
 });
 
@@ -98,5 +126,18 @@ describe('inputRules', () => {
 
     insertText(' amazing!');
     expect(view.state.doc.toJSON()).toEqual(finalExpected.toJSON());
+  });
+
+  it('can split content at the start of line', () => {
+    const editor = renderEditor([new HorizontalRuleExtension()]);
+    const { add, nodes, view } = editor;
+    const { doc, horizontalRule: hr, p } = nodes;
+
+    add(doc(p('<cursor>a'))).insertText('---');
+    expect(view.state.doc).toEqualRemirrorDocument(doc(hr(), p('a')));
+    expect(view.state.selection.from).toBe(2);
+
+    editor.insertText('hello ');
+    expect(view.state.doc).toEqualRemirrorDocument(doc(hr(), p('hello a')));
   });
 });

--- a/packages/@remirror/extension-positioner/src/positioner-utils.ts
+++ b/packages/@remirror/extension-positioner/src/positioner-utils.ts
@@ -1,22 +1,11 @@
 import {
-  bool,
   EditorState,
   EditorStateParameter,
   hasTransactionChanged,
-  ProsemirrorNode,
   TransactionParameter,
 } from '@remirror/core';
 
-/**
- * Checks if the current node is a block node and empty.
- *
- * @param node - the prosemirror node
- *
- * @public
- */
-export function isEmptyBlockNode(node: ProsemirrorNode | null | undefined) {
-  return bool(node) && node.type.isBlock && !node.textContent && !node.childCount;
-}
+export { isEmptyBlockNode } from '@remirror/core';
 
 interface HasChangedParameter extends EditorStateParameter, Partial<TransactionParameter> {
   previousState: EditorState;
@@ -28,7 +17,7 @@ interface HasChangedParameter extends EditorStateParameter, Partial<TransactionP
  *
  * Return `true` when a change is detected in the document or the selection.
  */
-export function hasStateChanged(parameter: HasChangedParameter) {
+export function hasStateChanged(parameter: HasChangedParameter): boolean {
   const { tr, state, previousState } = parameter;
 
   if (tr) {


### PR DESCRIPTION
### Description

- Move `isEmptyBlockNode` function from `@remirror/extension-positioner` to `@remirror/core-utils`. Re-export to prevent breaking change.
- Fix `commands.insertHorizontalRule` inserting the line in the wrong position.

Fixes #620

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-09-04 18 30 47](https://user-images.githubusercontent.com/1160934/92269915-0195d080-eedd-11ea-94ea-f9f085e6e248.gif)
