### PR TITLE
Add minimum supported TypeScript version

### DIFF
--- a/.changeset/forty-donuts-knock.md
+++ b/.changeset/forty-donuts-knock.md
@@ -3,7 +3,7 @@
 '@remirror/react-hooks': minor
 ---
 
-Add support for prioritized keymap handlers. It's now possible to make sure that a hook which consumes `useKeymap` runs before the extension keybindings.
+Add support for prioritized keymaps. It's now possible to make sure that a hook which consumes `useKeymap` runs before the extension keybindings.
 
 ```ts
 import React from 'react';
@@ -21,7 +21,30 @@ const KeymapHook = () => {
 };
 ```
 
-- By default hooks the hooks from `remirror/react/hooks` which consume `useKeymap are given a priority of`ExtensionPriority.High`.
+Here is a breakdown of the default priorities when consuming keymaps.
+
+- Hooks within `remirror/react/hooks` which consume `useKeymap` have a priority of `ExtensionPriority.High`.
 - `useKeymap` is given a priority of `ExtensionPriority.Medium`.
-- The `createKeymap` method on all extensions is given a priority of `ExtensionPriority.Default`.
+- The `createKeymap` method for extensions is given a priority of `ExtensionPriority.Default`.
 - The `baseKeymap` which is added by default is given a priority of `ExtensionPriority.Low`.
+
+To change the default priority of the `createKeymap` method in a custom extension wrap the `KeyBindings` return in a tuple with the priority as the first parameter.
+
+```ts
+import { PlainExtension, KeyBindingsTuple, ExtensionPriority, KeyBindings } from 'remirror/core';
+
+class CustomExtension extends PlainExtension {
+  get name() {
+    return 'custom' as const;
+  }
+
+  createKeymap(): KeyBindingsTuple {
+    const bindings = {
+      Enter: () => return true,
+      Backspace: () => return true,
+    }
+
+    return [ExtensionPriority.High, bindings];
+  }
+}
+```

--- a/.changeset/odd-ants-wait.md
+++ b/.changeset/odd-ants-wait.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': major
+'remirror': major
+---
+
+TypeScript 4.0.2 is now the minimum supported version.

--- a/packages/@remirror/core/src/index.ts
+++ b/packages/@remirror/core/src/index.ts
@@ -18,7 +18,7 @@ export {
   HelpersExtension,
   InputRulesExtension,
   KeymapExtension,
-  NodeViewExtension as NodeViewsExtension,
+  NodeViewExtension,
   PasteRulesExtension,
   PluginsExtension,
   SchemaExtension,

--- a/packages/@remirror/extension-annotation/readme.md
+++ b/packages/@remirror/extension-annotation/readme.md
@@ -16,13 +16,13 @@
 
 ```bash
 # yarn
-yarn add @remirror/extension-annotation @remirror/pm
+yarn add @remirror/extension-annotation@next @remirror/extension-positioner@next @remirror/pm@next
 
 # pnpm
-pnpm add @remirror/extension-annotation @remirror/pm
+pnpm add @remirror/extension-annotation@next @remirror/extension-positioner@next @remirror/pm@next
 
 # npm
-npm install @remirror/extension-annotation @remirror/pm
+npm install @remirror/extension-annotation@next @remirror/extension-positioner@next @remirror/pm@next
 ```
 
 ## Usage

--- a/support/base.babel.js
+++ b/support/base.babel.js
@@ -10,16 +10,9 @@ const ignore = [
 
 const basePreset = ['@babel/preset-react', 'linaria/babel'];
 
-const presets = [
-  ...basePreset,
-  ['@babel/preset-env', {}, 'name-added-to-prevent-duplicate-with-linaria-preset'],
-];
+const presets = [...basePreset, ['@babel/preset-env', { targets: 'since 2017' }, 'deduplicate']];
 
-const testBabelPresetEnv = [
-  '@babel/preset-env',
-  { targets: { node: '12' } },
-  'name-added-to-prevent-duplicate-with-linaria-preset',
-];
+const testBabelPresetEnv = ['@babel/preset-env', { targets: { node: 'current' } }, 'deduplicate'];
 const nonTestEnv = { ignore, presets };
 
 module.exports = {
@@ -37,8 +30,8 @@ module.exports = {
   ],
   plugins: [
     'babel-plugin-macros',
-    ['@babel/plugin-transform-runtime', {}, 'name-added-to-prevent-duplicate-with-linaria-preset'],
-    ['@babel/plugin-transform-template-literals', {}, 'no-clash'],
+    ['@babel/plugin-transform-runtime', {}, 'deduplicate'],
+    ['@babel/plugin-transform-template-literals', {}, 'deduplicate'],
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-proposal-nullish-coalescing-operator',


### PR DESCRIPTION
### Description

TypeScript 4.0.2 is now the minimum supported version.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
