### PR TITLE
Support exiting mentions with text selected

### DIFF
--- a/.changeset/early-points-grab.md
+++ b/.changeset/early-points-grab.md
@@ -1,0 +1,6 @@
+---
+'jest-prosemirror': minor
+'jest-remirror': minor
+---
+
+Add support for `anchor` and `head` cursors when writing tests. Also fix `selectText` when position is `0`.

--- a/.changeset/fresh-singers-march.md
+++ b/.changeset/fresh-singers-march.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Fix editable mentions support for exiting when text is selected. Also update `getSelection` to support `anchor` and `head` selections.

--- a/.changeset/smooth-readers-collect.md
+++ b/.changeset/smooth-readers-collect.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-types': minor
+---
+
+Add new `AnchorHeadParameter` export and make it a part of `PrimitiveSelection` type.

--- a/.changeset/weak-dodos-fry.md
+++ b/.changeset/weak-dodos-fry.md
@@ -1,0 +1,6 @@
+---
+'@remirror/react': major
+'@remirror/react-hooks': patch
+---
+
+**BREAKING**: 💥 Remove export of `useSetState` and use default `useState` instead.

--- a/packages/@remirror/core-types/src/core-types.ts
+++ b/packages/@remirror/core-types/src/core-types.ts
@@ -336,6 +336,23 @@ export interface RemirrorIdentifierShape {
 }
 
 /**
+ * A parameter for a non empty selection which defines the anchor (the non
+ * movable part of the selection) and the head (the movable part of the
+ * selection).
+ */
+export interface AnchorHeadParameter {
+  /**
+   * The non-movable part of the selection.
+   */
+  anchor: number;
+
+  /**
+   * The movable part of the selection.
+   */
+  head: number;
+}
+
+/**
  * The type of arguments acceptable for a selection.
  *
  * - Can be a selection
@@ -343,4 +360,11 @@ export interface RemirrorIdentifierShape {
  * - A single position with a `number`
  * - `'start' | 'end'`
  */
-export type PrimitiveSelection = Selection | FromToParameter | number | 'start' | 'end' | 'all';
+export type PrimitiveSelection =
+  | Selection
+  | FromToParameter
+  | AnchorHeadParameter
+  | number
+  | 'start'
+  | 'end'
+  | 'all';

--- a/packages/@remirror/core-types/src/index.ts
+++ b/packages/@remirror/core-types/src/index.ts
@@ -111,6 +111,7 @@ export type {
   Writeable,
 } from './base-types';
 export type {
+  AnchorHeadParameter,
   ChainedCommandFunction,
   CommandFunction,
   CommandFunctionParameter,

--- a/packages/@remirror/core-utils/src/__tests__/command-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/command-utils.spec.ts
@@ -1,4 +1,16 @@
-import { atomInline, blockquote, doc, h1, li, ol, p, schema, strong, ul } from 'jest-prosemirror';
+import {
+  atomInline,
+  blockquote,
+  createEditor,
+  doc,
+  h1,
+  li,
+  ol,
+  p,
+  schema,
+  strong,
+  ul,
+} from 'jest-prosemirror';
 
 import {
   removeMark,
@@ -89,6 +101,18 @@ describe('replaceText', () => {
       from,
       to,
     });
+  });
+
+  it('can preserve the non-empty selection', () => {
+    const editor = createEditor(doc(p('<head>Hell<anchor>o')));
+
+    editor.remirrorCommand((parameter) =>
+      replaceText({ content: 'Content', keepSelection: true })(parameter),
+    );
+
+    const { head, anchor } = editor.view.state.selection;
+    expect(head).toBe(1);
+    expect(anchor).toBe(5);
   });
 });
 

--- a/packages/@remirror/core-utils/src/command-utils.ts
+++ b/packages/@remirror/core-utils/src/command-utils.ts
@@ -282,23 +282,27 @@ export function isChrome(minVersion = 0): boolean {
  * @param tr - the transaction which has been updated and may have impacted the
  * selection.
  */
-function preserveSelection(state: EditorState, tr: Transaction) {
-  // Get the previous cursor selection.
-  let { anchor } = state.selection;
+function preserveSelection(state: EditorState, tr: Transaction): void {
+  // Get the previous movable part of the cursor selection.
+  let { head } = state.selection;
 
-  // Map this cursor selection through each of the steps that have happened in
+  // Map this movable cursor selection through each of the steps that have happened in
   // the transaction.
   for (const step of tr.steps) {
     const map = step.getMap();
-    anchor = map.map(anchor);
+    head = map.map(head);
   }
 
-  // Update the transaction with the new text selection.
-  tr.setSelection(new TextSelection(tr.doc.resolve(anchor)));
+  if (state.selection.empty) {
+    // Update the transaction with the new text selection.
+    tr.setSelection(TextSelection.create(tr.doc, head));
+  } else {
+    tr.setSelection(TextSelection.create(tr.doc, state.selection.anchor, head));
+  }
 }
 
 /**
- * Replaces text with an optional appended string at the end
+ * Replaces text with an optional appended string at the end.
  *
  * @param params - the destructured params
  *

--- a/packages/@remirror/react-hooks/src/use-suggest.ts
+++ b/packages/@remirror/react-hooks/src/use-suggest.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import type { Except } from 'type-fest';
 
 import {
@@ -17,7 +17,7 @@ import type {
   Suggester,
   SuggestState,
 } from '@remirror/pm/suggest';
-import { usePreset, useRemirror, useSetState } from '@remirror/react';
+import { usePreset, useRemirror } from '@remirror/react';
 
 /**
  * This hook allows you to dynamically create a suggester which can respond to
@@ -43,13 +43,13 @@ import { usePreset, useRemirror, useSetState } from '@remirror/react';
 export function useSuggester(props: UseSuggesterProps): UseSuggesterReturn {
   const { helpers } = useRemirror<BuiltinPreset>();
 
-  const [hookState, setHookState] = useSetState<UseSuggesterState>({
+  const [hookState, setHookState] = useState<UseSuggesterState>(() => ({
     change: undefined,
     exit: undefined,
     updatesSinceLastChange: 0,
     updatesSinceLastExit: 0,
     ...helpers.getSuggestMethods(),
-  });
+  }));
 
   // Track changes in the suggester
   const onChange: SuggestChangeHandler = useCallback(
@@ -59,12 +59,12 @@ export function useSuggester(props: UseSuggesterProps): UseSuggesterReturn {
       // Keep track of changes
       if (changeReason) {
         const change = { match, query, text, range, reason: changeReason };
-        setHookState({ change, updatesSinceLastChange: 0 });
+        setHookState((prevState) => ({ ...prevState, change, updatesSinceLastChange: 0 }));
       }
 
       if (exitReason) {
         const exit = { match, query, text, range, reason: exitReason };
-        setHookState({ exit, updatesSinceLastExit: 0 });
+        setHookState((prevState) => ({ ...prevState, exit, updatesSinceLastExit: 0 }));
       }
     },
     [setHookState],
@@ -100,7 +100,7 @@ export function useSuggester(props: UseSuggesterProps): UseSuggesterReturn {
       }
 
       // Call the state function to update the state.
-      setHookState(stateUpdate);
+      setHookState((prevState) => ({ ...prevState, ...stateUpdate }));
     },
     [
       helpers,

--- a/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
+++ b/packages/@remirror/react/src/components/__tests__/react-editor.spec.tsx
@@ -294,6 +294,22 @@ describe('focus', () => {
     }
   });
 
+  it('can specify expected anchor and head for the editor editor', () => {
+    const anchorHead = { anchor: 5, head: 2 };
+    editorNode.blur();
+
+    act(() => {
+      context.focus(anchorHead);
+      mock.flush();
+    });
+
+    {
+      const { from, to, head, anchor } = context.getState().selection;
+
+      expect({ from, to, anchor, head }).toEqual({ ...anchorHead, ...expected });
+    }
+  });
+
   it('restores the previous selection when focused without a parameter', () => {
     editorNode.blur();
 

--- a/packages/@remirror/react/src/hooks/core-hooks.ts
+++ b/packages/@remirror/react/src/hooks/core-hooks.ts
@@ -9,7 +9,6 @@ import {
   useState,
 } from 'react';
 import useEffectOnce from 'react-use/lib/useEffectOnce';
-import useSetState from 'react-use/lib/useSetState';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
 import ResizeObserver from 'resize-observer-polyfill';
 
@@ -95,20 +94,13 @@ export function useMeasure<Ref extends HTMLElement = HTMLElement>(): UseMeasureR
 }
 
 /**
- * The `setState` type for the `useSetState` hook.
- */
-export type PartialDispatch<Type extends object> = (
-  patch: Partial<Type> | ((prevState: Type) => Partial<Type>),
-) => void;
-
-/**
  * A `useEffect` function which issues a warning when the dependencies provided
  * are deeply equal, but only in development.
  *
  * This is used in places where it's important for developers to memoize and
  * wrap methods with `useCallback`.
  */
-const useEffectWithWarning: typeof useEffect =
+export const useEffectWithWarning: typeof useEffect =
   process.env.NODE_ENV === 'production'
     ? useEffect
     : (effect, deps) => {
@@ -143,5 +135,3 @@ const useEffectWithWarning: typeof useEffect =
         // eslint-disable-next-line react-hooks/exhaustive-deps
         useEffect(wrappedEffect, deps);
       };
-
-export { useEffectWithWarning, useSetState };

--- a/packages/@remirror/react/src/index.ts
+++ b/packages/@remirror/react/src/index.ts
@@ -4,7 +4,6 @@ export { I18nProvider, RemirrorProvider, ThemeProvider } from './components';
 export type {
   BaseReactCombinedUnion,
   DOMRectReadOnlyLike,
-  PartialDispatch,
   UseExtensionCallback,
   UsePositionerReturn,
   UseMultiPositionerReturn,
@@ -22,7 +21,6 @@ export {
   usePreset,
   usePrevious,
   useRemirror,
-  useSetState,
 } from './hooks';
 
 export { createReactManager } from './react-helpers';

--- a/support/e2e/src/social.e2e.test.ts
+++ b/support/e2e/src/social.e2e.test.ts
@@ -191,7 +191,8 @@ describe('Social Showcase', () => {
         );
       });
 
-      // TODO create a new issue to add forward deletion support to the `prosemirror-suggest`.
+      // TODO create a new issue to add forward deletion support to the
+      // `@remirror/extension-mention`.
       it.skip('removes mentions for forward deletes', async () => {
         await $editor.type('@abc ');
         await press({ key: 'ArrowLeft', count: 5 });
@@ -201,6 +202,30 @@ describe('Social Showcase', () => {
         ).rejects.toThrowErrorMatchingInlineSnapshot(
           `"Error: failed to find element matching selector \\".remirror-editor .mention-at\\""`,
         );
+      });
+
+      it('can exit when selecting text', async () => {
+        await $editor.type('@abc ');
+        await press({ key: 'ArrowLeft', count: 1 });
+        await page.keyboard.down('Shift');
+        await press({ key: 'ArrowLeft', count: 4 });
+        await page.keyboard.up('Shift');
+        await press({ key: 'ArrowLeft', count: 1 });
+        await $editor.type('Awesome ');
+
+        await expect(textContent(sel(EDITOR_CLASS_SELECTOR, '.mention-at'))).resolves.toBe('@abc');
+        await expect(textContent(sel(EDITOR_CLASS_SELECTOR))).resolves.toBe('Awesome @abc ');
+      });
+
+      it('only replaces the selected text in a mention', async () => {
+        await $editor.type('@abc ');
+        await press({ key: 'ArrowLeft', count: 2 });
+        await page.keyboard.down('Shift');
+        await press({ key: 'ArrowLeft', count: 3 });
+        await page.keyboard.up('Shift');
+        await $editor.type('d');
+
+        await expect(textContent(sel(EDITOR_CLASS_SELECTOR))).resolves.toBe('dc ');
       });
     });
 


### PR DESCRIPTION
### Description

- **BREAKING**: 💥 Remove export of `useSetState` and use default `useState` instead.
- Fix editable mentions support for exiting when text is selected. Also update `getSelection` to support `anchor` and `head` selections.
- Add new `AnchorHeadParameter` export and make it a part of `PrimitiveSelection` type.
- Add support for `anchor` and `head` cursors when writing tests. Also fix `selectText` when position is `0`.

Fixes #640

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-09-06 11 08 31](https://user-images.githubusercontent.com/1160934/92323519-66623f80-f031-11ea-855f-a29698bf52bd.gif)
