### PR TITLE
Fix `useEmoji` with `autoUpdate` (#642

### DIFF
--- a/.changeset/cyan-beds-whisper.md
+++ b/.changeset/cyan-beds-whisper.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react': minor
+---
+
+Add new signature return for `useExtension` and `usePreset`. If only provided the constructor they return a the extension or preset instance from within the manager.

--- a/.changeset/kind-mugs-mate.md
+++ b/.changeset/kind-mugs-mate.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-hooks': patch
+---
+
+Fix issue with `useEmoji`, `useKeymap` and `useEvents` when used together with `useRemirror({ autoUpdate: true })` causing an infinite loop.

--- a/packages/@remirror/react-hooks/src/use-events.ts
+++ b/packages/@remirror/react-hooks/src/use-events.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import type { GetHandler, StringKey } from '@remirror/core';
 import { EventsExtension, EventsOptions } from '@remirror/extension-events';
 import { useExtension } from '@remirror/react';
@@ -11,9 +13,12 @@ export function useEvents<Key extends StringKey<GetHandler<EventsOptions>>>(
 ): void {
   useExtension(
     EventsExtension,
-    ({ addHandler }) => {
-      return addHandler(event, handler);
-    },
+    useCallback(
+      ({ addHandler }) => {
+        return addHandler(event, handler);
+      },
+      [event, handler],
+    ),
     [event, handler],
   );
 }

--- a/packages/@remirror/react-hooks/src/use-history.ts
+++ b/packages/@remirror/react-hooks/src/use-history.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import type { GetHandler, StringKey } from '@remirror/core';
 import { HistoryExtension, HistoryOptions } from '@remirror/extension-history';
 import { useExtension } from '@remirror/react';
@@ -11,9 +13,12 @@ export function useHistory<Key extends StringKey<GetHandler<HistoryOptions>>>(
 ): void {
   useExtension(
     HistoryExtension,
-    ({ addHandler }) => {
-      return addHandler(event, handler);
-    },
+    useCallback(
+      ({ addHandler }) => {
+        return addHandler(event, handler);
+      },
+      [event, handler],
+    ),
     [event, handler],
   );
 }

--- a/packages/@remirror/react-hooks/src/use-keymap.ts
+++ b/packages/@remirror/react-hooks/src/use-keymap.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { KeyBindings, KeymapExtension } from '@remirror/core';
 import { useExtension } from '@remirror/react';
 
@@ -35,7 +37,9 @@ import { useExtension } from '@remirror/react';
  * ```
  */
 export function useKeymap(bindings: KeyBindings): void {
-  useExtension(KeymapExtension, ({ addCustomHandler }) => addCustomHandler('keymap', bindings), [
-    bindings,
-  ]);
+  useExtension(
+    KeymapExtension,
+    useCallback(({ addCustomHandler }) => addCustomHandler('keymap', bindings), [bindings]),
+    [bindings],
+  );
 }

--- a/packages/@remirror/react-hooks/src/use-suggest.ts
+++ b/packages/@remirror/react-hooks/src/use-suggest.ts
@@ -112,14 +112,17 @@ export function useSuggester(props: UseSuggesterProps): UseSuggesterReturn {
     ],
   );
 
-  // Attached the editor state handler to the instance of the remirror editor.
+  // Attach the editor state handler to the instance of the remirror editor.
   useRemirror(onStateUpdate);
 
   // Add the suggester to the editor via the BuiltinPreset.
   usePreset(
     BuiltinPreset,
-    ({ addCustomHandler }) => addCustomHandler('suggester', { ...props, onChange }),
-    [props, onChange],
+    useCallback(({ addCustomHandler }) => addCustomHandler('suggester', { ...props, onChange }), [
+      onChange,
+      props,
+    ]),
+    [(props, onChange)],
   );
 
   return omit(hookState, ['updatesSinceLastExit', 'updatesSinceLastChange']);

--- a/packages/@remirror/react/src/hooks/__tests__/core-hooks.spec.tsx
+++ b/packages/@remirror/react/src/hooks/__tests__/core-hooks.spec.tsx
@@ -30,7 +30,7 @@ test('useMeasure', () => {
   expect(result.current[1].height).toBe(0);
 
   const Component = () => {
-    const [bind, { height: measuredHeight }] = useMeasure();
+    const [bind, { height: measuredHeight }] = useMeasure<HTMLDivElement>();
 
     return (
       <div data-testid='test' {...bind}>

--- a/packages/@remirror/react/src/hooks/__tests__/editor-hooks.spec.tsx
+++ b/packages/@remirror/react/src/hooks/__tests__/editor-hooks.spec.tsx
@@ -135,8 +135,12 @@ describe('useRemirror', () => {
   });
 });
 
+/**
+ * A helper function for creating the editor setup when testing the editor
+ * hooks.
+ */
 function createTestChain() {
-  const chain = RemirrorTestChain.create(createReactManager([new BoldExtension()]));
+  const chain = RemirrorTestChain.create(createReactManager(() => [new BoldExtension()]));
 
   const InnerComponent: FC = ({ children }) => {
     const { getRootProps } = useRemirror();
@@ -152,7 +156,8 @@ function createTestChain() {
   const Wrapper: FC = ({ children }) => {
     return (
       <RemirrorProvider manager={chain.manager}>
-        <InnerComponent>{children}</InnerComponent>
+        <InnerComponent></InnerComponent>
+        {children}
       </RemirrorProvider>
     );
   };


### PR DESCRIPTION
### Description

- Add new signature return for `useExtension` and `usePreset`. If only provided the constructor they return a the extension or preset instance from within the manager.
- Fix issue with `useEmoji`, `useKeymap` and `useEvents` when used together with `useRemirror({ autoUpdate: true })` causing an infinite loop.


Fixes #625

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
