### PR TITLE
Add prioritization to `useKeymap` hook

### DIFF
--- a/.changeset/forty-donuts-knock.md
+++ b/.changeset/forty-donuts-knock.md
@@ -1,0 +1,27 @@
+---
+'@remirror/core': minor
+'@remirror/react-hooks': minor
+---
+
+Add support for prioritized keymap handlers. It's now possible to make sure that a hook which consumes `useKeymap` runs before the extension keybindings.
+
+```ts
+import React from 'react';
+import { ExtensionPriority } from 'remirror/core';
+import { useKeymap } from 'remirror/react/hooks';
+
+const KeymapHook = () => {
+  // Make sure this keybinding group is run first!
+  useKeymap({ Enter: () => doSomething() }, ExtensionPriority.Highest);
+
+  // This one we don't care about 🤷‍♀️
+  useKeymap({ 'Shift-Delete': () => notImportant() }, ExtensionPriority.Lowest);
+
+  return <div />;
+};
+```
+
+- By default hooks the hooks from `remirror/react/hooks` which consume `useKeymap are given a priority of`ExtensionPriority.High`.
+- `useKeymap` is given a priority of `ExtensionPriority.Medium`.
+- The `createKeymap` method on all extensions is given a priority of `ExtensionPriority.Default`.
+- The `baseKeymap` which is added by default is given a priority of `ExtensionPriority.Low`.

--- a/.changeset/tall-singers-admire.md
+++ b/.changeset/tall-singers-admire.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': patch
+'@remirror/styles': patch
+---
+
+Fix broken styles for firefox as raised on **discord**.

--- a/.changeset/wise-cougars-behave.md
+++ b/.changeset/wise-cougars-behave.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react': patch
+---
+
+Deprecate `@remirror/react` exports for `usePositioner` and `useMultiPositioner` to push adoption of `remirror/react/hooks`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,9 @@ title: Contributing
 
 Fork [this repository][repo], clone your fork and add this repository as the upstream remote.
 
-You will need to have [`pnpm`](https://pnpm.js.org) installed so make sure you follow the installation [instructions](https://pnpm.js.org/en/installation).
+You will need to have [`pnpm`](https://pnpm.js.org) installed so make sure you follow the installation [instructions](https://pnpm.js.org/en/installation). At the time of writing the advised way to install is via `npm i -g pnpm`.
+
+You will also need to install [`git-lfs`](https://git-lfs.github.com/) which is used for managing large file storage. The installation is platform dependent so please follow the instructions outlined [here](https://git-lfs.github.com/).
 
 ```bash
 git clone <<FORKED_REPO_URL>>
@@ -43,7 +45,7 @@ From the root directory use the following command to launch the documentation si
 pnpm docs
 ```
 
-Once the build completes (can take a minute the first time) navigate to http://localhost:3000 (or another port if that one is already being used).
+Once the build completes (can take a minute the first time) navigate to <http://localhost:3000> (or another port if that one is already being used).
 
 The documentation is written using [docusaurus] and all files and dependencies are available in the `/support/website` subdirectory. To add a new dependency, you will need to add it to `/support/website/package.json` and not the top level package.json file. You can either do this by manually editing the `/support/website/package.json` file or you use the following command.
 

--- a/packages/@remirror/core/src/manager/remirror-manager-helpers.ts
+++ b/packages/@remirror/core/src/manager/remirror-manager-helpers.ts
@@ -97,7 +97,7 @@ export function transformCombinedUnion<Combined extends AnyCombinedUnion>(
   }
 
   // Sort the extensions.
-  rawExtensions = sort(rawExtensions, (a, b) => b.priority - a.priority);
+  rawExtensions = sort(rawExtensions, (a, z) => z.priority - a.priority);
 
   // Keep track of added constructors for uniqueness.
   const found = new WeakSet<AnyExtensionConstructor>();

--- a/packages/@remirror/core/src/styles.ts
+++ b/packages/@remirror/core/src/styles.ts
@@ -2,10 +2,10 @@ import { css } from 'linaria';
 
 export const editorStyles = css`
   &.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0;
 
@@ -30,14 +30,15 @@ export const editorStyles = css`
     }
   }
 
-  .ProseMirror-hideselection {
-    * {
-      &::selection,
-      &::-moz-selection {
-        background: transparent;
-      }
-    }
+  .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
 
+  .ProseMirror-hideselection *::-moz-selection {
+    background: transparent;
+  }
+
+  .ProseMirror-hideselection {
     caret-color: transparent;
   }
 

--- a/packages/@remirror/react-hooks/src/use-emoji.ts
+++ b/packages/@remirror/react-hooks/src/use-emoji.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
 
-import { isEmptyArray, isUndefined } from '@remirror/core';
+import { ExtensionPriority, isEmptyArray, isUndefined } from '@remirror/core';
 import {
   EmojiExtension,
   EmojiObject,
@@ -153,7 +153,7 @@ function useEmojiKeyBindings(setState: SetEmojiState, state: EmojiState | null) 
     [ArrowDown, ArrowUp, state, helpers, setState],
   );
 
-  useKeymap(bindings);
+  useKeymap(bindings, ExtensionPriority.High);
 }
 
 type SetEmojiState = Dispatch<SetStateAction<EmojiState | null>>;

--- a/packages/@remirror/react-hooks/src/use-keymap.ts
+++ b/packages/@remirror/react-hooks/src/use-keymap.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { KeyBindings, KeymapExtension } from '@remirror/core';
+import { ExtensionPriority, KeyBindings, KeymapExtension } from '@remirror/core';
 import { useExtension } from '@remirror/react';
 
 /**
@@ -36,10 +36,13 @@ import { useExtension } from '@remirror/react';
  * };
  * ```
  */
-export function useKeymap(bindings: KeyBindings): void {
+export function useKeymap(bindings: KeyBindings, priority = ExtensionPriority.Medium): void {
   useExtension(
     KeymapExtension,
-    useCallback(({ addCustomHandler }) => addCustomHandler('keymap', bindings), [bindings]),
-    [bindings],
+    useCallback(({ addCustomHandler }) => addCustomHandler('keymap', [priority, bindings]), [
+      priority,
+      bindings,
+    ]),
+    [],
   );
 }

--- a/packages/@remirror/react-hooks/src/use-mention-atom.ts
+++ b/packages/@remirror/react-hooks/src/use-mention-atom.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
 
-import type { KeyBindings } from '@remirror/core';
+import { ExtensionPriority, KeyBindings } from '@remirror/core';
 import {
   MentionAtomChangeHandler,
   MentionAtomExtension,
@@ -185,7 +185,7 @@ function useMentionAtomKeyBindings<
   );
 
   // Attach the keybindings to the editor.
-  useKeymap(bindings);
+  useKeymap(bindings, ExtensionPriority.High);
 }
 
 type SetMentionAtomState<

--- a/packages/@remirror/react-hooks/src/use-mention.ts
+++ b/packages/@remirror/react-hooks/src/use-mention.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
 
-import type { KeyBindings, Replace } from '@remirror/core';
+import { ExtensionPriority, KeyBindings, Replace } from '@remirror/core';
 import type {
   MentionChangeHandler,
   MentionChangeHandlerCommand,
@@ -215,7 +215,7 @@ function useMentionKeyBindings(
   );
 
   // Attach the keybindings to the editor.
-  useKeymap(bindings);
+  useKeymap(bindings, ExtensionPriority.High);
 }
 
 type SetMentionState = Dispatch<SetStateAction<MentionState | null>>;

--- a/packages/@remirror/react/src/hooks/editor-hooks.ts
+++ b/packages/@remirror/react/src/hooks/editor-hooks.ts
@@ -499,6 +499,9 @@ export function useManager<Combined extends AnyCombinedUnion>(
 
 export type BaseReactCombinedUnion = ReactPreset | CorePreset | BuiltinPreset;
 
+/**
+ * @deprecated Import from `remirror/react/hooks` instead.
+ */
 export interface UseMultiPositionerReturn extends VirtualPosition {
   /**
    * This ref must be applied to the component that is being positioned in order
@@ -517,6 +520,9 @@ export interface UseMultiPositionerReturn extends VirtualPosition {
   key: string;
 }
 
+/**
+ * @deprecated Import from `remirror/react/hooks` instead.
+ */
 export interface UsePositionerReturn extends Partial<UseMultiPositionerReturn> {
   /**
    * When `true`, the position is active and the pop should be displayed.
@@ -525,37 +531,8 @@ export interface UsePositionerReturn extends Partial<UseMultiPositionerReturn> {
 }
 
 /**
- * A hook for creating a positioner with the `PositionerExtension`. When an
- * active position exists for the provided positioner it will return an object
- * with the `ref`, `top`, `left`, `bottom`, `right` properties.
- *
- * @param isActive - Set this to a boolean to override whether the positioner is
- * active. `true` leaves the behaviour unchanged.
- *
- *
- * @remarks
- *
- * Must apply the ref to the component when called.
- *
- * ```ts
- * import { usePositioner } from 'remirror/react';
- *
- * const MenuComponent: FC = () => {
- *   const positions = usePositioner('bubble');
- *
- *   return (
- *     <div style={{ bottom, left }} ref={ref}>
- *       <MenuIcon {...options} />
- *     </div>
- *   );
- * }
- *
- * const Wrapper = () => (
- *   <RemirrorProvider extensions={[]}>
- *     <MenuComponent />
- *   </RemirrorProvider>
- * )
- * ```
+ * @deprecated Import from `remirror/react/hooks` or
+ * `@remirror/react-hooks/use-positioner` instead.
  */
 export function usePositioner(
   positioner: Positioner | StringPositioner,
@@ -571,33 +548,8 @@ export function usePositioner(
 }
 
 /**
- * A positioner for your editor. This returns an array of active positions and
- * is useful for tracking the positions of multiple items in the editor.
- *
- * ```ts
- * import { Positioner } from 'remirror/extension/positioner
- * import { useMultiPositioner } from 'remirror/react';
- *
- * const positioner = Positioner.create({
- *   ...config, // custom config
- * })
- *
- * const MenuComponent: FC = () => {
- *   const positions = usePositioner(positioner);
- *
- *   return (
- *     <>
- *       {
- *         positions.map(({ ref, bottom, left, key }) => (
- *           <div style={{ bottom, left }} ref={ref} key={key}>
- *             <MenuIcon {...options} />
- *           </div>
- *         )
- *       }
- *     </>
- *   )
- * }
- * ```
+ * @deprecated Import from `remirror/react/hooks` or
+ * `@remirror/react-hooks/use-multi-positioner` instead.
  */
 export function useMultiPositioner(
   positioner: Positioner | StringPositioner,

--- a/packages/@remirror/styles/all.css
+++ b/packages/@remirror/styles/all.css
@@ -3,10 +3,10 @@
  */
 
 .remirror-editor.ProseMirror {
-  position: relative;
   word-wrap: break-word;
   white-space: pre-wrap;
   white-space: break-spaces;
+  position: relative;
   font-variant-ligatures: none;
   font-feature-settings: 'liga' 0, none;
 }
@@ -35,11 +35,14 @@
   background: transparent;
 }
 
-*::-moz-selection {
+.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }
 
-.remirror-editor .ProseMirror-hideselection *::selection,
+.remirror-editor .ProseMirror-hideselection *::selection {
+  background: transparent;
+}
+
 .remirror-editor .ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }

--- a/packages/@remirror/styles/core.css
+++ b/packages/@remirror/styles/core.css
@@ -3,10 +3,10 @@
  */
 
 .remirror-editor.ProseMirror {
-  position: relative;
   word-wrap: break-word;
   white-space: pre-wrap;
   white-space: break-spaces;
+  position: relative;
   font-variant-ligatures: none;
   font-feature-settings: 'liga' 0, none;
 }
@@ -35,11 +35,14 @@
   background: transparent;
 }
 
-*::-moz-selection {
+.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }
 
-.remirror-editor .ProseMirror-hideselection *::selection,
+.remirror-editor .ProseMirror-hideselection *::selection {
+  background: transparent;
+}
+
 .remirror-editor .ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }

--- a/packages/@remirror/styles/src/dom.tsx
+++ b/packages/@remirror/styles/src/dom.tsx
@@ -12,10 +12,10 @@ export const coreStyledCss = css`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -44,11 +44,14 @@ export const coreStyledCss = css`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -729,10 +732,10 @@ export const allStyledCss = css`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -761,11 +764,14 @@ export const allStyledCss = css`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }

--- a/packages/@remirror/styles/src/emotion.tsx
+++ b/packages/@remirror/styles/src/emotion.tsx
@@ -11,10 +11,10 @@ export const coreStyledCss = css`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -43,11 +43,14 @@ export const coreStyledCss = css`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -83,10 +86,10 @@ export const CoreStyledComponent = styled.div`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -115,11 +118,14 @@ export const CoreStyledComponent = styled.div`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -1445,10 +1451,10 @@ export const allStyledCss = css`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -1477,11 +1483,14 @@ export const allStyledCss = css`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -2146,10 +2155,10 @@ export const AllStyledComponent = styled.div`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -2178,11 +2187,14 @@ export const AllStyledComponent = styled.div`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }

--- a/packages/@remirror/styles/src/styled-components.tsx
+++ b/packages/@remirror/styles/src/styled-components.tsx
@@ -10,10 +10,10 @@ export const coreStyledCss = css`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -42,11 +42,14 @@ export const coreStyledCss = css`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -82,10 +85,10 @@ export const CoreStyledComponent = styled.div`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -114,11 +117,14 @@ export const CoreStyledComponent = styled.div`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -1444,10 +1450,10 @@ export const allStyledCss = css`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -1476,11 +1482,14 @@ export const allStyledCss = css`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
@@ -2145,10 +2154,10 @@ export const AllStyledComponent = styled.div`
  */
 
   .remirror-editor.ProseMirror {
-    position: relative;
     word-wrap: break-word;
     white-space: pre-wrap;
     white-space: break-spaces;
+    position: relative;
     font-variant-ligatures: none;
     font-feature-settings: 'liga' 0, none;
   }
@@ -2177,11 +2186,14 @@ export const AllStyledComponent = styled.div`
     background: transparent;
   }
 
-  *::-moz-selection {
+  .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .remirror-editor .ProseMirror-hideselection *::selection,
+  .remirror-editor .ProseMirror-hideselection *::selection {
+    background: transparent;
+  }
+
   .remirror-editor .ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }


### PR DESCRIPTION
### Description

Add support for prioritized keymap handlers. It's now possible to make sure that a hook which consumes `useKeymap` runs before the extension keybindings.

```ts
import React from 'react';
import { ExtensionPriority } from 'remirror/core';
import { useKeymap } from 'remirror/react/hooks';
const KeymapHook = () => {
  // Make sure this keybinding group is run first!
  useKeymap({ Enter: () => doSomething() }, ExtensionPriority.Highest);
  // This one we don't care about 🤷‍♀️
  useKeymap({ 'Shift-Delete': () => notImportant() }, ExtensionPriority.Lowest);
  return <div />;
};
```

- By default hooks the hooks from `remirror/react/hooks` which consume `useKeymap are given a priority of`ExtensionPriority.High`.
- `useKeymap` is given a priority of `ExtensionPriority.Medium`.
- The `createKeymap` method on all extensions is given a priority of `ExtensionPriority.Default`.
- The `baseKeymap` which is added by default is given a priority of `ExtensionPriority.Low`.


- Fix broken styles for firefox as raised on **discord**.
- Deprecate `@remirror/react` exports for `usePositioner` and `useMultiPositioner` to push adoption of `remirror/react/hooks`.

Fixes #632


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
