### PR TITLE
Fix `RangeError` when `TablePreset` added

### DIFF
--- a/.changeset/eight-pumpkins-matter.md
+++ b/.changeset/eight-pumpkins-matter.md
@@ -1,0 +1,5 @@
+---
+'@remirror/preset-table': patch
+---
+
+Fix text selection causing range error when creating table.

--- a/packages/@remirror/preset-table/src/table-extensions.ts
+++ b/packages/@remirror/preset-table/src/table-extensions.ts
@@ -79,15 +79,19 @@ export class TableExtension extends NodeExtension<TableOptions> {
        */
       createTable: (
         parameter: Pick<CreateTableParameter, 'rowsCount' | 'columnsCount' | 'withHeaderRow'>,
-      ): CommandFunction => ({ state, dispatch }) => {
-        const offset = state.tr.selection.anchor + 1;
-        const nodes = createTable({ schema: state.schema, ...parameter });
-        const tr = state.tr.replaceSelectionWith(nodes).scrollIntoView();
-        const resolvedPos = tr.doc.resolve(offset);
+      ): CommandFunction => ({ tr, dispatch, state }) => {
+        if (!tr.selection.empty) {
+          return false;
+        }
 
-        tr.setSelection(TextSelection.near(resolvedPos));
+        const offset = tr.selection.anchor + 1;
+        const nodes = createTable({ schema: state.schema, ...parameter });
 
         if (dispatch) {
+          tr.replaceSelectionWith(nodes).scrollIntoView();
+          const resolvedPos = tr.doc.resolve(offset);
+
+          tr.setSelection(TextSelection.near(resolvedPos));
           dispatch(tr);
         }
 


### PR DESCRIPTION
### Description

- Fix text selection causing range error when creating table.

No tests added since I wanted to get this into the next release quickly.

Fixes #661

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.


### Screenshot

#### Previous crash no longer happening

![2020-09-07 15 26 14](https://user-images.githubusercontent.com/1160934/92397378-a3583000-f11e-11ea-986c-29dfd8c8d7e7.gif)
