### PR TITLE
New `AcceptUndefined` annotation for `Options`

### DIFF
--- a/.changeset/moody-ants-drive.md
+++ b/.changeset/moody-ants-drive.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core': minor
+'@remirror/core-types': minor
+'@remirror/extension-history': minor
+---
+
+Add `AcceptUndefined` annotation which allows options to accept undefined as their default value.

--- a/docs/concepts/extension.md
+++ b/docs/concepts/extension.md
@@ -18,7 +18,7 @@ There are three types of `Extension`.
 
 ## Lifecycle Methods
 
-Extensions are able to completely customise the behaviour of the editor via these lifecycle methods. Even core functionality like the creation of `Schema` is built via `Extensions`. This section outlines what you're working with in extensions.
+Extensions are able to completely customise the behaviour of the editor via these lifecycle methods. Even core functionality like the creation of `Schema` is built via `Extension`s. This section outlines what you're working with in extensions.
 
 ### `onCreate`
 
@@ -26,7 +26,7 @@ Extensions are able to completely customise the behaviour of the editor via thes
 onCreate(extensions: readonly AnyExtension[]): void;
 ```
 
-This handler is called when the `RemirrorManager` is first created. Since it is called as soon as the manager is some methods may not be available in the extension store. When accessing methods on `this.store` be shore to check when they become available in the lifecycle. It is recommende that you don't use this method unless absolutely required.
+This handler is called when the `RemirrorManager` is first created. Since it is called as soon as the manager is created some methods may not be available in the extension store. When accessing methods on `this.store` be sure to check their documentation for when they become available. It is recommended that you don't use this method unless absolutely required.
 
 ### `onView`
 
@@ -34,7 +34,7 @@ This handler is called when the `RemirrorManager` is first created. Since it is 
 onView( extensions: readonly AnyExtension[], view: EditorView<EditorSchema>): void
 ```
 
-This event happens when the `EditorView` is first added by the ui layer. This is the lifecycle method where commands and editor helpers are added.
+This lifecycle method is called when the `EditorView` is first added by the UI layer. This is the lifecycle method where commands and editor helpers are added.
 
 ### `onStateUpdate`
 
@@ -50,7 +50,7 @@ This is called whenever a transaction successfully updates the `EditorState`. Fo
 onDestroy(extensions: readonly AnyExtension[]): void
 ```
 
-This is called when the `RemirrorManager` is being destroyed.
+This is called when the `RemirrorManager` is being destroyed. You can use this method if you need to clean up any externally created handlers in order to prevent memory leaks.
 
 ## Options
 
@@ -105,7 +105,7 @@ class ExampleExtension extends PlainExtension<ExampleOptions> {
 }
 ```
 
-These annotations can be used to provide better intelli-sense support for the end user.
+These annotations can be used to provide better intellisense support for the end user.
 
 ### `extensionDecorator`
 
@@ -128,6 +128,34 @@ const exampleExtension = new ExampleExtension({
 
 // Runtime update
 exampleExtension.setOptions({ color: 'pink', backgroundColor: 'purple' });
+```
+
+Please note that as mentioned in this issue [#624](https://github.com/remirror/remirror/issues/624), partial options can cause trouble when setting a default.
+
+If you need to accept `undefined`as an acceptable default option there are two possible ways to resolve this.
+
+#### Use `AcceptUndefined`
+
+This is the preferred solution and should be used instead of the following `null` union.
+
+```ts
+import { AcceptUndefined } from 'remirror/core';
+
+interface Options {
+  optional?: AcceptUndefined<string>;
+}
+```
+
+Now when the options are consumed by this decorator there should be no errors when setting the value to `undefined`.
+
+#### `null` union
+
+If you don't mind using nulls in your code then this might appeal to you.
+
+```ts
+interface Options {
+  optional?: string | null;
+}
 ```
 
 ### `Static` options
@@ -204,4 +232,6 @@ The onChange handler is automatically managed for you.
 
 ### `CustomHandler` options
 
-`CustomHandler` options are like `Handler` options except it's up to you to wire up the handler. More examples will be added later.
+`CustomHandler` options are like `Handler` options except it's up to the extension creator to manage how they are handled. They are useful for situations when you want the extension to allow composition of events but it doesn't quite fit into the neat `EventHandler` scenario.
+
+The KeymapExtension in `@remirror/core` is a good example of this.

--- a/packages/@remirror/core-types/src/annotation-types.ts
+++ b/packages/@remirror/core-types/src/annotation-types.ts
@@ -15,6 +15,13 @@ type DynamicAnnotation = Flavoring<'DynamicAnnotation'>;
 type HandlerAnnotation = Flavoring<'HandlerAnnotation'>;
 type CustomHandlerAnnotation = Flavoring<'CustomAnnotation'>;
 
+/**
+ * This type is in response to the issue raised
+ * [here](https://github.com/remirror/remirror/issues/624). It allows an type to
+ * be `undefined`.
+ */
+type AcceptUndefinedAnnotation = Flavoring<'AcceptUndefinedAnnotation'>;
+
 export type RemoveAnnotation<Type> = RemoveFlavoring<Type>;
 
 /**
@@ -72,6 +79,12 @@ export type Static<Type> = Type & StaticAnnotation;
  * ```
  */
 export type Dynamic<Type> = Type & DynamicAnnotation;
+
+/**
+ * Wrap a type in this to let the `DefaultOptions` know that it can accept
+ * undefined as the default value.
+ */
+export type AcceptUndefined<Type> = Type & AcceptUndefinedAnnotation;
 
 /**
  * A handler is a callback provided by the user to respond to events from your
@@ -148,6 +161,15 @@ export type GetDynamic<Options extends Shape> = Omit<
     Exclude<Remirror.ValidOptionsExtender[keyof Remirror.ValidOptionsExtender], DynamicAnnotation>
   >
 >;
+
+/**
+ * Get the properties that accept undefined as a default.
+ */
+export type GetAcceptUndefined<Options extends Shape> = ConditionalPick<
+  Options,
+  AcceptUndefinedAnnotation
+> &
+  Partial<ConditionalPick<PickPartial<Options>, AcceptUndefinedAnnotation>>;
 
 /**
  * Get the event handler `Options` from the options type.

--- a/packages/@remirror/core-types/src/base-types.ts
+++ b/packages/@remirror/core-types/src/base-types.ts
@@ -137,6 +137,12 @@ export type MakeOptional<Type extends object, Keys extends keyof Type> = Omit<Ty
   { [Key in Keys]+?: Type[Key] };
 
 /**
+ * Makes specified keys of an interface optional while the rest stay the same.
+ */
+export type MakeUndefined<Type extends object, Keys extends keyof Type> = Omit<Type, Keys> &
+  { [Key in Keys]: Type[Key] | undefined };
+
+/**
  * Makes specified keys of an interface nullable while the rest stay the same.
  */
 export type MakeNullable<Type extends object, Keys extends keyof Type> = Omit<Type, Keys> &

--- a/packages/@remirror/core-types/src/index.ts
+++ b/packages/@remirror/core-types/src/index.ts
@@ -20,6 +20,8 @@ export type {
   Transaction,
 } from './alias-types';
 export type {
+  AcceptUndefined,
+  GetAcceptUndefined,
   CustomHandler,
   CustomHandlerKey,
   CustomHandlerKeyList,
@@ -80,6 +82,7 @@ export type {
   MakeOptional,
   MakeReadonly,
   MakeRequired,
+  MakeUndefined,
   MarkAttributes,
   NodeAttributes,
   NodeMarkOptions,

--- a/packages/@remirror/core/src/builtins/persistent-selection-extension.ts
+++ b/packages/@remirror/core/src/builtins/persistent-selection-extension.ts
@@ -13,6 +13,10 @@ export interface PersistentSelectionOptions {
 
 export const DEFAULT_PERSISTENT_SELECTION_CLASS = 'selection';
 
+/**
+ * This extension adds a decoration to the selected text and can be used to
+ * preserve the marker for the selection when the editor loses focus.
+ */
 @extensionDecorator<PersistentSelectionOptions>({
   defaultOptions: {
     persistentSelectionClass: DEFAULT_PERSISTENT_SELECTION_CLASS,
@@ -31,18 +35,14 @@ export class PersistentSelectionExtension extends PlainExtension<PersistentSelec
         decorations: ({ doc, selection }) => {
           // Do not run the extension at all when there is no actual decoration
           // to be done.
-          if (!this.options.persistentSelectionClass) {
+          if (!this.options.persistentSelectionClass || selection.empty) {
             return;
           }
 
-          if (selection.empty) {
-            return;
-          }
-
+          let decoration: Decoration;
           const decorationAttrs = {
             class: this.options.persistentSelectionClass,
           };
-          let decoration: Decoration;
 
           if (isNodeSelection(selection)) {
             decoration = Decoration.node(selection.from, selection.to, decorationAttrs);

--- a/packages/@remirror/core/src/decorators.ts
+++ b/packages/@remirror/core/src/decorators.ts
@@ -29,6 +29,39 @@ interface DefaultOptionsParameter<Options extends Shape = EmptyShape> {
    *
    * All non required options must have a default value provided.
    *
+   * Please note that as mentioned in this issue
+   * [#624](https://github.com/remirror/remirror/issues/624), partial options
+   * can cause trouble when setting a default.
+   *
+   * If you need to accept `undefined `as an acceptable default option there are
+   * two possible ways to resolve this.
+   *
+   * #### Use `AcceptUndefined`
+   *
+   * This is the preferred solution and should be used instead of the following
+   * `null` union.
+   *
+   * ```ts
+   * import { AcceptUndefined } from 'remirror/core';
+   *
+   * interface Options {
+   *   optional?: AcceptUndefined<string>;
+   * }
+   * ```
+   *
+   * Now when the options are consumed by this decorator there should be no
+   * errors when setting the value to `undefined`.
+   *
+   * #### `null` union
+   *
+   * If you don't mind using nulls in your code then this might appeal to you.
+   *   *
+   * ```ts
+   * interface Options {
+   *   optional?: string | null;
+   * }
+   * ```
+   *
    * @default {}
    */
   defaultOptions: DefaultExtensionOptions<Options>;
@@ -80,8 +113,8 @@ interface HandlerKeysParameter<Options extends Shape = EmptyShape> {
    * Customize how the handler should work.
    *
    * This allows you to decide how the handlers will be composed together.
-   * Currenlty it only support function handlers, but you can tell the extension
-   * to exit early when a certain value is reached.
+   * Currently it only support function handlers, but you can tell the extension
+   * to exit early when a certain return value is received.
    *
    * ```ts
    * const handlerOptions = { onChange: { earlyReturnValue: true }};
@@ -126,7 +159,7 @@ export type ExtensionDecoratorOptions<
 export function extensionDecorator<Options extends Shape = EmptyShape>(
   options: ExtensionDecoratorOptions<Options>,
 ) {
-  return <Type extends AnyExtensionConstructor>(ReadonlyConstructor: Type) => {
+  return <Type extends AnyExtensionConstructor>(ReadonlyConstructor: Type): Type => {
     const {
       defaultOptions,
       customHandlerKeys,
@@ -192,7 +225,7 @@ export type PresetDecoratorOptions<Options extends Shape = EmptyShape> = IfHasRe
 export function presetDecorator<Options extends Shape = EmptyShape>(
   options: PresetDecoratorOptions<Options>,
 ) {
-  return <Type extends AnyPresetConstructor>(ReadonlyConstructor: Type) => {
+  return <Type extends AnyPresetConstructor>(ReadonlyConstructor: Type): Type => {
     const { defaultOptions, customHandlerKeys, handlerKeys, staticKeys } = options;
 
     const Constructor = Cast<Writeable<PresetConstructor<Options>>>(ReadonlyConstructor);

--- a/packages/@remirror/core/src/extension/base-class.ts
+++ b/packages/@remirror/core/src/extension/base-class.ts
@@ -21,6 +21,7 @@ import type {
   AnyFunction,
   Dispose,
   EmptyShape,
+  GetAcceptUndefined,
   GetConstructorParameter,
   GetCustomHandler,
   GetFixed,
@@ -31,8 +32,10 @@ import type {
   GetStatic,
   HandlerKeyList,
   IfNoRequiredProperties,
+  MakeUndefined,
   Replace,
   Shape,
+  StringKey,
   UndefinedFlipPartialAndRequired,
   ValidOptions,
 } from '@remirror/core-types';
@@ -614,9 +617,12 @@ export type ConstructorParameter<
 export type DefaultOptions<
   Options extends ValidOptions,
   DefaultStaticOptions extends Shape
-> = UndefinedFlipPartialAndRequired<GetStatic<Options>> &
-  Partial<DefaultStaticOptions> &
-  GetFixedDynamic<Options>;
+> = MakeUndefined<
+  UndefinedFlipPartialAndRequired<GetStatic<Options>> &
+    Partial<DefaultStaticOptions> &
+    GetFixedDynamic<Options>,
+  StringKey<GetAcceptUndefined<Options>>
+>;
 
 /**
  * Checks that the extension has a valid constructor with the `defaultOptions`

--- a/packages/@remirror/extension-history/src/history-extension.ts
+++ b/packages/@remirror/extension-history/src/history-extension.ts
@@ -1,4 +1,5 @@
 import {
+  AcceptUndefined,
   CommandFunction,
   DispatchFunction,
   EditorState,
@@ -22,7 +23,7 @@ export interface HistoryOptions {
    *
    * @default 100
    */
-  depth?: Static<number | null>;
+  depth?: Static<number>;
 
   /**
    * The delay (ms) between changes after which a new group should be
@@ -30,7 +31,7 @@ export interface HistoryOptions {
    *
    * @default 500
    */
-  newGroupDelay?: Static<number | null>;
+  newGroupDelay?: Static<number>;
 
   /**
    * Provide a custom state getter function.
@@ -42,7 +43,7 @@ export interface HistoryOptions {
    * can be dispatched into the parent editor allowing them to propagate into
    * the child editor
    */
-  getState?: (() => EditorState) | null;
+  getState?: AcceptUndefined<() => EditorState>;
 
   /**
    * Provide a custom dispatch getter function for embedded editors
@@ -54,7 +55,7 @@ export interface HistoryOptions {
    * can be dispatched into the parent editor allowing them to propagate into
    * the child editor.
    */
-  getDispatch?: (() => DispatchFunction) | null;
+  getDispatch?: AcceptUndefined<() => DispatchFunction>;
 
   /**
    * A callback to listen to when the user attempts to undo with the keyboard.
@@ -79,8 +80,8 @@ export interface HistoryOptions {
   defaultOptions: {
     depth: 100,
     newGroupDelay: 500,
-    getDispatch: null,
-    getState: null,
+    getDispatch: undefined,
+    getState: undefined,
   },
   staticKeys: ['depth', 'newGroupDelay'],
   handlerKeys: ['onRedo', 'onUndo'],


### PR DESCRIPTION
### Description

Add `AcceptUndefined` annotation which allows options to accept undefined as their default value.

Fixes #624

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
