### PR TITLE
Support adding extra attributes by `tags`

### DIFF
--- a/.changeset/thick-pianos-wink.md
+++ b/.changeset/thick-pianos-wink.md
@@ -1,0 +1,34 @@
+---
+'@remirror/core': minor
+---
+
+🎉 Brings support for adding extra attributes to the `RemirrorManager` via extension tags. Attributes can now be added to all nodes and marks with a specific tag like `ExtensionTag.Alignment` or `ExtensionTag.NodeBlock`. Every matching tag in the `Schema` receives the extra attributes defined.
+
+With tags, you can select a specific sub selection of marks and nodes. This will be the basis for adding advanced formatting to `remirror`.
+
+```ts
+import { ExtensionTag } from 'remirror/core';
+import { createCoreManager, CorePreset } from 'remirror/preset/core';
+import { WysiwygPreset } from 'remirror/preset/wysiwyg';
+const manager = createCoreManager(() => [new WysiwygPreset(), new CorePreset()], {
+  extraAttributes: [
+    {
+      identifiers: {
+        tags: [ExtensionTag.NodeBlock],
+
+        // Can be limited by type to `node | mark`.
+        type: 'node',
+      },
+      attributes: { role: 'presentation' },
+    },
+  ],
+});
+```
+
+Each item in the tags array should be read as an `OR` so the following would match `Tag1` OR `Tag2` OR `Tag3`.
+
+```json
+{ "tags": ["Tag1", "Tag2", "Tag3"] }
+```
+
+The `type` property (`mark | node`) is exclusive and limits the type of matches that will be matched.

--- a/docs/concepts/error-handling.md
+++ b/docs/concepts/error-handling.md
@@ -2,20 +2,20 @@
 title: Error Handling
 ---
 
-Remirror reuses the ProseMirror `Schema` to identify the content the document will support and the rules around how it can be manipulated. For this reason, error handling is a key concern when implementing a Remirror editor.
+Remirror relies on the ProseMirror `Schema` to identify the content the document will support and the rules around how it can be manipulated. For this reason, error handling is a key concern when implementing a Remirror editor.
 
 ## Introduction
 
 Sometimes the content that is passed into the editor is invalid. It may have been valid at the time it was written but the end-user is opening the editor for the first time in months.
 
-Perhaps you've removed a NodeExtension or MarkExtension from the manager since the content was created. If the content passed includes the invalid types ProseMirror throws an error `RangeError: There is no mark type italic in this schema`. Depending on how you're handling things this could lead to all the data being wiped away. This should never be allowed to happen. Imagine your editor is set up to automatically save content over the network, then your code might just have deleted a user's 10,000-word _magnum opus_.
+Perhaps you've removed a `NodeExtension` or `MarkExtension` from the manager since the content was created. If the content includes these invalid types ProseMirror throws `RangeError: There is no mark type italic in this schema`. Depending on how you're handling things this could lead to all the data being wiped away. This should never be allowed to happen. Imagine your editor is set up to automatically save content over the network, then your code might just have deleted a user's 10,000-word _magnum opus_.
 
-**`remirror`** attemptes to give you full control on how to respond when invalid content is encountered.
+**`remirror`** attempts to give you full control on how to respond when invalid content is encountered.
 
-#### What is invalid?
+#### What is invalid
 
-- A node type that is unsupported by the editor (ProseMirror will throw an error)
-- A mark type that is unsupported by the editor (ProseMirror will throw an error)
+- A node type that is unsupported by the editor (ProseMirror will throw an error).
+- A mark type that is unsupported by the editor (ProseMirror will throw an error).
 - Attributes that aren't supported (these are automatically discarded or added by ProseMirror) but can change the expected behaviour of the editor. This is the case if `schema.nodeFromJSON(json)` has attrs that don't exist on the `json.attrs`.
 
 ### Handling errors

--- a/docs/concepts/extra-attributes.md
+++ b/docs/concepts/extra-attributes.md
@@ -1,0 +1,96 @@
+---
+title: Extra Attributes
+---
+
+In ProseMirror each node and mark can have certain attributes. These attribute are stored on the dom and can be retrieved from the dom via the created `MarkSpec` or the `NodeSpec`.
+
+Attributes can also set default values.
+
+One constraint that ProseMirror sets is that attributes must be declared ahead of time. There is no runtime ability to add undeclared attributes dynamically. This can be an issue when consuming a library like `Remirror`. Perhaps you want the `paragraph` functionality, but also want to add an extra attribute as well. This is where extra attributes come into play.
+
+:::note
+
+The following is a work in progress. Please edit the page and provide your suggestions if you notice any problems.
+
+:::
+
+## Extension
+
+Every extension can be given extra attributes when created.
+
+```ts
+import { ParagraphExtension } from 'remirror/extension/paragraph';
+import { uniqueId } from 'remirror/core';
+
+const paragraphExtension = new ParagraphExtension({
+  extraAttributes: {
+    id: {
+      default: () => uniqueId(),
+      parseDOM: (dom) => dom.id,
+      toDOM: (attrs) => attrs.id as string,
+    },
+  },
+});
+```
+
+The above has given a dynamic attribute `id`, which assigns a unique `id` to every paragraph node as well as giving instruction on how to retrieve that node from the dom and pass the node back to the DOM.
+
+The above could have also been defined like this.
+
+```ts
+import { ParagraphExtension } from 'remirror/extension/paragraph';
+import { uniqueId } from 'remirror/core';
+
+const paragraphExtension = new ParagraphExtension({
+  extraAttributes: {
+    // Remirror is smart enough to search the dom for the id if no `parseDOM`
+    // method or `toDOM` method provided.
+    id: () => uniqueId(),
+  },
+});
+```
+
+This example accomplishes the same things as the previous example and remirror is smart enough to automatically parse the dom and write to the dom the required values.
+
+## RemirrorManager
+
+Extra attributes can also be added via the `RemirrorManager`. This can set attributes for a collection of nodes, marks and tags. This is very useful when adding attributes to multiple places in one sweep.
+
+```ts
+import { CorePreset } from 'remirror/preset/core';
+import { WysiwygPreset } from 'remirror/preset/wysiwyg';
+import { RemirrorManager } from 'remirror/core';
+
+const manager = RemirrorManager.create(() => [new WysiwygPreset(), new CorePreset()], {
+  extraAttributes: [
+    // Can match by grouping of `nodes` | `marks` | `all`.
+    { identifiers: 'nodes', attributes: { totallyNodes: 'abc' } },
+    { identifiers: 'marks', attributes: { totallyMarks: 'abc' } },
+    { identifiers: 'all', attributes: { totallyAll: 'abc' } },
+
+    // Can match by node or mark name when `identifiers` is set to an array.
+    { identifiers: ['paragraph', 'italic'], attributes: { fun: 'abc' } },
+
+    // Can match by `tags`.
+    {
+      identifiers: { tags: [ExtensionTag.Alignment] },
+      attributes: { matchesEverything: 'abc' },
+    },
+
+    // Can match by `tags` and type of `node` | `mark`.
+    {
+      identifiers: { tags: [ExtensionTag.Alignment], type: 'node' },
+      attributes: { matchesEverything: 'abc' },
+    },
+
+    // This would never match as block node tags aren't marks.
+    {
+      identifiers: { tags: [ExtensionTag.BlockNode], type: 'mark' },
+      attributes: { onlyMarks: 'abc' },
+    },
+
+    // This would also never match since there are no tags given.
+    { identifiers: { tags: [] }, attributes: { emptyTags: 'abc' } },
+  ],
+});
+```

--- a/packages/@remirror/core/src/manager/remirror-manager-helpers.ts
+++ b/packages/@remirror/core/src/manager/remirror-manager-helpers.ts
@@ -347,12 +347,14 @@ export function extractLifecycleMethods(parameter: SetupExtensionParameter): voi
   // Keep track of the names of the different types of extension held by this
   // manager. This is already in use by the [[`TagsExtension`]].
 
-  if (isNodeExtension(extension)) {
-    nodeNames.push(extension.name);
-  }
-
   if (isMarkExtension(extension)) {
     markNames.push(extension.name);
+  }
+
+  // Don't include the `doc` as a node since it is a requirement for all editors
+  // and doesn't behave in the same way as other nodes.
+  if (isNodeExtension(extension) && extension.name !== 'doc') {
+    nodeNames.push(extension.name);
   }
 
   if (isPlainExtension(extension)) {

--- a/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
+++ b/packages/@remirror/extension-paragraph/src/paragraph-extension.ts
@@ -1,5 +1,6 @@
 import {
   ApplySchemaAttributes,
+  CommandFunction,
   extensionDecorator,
   ExtensionPriority,
   ExtensionTag,
@@ -52,7 +53,7 @@ export class ParagraphExtension extends NodeExtension {
    */
   createCommands() {
     return {
-      createParagraph: (attributes: ProsemirrorAttributes) => {
+      createParagraph: (attributes: ProsemirrorAttributes): CommandFunction => {
         return setBlockType(this.type, attributes);
       },
     };

--- a/packages/@remirror/i18n/src/__tests__/plurals.spec.ts
+++ b/packages/@remirror/i18n/src/__tests__/plurals.spec.ts
@@ -1,0 +1,5 @@
+import { en } from '../../plurals';
+
+test('plurals are forwarded correctly', () => {
+  expect(en).toBeFunction();
+});

--- a/support/website/sidebars.js
+++ b/support/website/sidebars.js
@@ -24,6 +24,7 @@ const sidebarConfig = {
         'concepts/priority',
         'concepts/keymap',
         'concepts/error-handling',
+        'concepts/extra-attributes',
       ],
     },
     { type: 'category', label: 'Showcase', items: ['showcase/social'] },


### PR DESCRIPTION
### Description

🎉 Brings support for adding extra attributes to the `RemirrorManager` via extension tags. Attributes can now be added to all nodes and marks with a specific tag like `ExtensionTag.Alignment` or `ExtensionTag.NodeBlock`. Every matching tag in the `Schema` receives the extra attributes defined.

With tags, you can select a specific sub selection of marks and nodes. This will be the basis for adding advanced formatting to remirror.

```ts
import { ExtensionTag } from 'remirror/core';
import { createCoreManager, CorePreset } from 'remirror/preset/core';
import { WysiwygPreset } from 'remirror/preset/wysiwyg';
const manager = createCoreManager(() => [new WysiwygPreset(), new CorePreset()], {
  extraAttributes: [
    {
      identifiers: {
        
        tags: [ExtensionTag.NodeBlock],

        // Can be limited by type to `node | mark`.
        type: 'node',
      },
      attributes: { role: 'presentation' },
    },
  ],
});
```

Each item in the tags array should be read as an `OR` so the following would match `Tag1` OR `Tag2` OR `Tag3`.

```json
{ "tags": ["Tag1", "Tag2", "Tag3"] }
```

The `type` property (`mark | node`) is exclusive and limits the type of matches that will be matched.

Fixes #463


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
