### PR TITLE
Refactor `RemirrorManager` and rename `EditorWrapper`

### DIFF
--- a/.changeset/honest-yaks-impress.md
+++ b/.changeset/honest-yaks-impress.md
@@ -1,0 +1,18 @@
+---
+'@remirror/core': major
+'@remirror/dom': major
+'@remirror/react-social': major
+'@remirror/extension-react-component': patch
+'@remirror/preset-core': patch
+'@remirror/react': patch
+'@remirror/react-wysiwyg': patch
+'@remirror/styles': patch
+'jest-remirror': patch
+---
+
+Refactor `RemirrorManager` and rename `EditorWrapper` to `Framework`.
+
+- New `BaseFramework` interface which is implemented by the abstract `Framework` class and used by the `RemirrorManager` to keep hold of an instance of the `Framework`.
+- New `attachFramework` method on the manager.
+- Update `doc` property to `document` throughout the codebase. `doc` could be confused with the `doc` node or the actual document. Now it's clearer. Any time `doc` is mentioned in the code base it refers to the `ProseMirror` node. Any time `document` is mentioned it is referring to the DOM.
+- Remove `SocialEditorWrapperComponent` export from `@remirror/react-social`.

--- a/docs/guide/hello-remirror.md
+++ b/docs/guide/hello-remirror.md
@@ -1,9 +1,9 @@
 ---
 title: Hello Remirror
+hide_title: Hello Remirror
 ---
 
-import * as Remirror from 'remirror/react/social';
-import { useState, useCallback } from 'react';
+# Hello Remirror
 
 The most straightforward way of using `remirror` is to get start with a prebuilt editor. In a later section of this quide I'll walk you through creating your own editor but for now there's enought to learn in consuming the readily available components.
 
@@ -70,39 +70,41 @@ Now that the data is available let's use it.
 
 ```tsx live
 function MyEditor() {
-  const [users, setUsers] = useState([]);
-  const [tags, setTags] = useState([]);
+  const [mention, setMention] = useState(null);
 
-  const onMentionChange = (parameter) => {
-    if (!parameter) {
-      setUsers([]);
-      setTags([]);
+  const onChange = useCallback((parameter) => {
+    setMention(parameter);
+  }, []);
 
-      return;
-    }
+  console.log(mention);
 
-    if (parameter.name === 'tag') {
-      const tags = exampleTags.filter((tag) =>
-        tag.tag.toLowerCase().includes(parameter.query.toLowerCase()),
+  const onExit = useCallback(({ query }, command) => {
+    command({ href: `/${query.full}` });
+  }, []);
+
+  const items = useMemo(() => {
+    if (mention && mention.name === 'at' && mention.query) {
+      return exampleUsers.filter((user) =>
+        user.username.toLowerCase().includes(mention.query.toLowerCase()),
       );
-      setTags(tags);
     }
 
-    if (parameter.name === 'at') {
-      const users = exampleUsers.filter((user) =>
-        user.username.toLowerCase().includes(parameter.query.toLowerCase()),
+    if (mention && mention.name === 'tag' && mention.query) {
+      return exampleTags.filter((tag) =>
+        tag.tag.toLowerCase().includes(mention.query.toLowerCase()),
       );
-      setUsers(users);
     }
-  };
+
+    return [];
+  }, [mention]);
 
   return (
     <SocialEditor
-      placeholder='Start typing...'
+      placeholder='Start typing here'
       autoFocus={false}
-      users={users}
-      tags={tags}
-      onMentionChange={onMentionChange}
+      items={items}
+      onMentionChange={onChange}
+      onExit={onExit}
     />
   );
 }

--- a/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
@@ -433,7 +433,7 @@ describe('toHTML', () => {
   });
 
   it('allows for custom document to be passed in', () => {
-    expect(toHtml({ node, schema: testSchema, doc: document })).toBe('<p>hello</p>');
+    expect(toHtml({ node, schema: testSchema, document })).toBe('<p>hello</p>');
   });
 });
 
@@ -445,7 +445,7 @@ describe('toDOM', () => {
   });
 
   it('allows for custom document to be passed in', () => {
-    expect(toDom({ node, schema: testSchema, doc: domino.createDocument() })).toBeTruthy();
+    expect(toDom({ node, schema: testSchema, document: domino.createDocument() })).toBeTruthy();
   });
 });
 
@@ -458,7 +458,7 @@ describe('fromHTML', () => {
 
   it('allows for custom document to be passed in', () => {
     expect(
-      fromHtml({ content, schema: testSchema, doc: domino.createDocument() }),
+      fromHtml({ content, schema: testSchema, document: domino.createDocument() }),
     ).toEqualProsemirrorNode(doc(p('Hello')));
   });
 });

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -705,7 +705,7 @@ const MAX_ATTEMPTS = 3;
  * @param parameter - the destructured create document node params
  */
 export function createDocumentNode(parameter: CreateDocumentNodeParameter): ProsemirrorNode {
-  const { content, schema, doc, stringHandler, onError, attempts = 0 } = parameter;
+  const { content, schema, document, stringHandler, onError, attempts = 0 } = parameter;
 
   // If there is an `onError` handler then check the attempts does not exceed
   // the maximum, otherwise only allow one attempt.
@@ -725,7 +725,7 @@ export function createDocumentNode(parameter: CreateDocumentNodeParameter): Pros
 
     // With string content it is up to you the developer to ensure there are no
     // errors in the produced content.
-    return stringHandler({ doc, content, schema });
+    return stringHandler({ document, content, schema });
   }
 
   // If passing in an editor state, it is left to the developer to make sure the
@@ -792,8 +792,8 @@ export function getDocument(forceEnvironment?: RenderEnvironment): Document {
 }
 
 interface CustomDocParameter {
-  /** The custom document to use (allows for ssr rendering) */
-  doc: Document;
+  /** The root or custom document to use (allows for ssr rendering) */
+  document: Document;
 }
 
 /**
@@ -801,9 +801,9 @@ interface CustomDocParameter {
  *
  * @param params - the from node params
  */
-export function toDom({ node, schema, doc }: FromNodeParameter): DocumentFragment {
+export function toDom({ node, schema, document }: FromNodeParameter): DocumentFragment {
   const fragment = isDocNode(node, schema) ? node.content : Fragment.from(node);
-  return DOMSerializer.fromSchema(schema).serializeFragment(fragment, { document: doc });
+  return DOMSerializer.fromSchema(schema).serializeFragment(fragment, { document });
 }
 
 interface FromNodeParameter
@@ -824,9 +824,9 @@ interface FromNodeParameter
  * }
  * ```
  */
-export function toHtml({ node, schema, doc = getDocument() }: FromNodeParameter): string {
-  const element = doc.createElement('div');
-  element.append(toDom({ node, schema, doc }));
+export function toHtml({ node, schema, document = getDocument() }: FromNodeParameter): string {
+  const element = document.createElement('div');
+  element.append(toDom({ node, schema, document }));
 
   return element.innerHTML;
 }
@@ -859,8 +859,8 @@ interface FromStringParameter extends Partial<CustomDocParameter>, SchemaParamet
  * ```
  */
 export function fromHtml(parameter: FromStringParameter): ProsemirrorNode {
-  const { content, schema, doc = getDocument() } = parameter;
-  const element = doc.createElement('div');
+  const { content, schema, document = getDocument() } = parameter;
+  const element = document.createElement('div');
   element.innerHTML = content.trim();
 
   return DOMParser.fromSchema(schema).parse(element);

--- a/packages/@remirror/core/src/framework/base-framework.ts
+++ b/packages/@remirror/core/src/framework/base-framework.ts
@@ -1,0 +1,11 @@
+export interface BaseFramework {
+  /**
+   * The name of the framework being used.
+   */
+  readonly name: string;
+
+  /**
+   * Destroy the framework and cleanup all created listeners.
+   */
+  destroy(): void;
+}

--- a/packages/@remirror/core/src/framework/index.ts
+++ b/packages/@remirror/core/src/framework/index.ts
@@ -1,0 +1,2 @@
+export * from './framework';
+export * from './base-framework';

--- a/packages/@remirror/core/src/index.ts
+++ b/packages/@remirror/core/src/index.ts
@@ -33,11 +33,12 @@ export { extensionDecorator, presetDecorator } from './decorators';
 
 export type {
   AttributePropFunction,
+  BaseFramework,
   BaseListenerParameter,
   CreateStateFromContent,
-  EditorWrapperOutput,
-  EditorWrapperParameter,
-  EditorWrapperProps,
+  FrameworkOutput,
+  FrameworkParameter,
+  FrameworkProps,
   FocusType,
   ListenerParameter,
   PlaceholderConfig,
@@ -46,8 +47,8 @@ export type {
   RemirrorGetterParameter,
   TriggerChangeParameter,
   UpdateStateParameter,
-} from './editor-wrapper';
-export { EditorWrapper } from './editor-wrapper';
+} from './framework';
+export { Framework } from './framework/framework';
 
 export type {
   AnyExtension,

--- a/packages/@remirror/dom/src/dom-framework.ts
+++ b/packages/@remirror/dom/src/dom-framework.ts
@@ -1,0 +1,93 @@
+import {
+  AnyCombinedUnion,
+  EditorState,
+  Framework,
+  FrameworkOutput,
+  FrameworkProps,
+  SchemaFromCombined,
+  UpdateStateParameter,
+} from '@remirror/core';
+import { EditorView } from '@remirror/pm/view';
+
+export interface DomFrameworkOutput<Combined extends AnyCombinedUnion>
+  extends FrameworkOutput<Combined> {
+  /**
+   * Call this method when cleaning up the DOM. It is called for you if you call
+   * `manager.destroy()`.
+   */
+  destroy: () => void;
+}
+
+export interface DomFrameworkProps<Combined extends AnyCombinedUnion>
+  extends FrameworkProps<Combined> {
+  /**
+   * Provide a container element. Which the editor will be appended to.
+   */
+  element: Element;
+}
+
+/**
+ * The helper class which makes integrating with the DOM easier.
+ */
+export class DomFramework<Combined extends AnyCombinedUnion> extends Framework<
+  Combined,
+  DomFrameworkProps<Combined>
+> {
+  get name() {
+    return 'dom' as const;
+  }
+
+  /**
+   * Create the prosemirror `[[EditorView`]].
+   */
+  protected createView(
+    state: EditorState<SchemaFromCombined<Combined>>,
+    element?: Element,
+  ): EditorView<SchemaFromCombined<Combined>> {
+    return new EditorView(element, {
+      state,
+      nodeViews: this.manager.store.nodeViews,
+      dispatchTransaction: this.dispatchTransaction,
+      attributes: () => this.getAttributes(),
+      editable: () => {
+        return this.props.editable ?? true;
+      },
+    });
+  }
+
+  /**
+   * This method should be called when the framework is first created.
+   */
+  onFirstRender(): void {
+    if (!this.firstRender) {
+      return;
+    }
+
+    this.onChange();
+    this.addFocusListeners();
+  }
+
+  /**
+   * Responsible for managing state updates.
+   */
+  protected updateState(parameter: UpdateStateParameter<SchemaFromCombined<Combined>>): void {
+    const { state, tr, triggerChange = true } = parameter;
+
+    // Update the internal prosemirror state. This happens before we update
+    // the component's copy of the state.
+    this.view.updateState(state);
+
+    if (triggerChange) {
+      this.onChange({ state, tr });
+    }
+
+    this.manager.onStateUpdate({ previousState: this.previousState, state });
+  }
+
+  get domOutput(): DomFrameworkOutput<Combined> {
+    return {
+      ...this.frameworkHelpers,
+      destroy: () => this.destroy(),
+    };
+  }
+}

--- a/packages/@remirror/dom/src/dom.ts
+++ b/packages/@remirror/dom/src/dom.ts
@@ -2,16 +2,14 @@ import type {
   AnyCombinedUnion,
   BuiltinPreset,
   EditorState,
-  EditorWrapperOutput,
-  EditorWrapperProps,
   PrimitiveSelection,
   RemirrorContentType,
   SchemaFromCombined,
-  UpdateStateParameter,
 } from '@remirror/core';
-import { EditorWrapper, getDocument, isArray, RemirrorManager } from '@remirror/core';
-import { EditorView } from '@remirror/pm/view';
+import { getDocument, isArray, RemirrorManager } from '@remirror/core';
 import { CorePreset, createCoreManager, CreateCoreManagerOptions } from '@remirror/preset-core';
+
+import { DomFramework, DomFrameworkOutput, DomFrameworkProps } from './dom-framework';
 
 /**
  * Create an editor manager. It comes with the `CorePreset` already available.
@@ -23,20 +21,29 @@ export function createDomManager<Combined extends AnyCombinedUnion>(
   return createCoreManager([...combined], options);
 }
 
-export interface DomEditorWrapperProps<Combined extends AnyCombinedUnion>
-  extends EditorWrapperProps<Combined> {
-  /**
-   * Provide a container element. Which the editor will be appended to.
-   */
-  element: Element;
-}
-
 /**
- * Create the prosemirror editor for the dom environment.
+ * Create the `remirror` editor for the DOM environment.
+ *
+ * ```ts
+ * // Get the element to append the editor to.
+ * const element = document.querySelector('#editor');
+ *
+ * // Create the manager.
+ * const manager = createDomManager([], {});
+ *
+ * // Create the dom editor.
+ * const editor = createDomEditor({ element, manager });
+ *
+ * // Focus at the end of the editor.
+ * editor.focus('end');
+ *
+ * // Insert some text.
+ * editor.commands.insertText('Hello Friend!');
+ * ```
  */
 export function createDomEditor<Combined extends AnyCombinedUnion>(
-  props: DomEditorWrapperProps<Combined>,
-): DomEditorWrapperOutput<Combined> {
+  props: DomFrameworkProps<Combined>,
+): DomFrameworkOutput<Combined> {
   const { stringHandler, onError, manager, forceEnvironment, element } = props;
 
   function createStateFromContent(
@@ -45,7 +52,7 @@ export function createDomEditor<Combined extends AnyCombinedUnion>(
   ): EditorState<SchemaFromCombined<Combined>> {
     return manager.createState({
       content,
-      doc: getDocument(forceEnvironment),
+      document: getDocument(forceEnvironment),
       stringHandler,
       selection,
       onError,
@@ -60,70 +67,14 @@ export function createDomEditor<Combined extends AnyCombinedUnion>(
     : ([props.initialContent ?? fallback] as const);
   const initialEditorState = createStateFromContent(initialContent, initialSelection);
 
-  const wrapper = new DomEditorWrapper<Combined>({
+  const framework = new DomFramework<Combined>({
     createStateFromContent,
     getProps: () => props,
     initialEditorState,
     element,
   });
 
-  return wrapper.output;
-}
+  framework.onFirstRender();
 
-interface DomEditorWrapperOutput<Combined extends AnyCombinedUnion>
-  extends EditorWrapperOutput<Combined> {
-  /**
-   * Call this to cleanup the view.
-   */
-  destroy: () => void;
-}
-
-/**
- * The helper class which makes integrating with the DOM easier.
- */
-class DomEditorWrapper<Combined extends AnyCombinedUnion> extends EditorWrapper<
-  Combined,
-  DomEditorWrapperProps<Combined>
-> {
-  /**
-   * Create the prosemirror EditorView.
-   */
-  protected createView(state: EditorState<SchemaFromCombined<Combined>>, element?: Element) {
-    return new EditorView(element, {
-      state,
-      nodeViews: this.manager.store.nodeViews,
-      dispatchTransaction: this.dispatchTransaction,
-      attributes: () => this.getAttributes(),
-      editable: () => {
-        return this.props.editable ?? true;
-      },
-    });
-
-    this.onChange();
-    this.addFocusListeners();
-  }
-
-  /**
-   * Responsible for managing state updates.
-   */
-  protected updateState(parameter: UpdateStateParameter<SchemaFromCombined<Combined>>): void {
-    const { state, tr, triggerChange = true } = parameter;
-
-    // Update the internal prosemirror state. This happens before we update
-    // the component's copy of the state.
-    this.view.updateState(state);
-
-    if (triggerChange) {
-      this.onChange({ state, tr });
-    }
-
-    this.manager.onStateUpdate({ previousState: this.previousState, state });
-  }
-
-  get output() {
-    return {
-      ...this.editorWrapperOutput,
-      destroy: () => this.onDestroy(),
-    };
-  }
+  return framework.domOutput;
 }

--- a/packages/@remirror/dom/src/index.ts
+++ b/packages/@remirror/dom/src/index.ts
@@ -1,2 +1,2 @@
-export type { DomEditorWrapperProps } from './dom';
+export type { DomFrameworkProps } from './dom-framework';
 export { createDomEditor, createDomManager } from './dom';

--- a/packages/@remirror/extension-react-component/src/portals/react-portals.tsx
+++ b/packages/@remirror/extension-react-component/src/portals/react-portals.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import type { AnyCombinedUnion, EditorWrapperOutput } from 'remirror/core';
+import type { AnyCombinedUnion, FrameworkOutput } from 'remirror/core';
 
 import type { MountedPortal, PortalContainer, PortalMap } from './portal-container';
 
@@ -12,7 +12,7 @@ export interface RemirrorPortalsProps<Combined extends AnyCombinedUnion> {
    */
   portals: Array<[HTMLElement, MountedPortal]>;
 
-  context: EditorWrapperOutput<Combined>;
+  context: FrameworkOutput<Combined>;
 }
 
 /**
@@ -57,13 +57,11 @@ export function usePortals(portalContainer: PortalContainer): Array<[HTMLElement
 /**
  * Get the current remirror context when using a portal.
  */
-export function usePortalContext<Combined extends AnyCombinedUnion>(): EditorWrapperOutput<
-  Combined
-> {
-  return useContext(EditorContext) as EditorWrapperOutput<Combined>;
+export function usePortalContext<Combined extends AnyCombinedUnion>(): FrameworkOutput<Combined> {
+  return useContext(EditorContext) as FrameworkOutput<Combined>;
 }
 
 /**
  * Allows elemenent inside the portals to consume the provided contenxt
  */
-const EditorContext = createContext<EditorWrapperOutput<any> | null>(null);
+const EditorContext = createContext<FrameworkOutput<any> | null>(null);

--- a/packages/@remirror/playground/src/make-code.tsx
+++ b/packages/@remirror/playground/src/make-code.tsx
@@ -131,7 +131,7 @@ const SmallEditor: FC = () => {
   );
 };
 
-const SmallEditorWrapper = () => {
+const SmallEditorContainer = () => {
   const extensionManager = useManager(EXTENSIONS);
 
   const { value, onChange } = useRemirrorPlayground(extensionManager); // Delete this line
@@ -147,7 +147,7 @@ const SmallEditorWrapper = () => {
   );
 };
 
-export default SmallEditorWrapper;
+export default SmallEditorContainer;
 `;
 
   if (window.prettier) {

--- a/packages/@remirror/preset-core/src/core-preset.ts
+++ b/packages/@remirror/preset-core/src/core-preset.ts
@@ -1,6 +1,7 @@
 import {
   AddCustomHandler,
   AnyCombinedUnion,
+  BuiltinPreset,
   getLazyArray,
   GetStaticAndDynamic,
   OnSetOptionsParameter,
@@ -159,7 +160,7 @@ export interface CreateCoreManagerOptions extends Remirror.ManagerSettings {
 export function createCoreManager<Combined extends AnyCombinedUnion>(
   combined: Combined[] | (() => Combined[]),
   options: CreateCoreManagerOptions = {},
-) {
+): RemirrorManager<Combined | CorePreset | BuiltinPreset> {
   const { core, ...managerSettings } = options;
 
   return RemirrorManager.create(

--- a/packages/@remirror/react-social/src/components/social-editor.tsx
+++ b/packages/@remirror/react-social/src/components/social-editor.tsx
@@ -31,12 +31,12 @@ export const SocialEditor: FC<SocialEditorProps> = (props: SocialEditorProps) =>
 
   return (
     <SocialProvider {...providerProps}>
-      <SocialEditorWrapperComponent data-testid='remirror-editor'>
+      <SocialEditorContainerComponent data-testid='remirror-editor'>
         <TextEditor />
         <SocialEmojiComponent />
         <Indicator characterLimit={characterLimit} />
         {children}
-      </SocialEditorWrapperComponent>
+      </SocialEditorContainerComponent>
       <SocialMentionComponent
         items={items}
         onExit={onExit}
@@ -123,7 +123,7 @@ export const SocialEditorComponent = styled.div`
   }
 `;
 
-export const SocialEditorWrapperComponent = styled.div`
+const SocialEditorContainerComponent = styled.div`
   position: relative;
   height: 100%;
 `;

--- a/packages/@remirror/react-social/src/index.ts
+++ b/packages/@remirror/react-social/src/index.ts
@@ -4,7 +4,6 @@ export {
   SocialCharacterCountWrapper,
   SocialEditor,
   SocialEditorComponent,
-  SocialEditorWrapperComponent,
   SocialEmojiComponent,
   SocialMentionComponent,
   SocialProvider,

--- a/packages/@remirror/react-wysiwyg/src/components/wysiwyg-editor.tsx
+++ b/packages/@remirror/react-wysiwyg/src/components/wysiwyg-editor.tsx
@@ -16,10 +16,10 @@ export const WysiwygEditor: FC<WysiwygEditorProps> = (props: WysiwygEditorProps)
 
   return (
     <WysiwygProvider {...providerProps}>
-      <WysiwygEditorWrapperComponent data-testid='remirror-editor'>
+      <WysiwygEditorContainerComponent data-testid='remirror-editor'>
         <TextEditor />
         {children}
-      </WysiwygEditorWrapperComponent>
+      </WysiwygEditorContainerComponent>
     </WysiwygProvider>
   );
 };
@@ -85,7 +85,7 @@ export const WysiwygEditorComponent = styled.div`
   }
 `;
 
-export const WysiwygEditorWrapperComponent = styled.div`
+export const WysiwygEditorContainerComponent = styled.div`
   position: relative;
   height: 100%;
 `;

--- a/packages/@remirror/react/src/components/react-editor.tsx
+++ b/packages/@remirror/react/src/components/react-editor.tsx
@@ -1,58 +1,26 @@
-import composeRefs from '@seznam/compose-react-refs';
-import React, {
-  cloneElement,
-  Dispatch,
-  ReactElement,
-  ReactNode,
-  Ref,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useCallback, useEffect, useRef, useState } from 'react';
 import { useFirstMountState } from 'react-use/lib/useFirstMountState';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
 
 import {
   AnyCombinedUnion,
   bool,
-  EditorWrapper,
-  EditorWrapperParameter,
   ErrorConstant,
   getDocument,
   invariant,
   isArray,
   isNullOrUndefined,
-  isPlainObject,
-  object,
   PrimitiveSelection,
   RemirrorContentType,
   SchemaFromCombined,
-  shouldUseDomEnvironment,
-  UpdateStateParameter,
 } from '@remirror/core';
 import { RemirrorPortals, usePortals } from '@remirror/extension-react-component';
 import type { EditorState } from '@remirror/pm/state';
 import { ReactPreset } from '@remirror/preset-react';
-import {
-  addKeyToElement,
-  getElementProps,
-  isReactDOMElement,
-  isRemirrorContextProvider,
-  isRemirrorProvider,
-  propIsFunction,
-  RemirrorType,
-} from '@remirror/react-utils';
+import { RemirrorType } from '@remirror/react-utils';
 
 import { usePrevious } from '../hooks';
-import type {
-  BaseProps,
-  GetRootPropsConfig,
-  RefKeyRootProps,
-  RemirrorContextProps,
-} from '../react-types';
-import { createEditorView, RemirrorSSR } from '../ssr';
+import { ReactEditorProps, ReactFramework, ReactFrameworkParameter } from '../react-framework';
 
 /**
  * The component responsible for rendering your prosemirror editor to the DOM.
@@ -93,7 +61,7 @@ export const ReactEditor = <Combined extends AnyCombinedUnion>(
     ): EditorState<SchemaFromCombined<Combined>> => {
       return manager.createState({
         content,
-        doc: getDocument(forceEnvironment),
+        document: getDocument(forceEnvironment),
         stringHandler,
         selection,
         onError,
@@ -114,7 +82,7 @@ export const ReactEditor = <Combined extends AnyCombinedUnion>(
   );
 
   // Store all the `logic` in a `ref`
-  const methods: ReactEditorWrapper<Combined> = useEditorWrapper<Combined>({
+  const framework: ReactFramework<Combined> = useFramework<Combined>({
     initialEditorState,
     setShouldRenderClient,
     createStateFromContent,
@@ -123,32 +91,32 @@ export const ReactEditor = <Combined extends AnyCombinedUnion>(
   });
 
   useEffect(() => {
-    methods.onMount();
+    framework.onMount();
 
     return () => {
-      methods.onDestroy();
+      framework.destroy();
     };
-  }, [methods]);
+  }, [framework]);
 
   const previousEditable = usePrevious(props.editable);
 
   // Handle editor updates
   useEffect(() => {
-    methods.onUpdate(previousEditable);
-  }, [previousEditable, methods]);
+    framework.onUpdate(previousEditable);
+  }, [previousEditable, framework]);
 
   // Handle the controlled editor usage.
-  useControlledEditor(methods);
+  useControlledEditor(framework);
 
   // Subscribe to updates from the [[`PortalContainer`]]
-  const portals = usePortals(methods.remirrorContext.portalContainer);
+  const portals = usePortals(framework.remirrorContext.portalContainer);
 
   // Return the rendered component and the portals for custom node views and
   // decorations
   return (
     <>
-      {methods.render()}
-      <RemirrorPortals portals={portals} context={methods.remirrorContext} />
+      {framework.generateReactElement()}
+      <RemirrorPortals portals={portals} context={framework.remirrorContext} />
     </>
   );
 };
@@ -159,458 +127,24 @@ export const ReactEditor = <Combined extends AnyCombinedUnion>(
 ReactEditor.remirrorType = RemirrorType.Editor;
 
 /**
- * A function that takes the injected remirror params and returns JSX to render.
- *
- * @param - injected remirror params
- */
-type RenderPropFunction<Combined extends AnyCombinedUnion> = (
-  params: RemirrorContextProps<Combined>,
-) => JSX.Element;
-
-export interface ReactEditorProps<Combined extends AnyCombinedUnion> extends BaseProps<Combined> {
-  /**
-   * The render prop that takes the injected remirror params and returns an
-   * element to render. The editor view is automatically attached to the DOM.
-   */
-  children: RenderPropFunction<Combined>;
-
-  /**
-   * Set to true to ignore the hydration warning for a mismatch between the
-   * rendered server and client content.
-   *
-   * @remarks
-   *
-   * This is a potential solution for those who require server side rendering.
-   *
-   * While on the server the prosemirror document is transformed into a react
-   * component so that it can be rendered. The moment it enters the DOM
-   * environment prosemirror takes over control of the root element. The problem
-   * is that this will always see this hydration warning on the client:
-   *
-   * `Warning: Did not expect server HTML to contain a <div> in <div>.`
-   *
-   * Setting this to true removes the warning at the cost of a slightly slower
-   * start up time. It uses the two pass solution mentioned in the react docs.
-   * See {@link https://reactjs.org/docs/react-dom.html#hydrate}.
-   *
-   * For ease of use this prop copies the name used by react for DOM Elements.
-   * See {@link
-   * https://reactjs.org/docs/dom-elements.html#suppresshydrationwarning}.
-   */
-  suppressHydrationWarning?: boolean;
-}
-
-class ReactEditorWrapper<Combined extends AnyCombinedUnion> extends EditorWrapper<
-  Combined,
-  ReactEditorProps<Combined>
-> {
-  /**
-   * Whether to render the client immediately.
-   */
-  #getShouldRenderClient: () => boolean | undefined;
-
-  /**
-   * Update the should render client state input.
-   */
-  #setShouldRenderClient: SetShouldRenderClient;
-
-  /**
-   * Stores the Prosemirror EditorView dom element.
-   */
-  #editorRef?: HTMLElement;
-
-  /**
-   * Used when suppressHydrationWarning is true to determine when it's okay to
-   * render the client content.
-   */
-  private get shouldRenderClient(): boolean | undefined {
-    return this.#getShouldRenderClient();
-  }
-
-  /**
-   * Keep track of whether the get root props has been called during the most recent render.
-   */
-  private rootPropsConfig = {
-    called: false,
-    count: 0,
-  };
-
-  constructor(parameter: ReactEditorWrapperParameter<Combined>) {
-    super(parameter);
-
-    const { getShouldRenderClient, setShouldRenderClient } = parameter;
-
-    this.#getShouldRenderClient = getShouldRenderClient;
-    this.#setShouldRenderClient = setShouldRenderClient;
-
-    propIsFunction(this.props.children);
-
-    if (this.manager.view) {
-      this.manager.view.setProps({
-        state: this.manager.view.state,
-        dispatchTransaction: this.dispatchTransaction,
-        attributes: () => this.getAttributes(),
-        editable: () => this.props.editable ?? true,
-      });
-
-      return;
-    }
-
-    this.manager.getPreset(ReactPreset).setOptions({ placeholder: this.props.placeholder ?? '' });
-  }
-
-  /**
-   * This is called to update props on every render so that values don't become stale.
-   */
-  update(parameter: ReactEditorWrapperParameter<Combined>) {
-    super.update(parameter);
-
-    const { getShouldRenderClient, setShouldRenderClient } = parameter;
-
-    this.#getShouldRenderClient = getShouldRenderClient;
-    this.#setShouldRenderClient = setShouldRenderClient;
-
-    return this;
-  }
-
-  /**
-   * Create the prosemirror editor view.
-   */
-  protected createView(state: EditorState<SchemaFromCombined<Combined>>) {
-    return createEditorView<SchemaFromCombined<Combined>>(
-      undefined,
-      {
-        state,
-        nodeViews: this.manager.store.nodeViews,
-        dispatchTransaction: this.dispatchTransaction,
-        attributes: () => this.getAttributes(),
-        editable: () => this.props.editable ?? true,
-      },
-      this.props.forceEnvironment,
-    );
-  }
-
-  /**
-   * The external `getRootProps` that is used to spread props onto a desired
-   * holder element for the prosemirror view.
-   */
-  private readonly getRootProps = <RefKey extends string = 'ref'>(
-    options?: GetRootPropsConfig<RefKey>,
-  ) => {
-    return this.internalGetRootProps(options, null);
-  };
-
-  /**
-   * Creates the props that should be spread on the root element inside which
-   * the prosemirror instance will be rendered.
-   */
-  private readonly internalGetRootProps = <RefKey extends string = 'ref'>(
-    options?: GetRootPropsConfig<RefKey>,
-    children?: ReactNode,
-  ): RefKeyRootProps<RefKey> => {
-    // Ensure that this is the first time `getRootProps` is being called during
-    // this commit phase of the .
-    // invariant(!this.rootPropsConfig.called, { code: ErrorConstant.REACT_GET_ROOT_PROPS });
-    this.rootPropsConfig.called = true;
-
-    const { refKey: refKey = 'ref', ref, ...config } =
-      options ?? object<GetRootPropsConfig<RefKey>>();
-
-    return {
-      [refKey]: composeRefs(ref as Ref<HTMLElement>, this.onRef),
-      key: this.uid,
-      ...config,
-      children: children ?? this.renderChildren(null),
-    } as any;
-  };
-
-  /**
-   * Stores the Prosemirror editor dom instance for this component using `refs`
-   */
-  private readonly onRef: Ref<HTMLElement> = (element) => {
-    if (!element) {
-      return;
-    }
-
-    this.rootPropsConfig.count += 1;
-
-    invariant(this.rootPropsConfig.count <= 1, {
-      code: ErrorConstant.REACT_GET_ROOT_PROPS,
-      message: `Called ${this.rootPropsConfig.count} times`,
-    });
-
-    this.#editorRef = element;
-    this.onRefLoad();
-  };
-
-  /**
-   * Updates the state either by calling onStateChange when it exists or
-   * directly setting the internal state via a `setState` call.
-   */
-  protected updateState(parameter: UpdateStateParameter<SchemaFromCombined<Combined>>) {
-    const { state, triggerChange = true, tr, transactions } = parameter;
-
-    if (this.props.value) {
-      const { onChange } = this.props;
-
-      invariant(onChange, {
-        code: ErrorConstant.REACT_CONTROLLED,
-        message:
-          'You are required to provide the `onChange` handler when creating a controlled editor.',
-      });
-
-      invariant(triggerChange, {
-        code: ErrorConstant.REACT_CONTROLLED,
-        message:
-          'Controlled editors do not support `clearContent` or `setContent` where `triggerChange` is `true`. Update the `value` prop instead.',
-      });
-
-      if (!this.previousStateOverride) {
-        this.previousStateOverride = this.getState();
-      }
-
-      this.onChange({ state, tr });
-
-      return;
-    }
-
-    // Update the internal prosemirror state. This happens before we update
-    // the component's copy of the state.
-    this.view.updateState(state);
-
-    if (triggerChange) {
-      // Update the `onChange` handler before notifying the manager but only when a change should be triggered.
-      this.onChange({ state, tr });
-    }
-
-    this.manager.onStateUpdate({ previousState: this.previousState, state, tr, transactions });
-  }
-
-  /**
-   * Update the controlled state when the value changes and notify the extension
-   * of this update.
-   */
-  updateControlledState(
-    state: EditorState<SchemaFromCombined<Combined>>,
-    previousState?: EditorState<SchemaFromCombined<Combined>>,
-  ) {
-    this.previousStateOverride = previousState;
-
-    this.view.updateState(state);
-    this.manager.onStateUpdate({ previousState: this.previousState, state });
-
-    this.previousStateOverride = undefined;
-  }
-
-  /**
-   * Adds the prosemirror view to the dom in the position specified via the
-   * component props.
-   */
-  private addProsemirrorViewToDom(element: HTMLElement, viewDom: Element) {
-    if (this.props.insertPosition === 'start') {
-      element.insertBefore(viewDom, element.firstChild);
-    } else {
-      element.append(viewDom);
-    }
-  }
-
-  /**
-   * Called once the container dom node (`this.editorRef`) has been initialized
-   * after the component mounts.
-   *
-   * This method handles the cases where the dom is not focused.
-   */
-  private onRefLoad() {
-    invariant(this.#editorRef, {
-      code: ErrorConstant.REACT_EDITOR_VIEW,
-      message: 'Something went wrong when initializing the text editor. Please check your setup.',
-    });
-
-    const { autoFocus } = this.props;
-    this.addProsemirrorViewToDom(this.#editorRef, this.view.dom);
-
-    if (autoFocus) {
-      this.focus(autoFocus);
-    }
-
-    this.onChange();
-    this.addFocusListeners();
-  }
-
-  onMount() {
-    const { suppressHydrationWarning } = this.props;
-
-    if (suppressHydrationWarning) {
-      this.#setShouldRenderClient(true);
-    }
-  }
-
-  /**
-   * Called for every update of the props and state.
-   */
-  onUpdate(previousEditable: boolean | undefined) {
-    // Ensure that `children` is still a render prop
-    propIsFunction(this.props.children);
-
-    // Check whether the editable prop has been updated
-    if (this.props.editable !== previousEditable && this.view && this.#editorRef) {
-      this.view.setProps({ ...this.view.props, editable: () => this.props.editable ?? true });
-    }
-  }
-
-  get remirrorContext(): RemirrorContextProps<Combined> {
-    return {
-      ...this.editorWrapperOutput,
-      getRootProps: this.getRootProps,
-      portalContainer: this.manager.store.portalContainer,
-    };
-  }
-
-  /**
-   * Checks whether this is an SSR environment and returns a child array with
-   * the SSR component
-   *
-   * @param children
-   */
-  private renderChildren(child: ReactNode) {
-    const { forceEnvironment, insertPosition = 'end', suppressHydrationWarning } = this.props;
-    const children = isArray(child) ? child : [child];
-
-    if (
-      shouldUseDomEnvironment(forceEnvironment) &&
-      (!suppressHydrationWarning || this.shouldRenderClient)
-    ) {
-      return children;
-    }
-
-    const ssrElement = this.renderSSR();
-
-    return (insertPosition === 'start' ? [ssrElement, ...children] : [...children, ssrElement]).map(
-      addKeyToElement,
-    );
-  }
-
-  /**
-   * Return a JSX Element to be used within the domless environment.
-   */
-  private renderSSR() {
-    return (
-      <RemirrorSSR
-        attributes={this.getAttributes(true)}
-        state={this.getState()}
-        manager={this.manager}
-        editable={this.props.editable ?? true}
-      />
-    );
-  }
-
-  /**
-   * Clones the passed element when `getRootProps` hasn't yet been called.
-   *
-   * This method also supports rendering the children within a domless environment where necessary.
-   */
-  private renderClonedElement(
-    element: JSX.Element,
-    rootProperties?: GetRootPropsConfig<string> | boolean,
-  ) {
-    const [editorElement, ...other] = isArray(element) ? element : [element, null];
-    const { children, ...rest } = getElementProps(editorElement);
-    const properties = isPlainObject(rootProperties) ? { ...rootProperties, ...rest } : rest;
-
-    return (
-      <>
-        {cloneElement(
-          editorElement,
-          this.internalGetRootProps(properties, this.renderChildren(children)),
-        )}
-        {[...other]}
-      </>
-    );
-  }
-
-  /**
-   * Reset the `getRootProps` called status.
-   */
-  private resetRender() {
-    // Reset the status of roots props being called
-    this.rootPropsConfig.called = false;
-    this.rootPropsConfig.count = 0;
-  }
-
-  /**
-   * Create the react element which renders the text editor. This render method
-   * also provides the `RemirrorPortals` which are used to render custom
-   * component based node views.
-   */
-  render() {
-    this.resetRender();
-
-    const element: JSX.Element | null = this.props.children(this.remirrorContext);
-
-    const { children, ...properties } = getElementProps(element);
-    let renderedElement: JSX.Element;
-
-    if (this.rootPropsConfig.called) {
-      // Simply return the element as this method can never actually be called
-      // within an ssr environment
-      renderedElement = element;
-    } else if (
-      // When called by a provider `getRootProps` can't actually be called until
-      // the jsx is generated. Check if this is being rendered via any remirror
-      // context provider. In this case `getRootProps` **must** be called by the
-      // consumer.
-      isRemirrorContextProvider(element) ||
-      isRemirrorProvider(element)
-    ) {
-      const { childAsRoot } = element.props;
-
-      renderedElement = childAsRoot
-        ? cloneElement(element, properties, this.renderClonedElement(children, childAsRoot))
-        : element;
-    } else {
-      renderedElement = isReactDOMElement(element) ? (
-        this.renderClonedElement(element)
-      ) : (
-        <div {...this.internalGetRootProps(undefined, this.renderChildren(element))} />
-      );
-    }
-
-    this.resetRender();
-
-    return renderedElement;
-  }
-}
-
-/**
- * The parameter that is passed into the ReactEditorWrapper.
- */
-interface ReactEditorWrapperParameter<Combined extends AnyCombinedUnion>
-  extends EditorWrapperParameter<Combined, ReactEditorProps<Combined>> {
-  getShouldRenderClient: () => boolean | undefined;
-  setShouldRenderClient: SetShouldRenderClient;
-}
-
-type SetShouldRenderClient = Dispatch<SetStateAction<boolean | undefined>>;
-
-/**
- * A hook which creates a reference to the `ReactEditorWrapper` and updates the
+ * A hook which creates a reference to the `ReactFramework` and updates the
  * parameters on every render.
  */
-function useEditorWrapper<Combined extends AnyCombinedUnion>(
-  parameter: ReactEditorWrapperParameter<Combined>,
-) {
+function useFramework<Combined extends AnyCombinedUnion>(
+  parameter: ReactFrameworkParameter<Combined>,
+): ReactFramework<Combined> {
   const parameterRef = useRef(parameter);
   parameterRef.current = parameter;
 
-  const [editorWrapper, setEditorWrapper] = useState(
-    () => new ReactEditorWrapper<Combined>(parameterRef.current),
+  const [editorWrapper, setFramework] = useState(
+    () => new ReactFramework<Combined>(parameterRef.current),
   );
 
   editorWrapper.update(parameter);
 
   useEffect(() => {
     editorWrapper.props.manager.addHandler('destroy', () => {
-      setEditorWrapper(new ReactEditorWrapper<Combined>(parameterRef.current));
+      setFramework(() => new ReactFramework<Combined>(parameterRef.current));
     });
   }, [editorWrapper.props.manager]);
 
@@ -633,9 +167,9 @@ function defaultStringHandler(): never {
  * A hook which manages the controlled updates for the editor.
  */
 function useControlledEditor<Combined extends AnyCombinedUnion>(
-  methods: ReactEditorWrapper<Combined>,
-) {
-  const { value } = methods.props;
+  framework: ReactFramework<Combined>,
+): void {
+  const { value } = framework.props;
 
   // Cache whether this is a controlled editor.
   const isControlled = useRef(bool(value)).current;
@@ -667,8 +201,7 @@ function useControlledEditor<Combined extends AnyCombinedUnion>(
   // while rendering a different component [`ReactEditor`]'.
   //
   // This is because rendering one component should not attempt to update the
-  // state of a different component while rendering. NodeView are called as soon
-  // as `view.updateState` is called and since the NodeView implementation
-  // relies has an event listener.
-  methods.updateControlledState(value, previousValue ?? undefined);
+  // state of a different component while rendering. NodeView's are called as soon
+  // as `view.updateState` is called and the NodeView is updated via a synchronous event listener which triggers a `setState` causing the
+  framework.updateControlledState(value, previousValue ?? undefined);
 }

--- a/packages/@remirror/react/src/hooks/editor-hooks.ts
+++ b/packages/@remirror/react/src/hooks/editor-hooks.ts
@@ -460,7 +460,7 @@ type UsePresetCallback<Type extends AnyPresetConstructor> = (
  * import { PresetCore } from 'remirror/preset-core';
  * import { BoldExtension } from 'remirror/extension-bold';
  *
- * const EditorWrapper = () => {
+ * const Framework = () => {
  *   const manager = useManager([new BoldExtension(), new CorePreset()]);
  *
  *   <RemirrorProvider >

--- a/packages/@remirror/react/src/react-framework.tsx
+++ b/packages/@remirror/react/src/react-framework.tsx
@@ -1,0 +1,475 @@
+import composeRefs from '@seznam/compose-react-refs';
+import React, { cloneElement, Dispatch, ReactNode, Ref, SetStateAction } from 'react';
+
+import {
+  AnyCombinedUnion,
+  ErrorConstant,
+  Framework,
+  FrameworkParameter,
+  invariant,
+  isArray,
+  isPlainObject,
+  object,
+  SchemaFromCombined,
+  shouldUseDomEnvironment,
+  UpdateStateParameter,
+} from '@remirror/core';
+import type { EditorState } from '@remirror/pm/state';
+import type { EditorView } from '@remirror/pm/view';
+import { ReactPreset } from '@remirror/preset-react';
+import {
+  addKeyToElement,
+  getElementProps,
+  isReactDOMElement,
+  isRemirrorContextProvider,
+  isRemirrorProvider,
+  propIsFunction,
+} from '@remirror/react-utils';
+
+import type {
+  BaseProps,
+  GetRootPropsConfig,
+  RefKeyRootProps,
+  RemirrorContextProps,
+} from './react-types';
+import { createEditorView, RemirrorSSR } from './ssr';
+
+export class ReactFramework<Combined extends AnyCombinedUnion> extends Framework<
+  Combined,
+  ReactEditorProps<Combined>
+> {
+  /**
+   * Whether to render the client immediately.
+   */
+  #getShouldRenderClient: () => boolean | undefined;
+
+  /**
+   * Update the should render client state input.
+   */
+  #setShouldRenderClient: SetShouldRenderClient;
+
+  /**
+   * Stores the Prosemirror EditorView dom element.
+   */
+  #editorRef?: HTMLElement;
+
+  /**
+   * Used when suppressHydrationWarning is true to determine when it's okay to
+   * render the client content.
+   */
+  private get shouldRenderClient(): boolean | undefined {
+    return this.#getShouldRenderClient();
+  }
+
+  /**
+   * Keep track of whether the get root props has been called during the most recent render.
+   */
+  private rootPropsConfig = {
+    called: false,
+    count: 0,
+  };
+
+  get name() {
+    return 'react' as const;
+  }
+
+  constructor(parameter: ReactFrameworkParameter<Combined>) {
+    super(parameter);
+
+    const { getShouldRenderClient, setShouldRenderClient } = parameter;
+
+    this.#getShouldRenderClient = getShouldRenderClient;
+    this.#setShouldRenderClient = setShouldRenderClient;
+
+    propIsFunction(this.props.children);
+
+    if (this.manager.view) {
+      this.manager.view.setProps({
+        state: this.manager.view.state,
+        dispatchTransaction: this.dispatchTransaction,
+        attributes: () => this.getAttributes(),
+        editable: () => this.props.editable ?? true,
+      });
+
+      return;
+    }
+
+    this.manager.getPreset(ReactPreset).setOptions({ placeholder: this.props.placeholder ?? '' });
+  }
+
+  /**
+   * This is called to update props on every render so that values don't become stale.
+   */
+  update(parameter: ReactFrameworkParameter<Combined>): this {
+    super.update(parameter);
+
+    const { getShouldRenderClient, setShouldRenderClient } = parameter;
+
+    this.#getShouldRenderClient = getShouldRenderClient;
+    this.#setShouldRenderClient = setShouldRenderClient;
+
+    return this;
+  }
+
+  /**
+   * Create the prosemirror editor view.
+   */
+  protected createView(
+    state: EditorState<SchemaFromCombined<Combined>>,
+  ): EditorView<SchemaFromCombined<Combined>> {
+    return createEditorView<SchemaFromCombined<Combined>>(
+      undefined,
+      {
+        state,
+        nodeViews: this.manager.store.nodeViews,
+        dispatchTransaction: this.dispatchTransaction,
+        attributes: () => this.getAttributes(),
+        editable: () => this.props.editable ?? true,
+      },
+      this.props.forceEnvironment,
+    );
+  }
+
+  /**
+   * The external `getRootProps` that is used to spread props onto a desired
+   * holder element for the prosemirror view.
+   */
+  private readonly getRootProps = <RefKey extends string = 'ref'>(
+    options?: GetRootPropsConfig<RefKey>,
+  ) => {
+    return this.internalGetRootProps(options, null);
+  };
+
+  /**
+   * Creates the props that should be spread on the root element inside which
+   * the prosemirror instance will be rendered.
+   */
+  private readonly internalGetRootProps = <RefKey extends string = 'ref'>(
+    options?: GetRootPropsConfig<RefKey>,
+    children?: ReactNode,
+  ): RefKeyRootProps<RefKey> => {
+    // Ensure that this is the first time `getRootProps` is being called during
+    // this commit phase of the .
+    // invariant(!this.rootPropsConfig.called, { code: ErrorConstant.REACT_GET_ROOT_PROPS });
+    this.rootPropsConfig.called = true;
+
+    const { refKey: refKey = 'ref', ref, ...config } =
+      options ?? object<GetRootPropsConfig<RefKey>>();
+
+    return {
+      [refKey]: composeRefs(ref as Ref<HTMLElement>, this.onRef),
+      key: this.uid,
+      ...config,
+      children: children ?? this.renderChildren(null),
+    } as any;
+  };
+
+  /**
+   * Stores the Prosemirror editor dom instance for this component using `refs`
+   */
+  private readonly onRef: Ref<HTMLElement> = (element) => {
+    if (!element) {
+      return;
+    }
+
+    this.rootPropsConfig.count += 1;
+
+    invariant(this.rootPropsConfig.count <= 1, {
+      code: ErrorConstant.REACT_GET_ROOT_PROPS,
+      message: `Called ${this.rootPropsConfig.count} times`,
+    });
+
+    this.#editorRef = element;
+    this.onRefLoad();
+  };
+
+  /**
+   * Updates the state either by calling onStateChange when it exists or
+   * directly setting the internal state via a `setState` call.
+   */
+  protected updateState(parameter: UpdateStateParameter<SchemaFromCombined<Combined>>): void {
+    const { state, triggerChange = true, tr, transactions } = parameter;
+
+    if (this.props.value) {
+      const { onChange } = this.props;
+
+      invariant(onChange, {
+        code: ErrorConstant.REACT_CONTROLLED,
+        message:
+          'You are required to provide the `onChange` handler when creating a controlled editor.',
+      });
+
+      invariant(triggerChange, {
+        code: ErrorConstant.REACT_CONTROLLED,
+        message:
+          'Controlled editors do not support `clearContent` or `setContent` where `triggerChange` is `true`. Update the `value` prop instead.',
+      });
+
+      if (!this.previousStateOverride) {
+        this.previousStateOverride = this.getState();
+      }
+
+      this.onChange({ state, tr });
+
+      return;
+    }
+
+    // Update the internal prosemirror state. This happens before we update
+    // the component's copy of the state.
+    this.view.updateState(state);
+
+    if (triggerChange) {
+      // Update the `onChange` handler before notifying the manager but only when a change should be triggered.
+      this.onChange({ state, tr });
+    }
+
+    this.manager.onStateUpdate({ previousState: this.previousState, state, tr, transactions });
+  }
+
+  /**
+   * Update the controlled state when the value changes and notify the extension
+   * of this update.
+   */
+  updateControlledState(
+    state: EditorState<SchemaFromCombined<Combined>>,
+    previousState?: EditorState<SchemaFromCombined<Combined>>,
+  ): void {
+    this.previousStateOverride = previousState;
+
+    this.view.updateState(state);
+    this.manager.onStateUpdate({ previousState: this.previousState, state });
+
+    this.previousStateOverride = undefined;
+  }
+
+  /**
+   * Adds the prosemirror view to the dom in the position specified via the
+   * component props.
+   */
+  private addProsemirrorViewToDom(element: HTMLElement, viewDom: Element) {
+    if (this.props.insertPosition === 'start') {
+      element.insertBefore(viewDom, element.firstChild);
+    } else {
+      element.append(viewDom);
+    }
+  }
+
+  /**
+   * Called once the container dom node (`this.editorRef`) has been initialized
+   * after the component mounts.
+   *
+   * This method handles the cases where the dom is not focused.
+   */
+  private onRefLoad() {
+    invariant(this.#editorRef, {
+      code: ErrorConstant.REACT_EDITOR_VIEW,
+      message: 'Something went wrong when initializing the text editor. Please check your setup.',
+    });
+
+    const { autoFocus } = this.props;
+    this.addProsemirrorViewToDom(this.#editorRef, this.view.dom);
+
+    if (autoFocus) {
+      this.focus(autoFocus);
+    }
+
+    this.onChange();
+    this.addFocusListeners();
+  }
+
+  onMount(): void {
+    const { suppressHydrationWarning } = this.props;
+
+    if (suppressHydrationWarning) {
+      this.#setShouldRenderClient(true);
+    }
+  }
+
+  /**
+   * Called for every update of the props and state.
+   */
+  onUpdate(previousEditable: boolean | undefined): void {
+    // Ensure that `children` is still a render prop
+    propIsFunction(this.props.children);
+
+    // Check whether the editable prop has been updated
+    if (this.props.editable !== previousEditable && this.view && this.#editorRef) {
+      this.view.setProps({ ...this.view.props, editable: () => this.props.editable ?? true });
+    }
+  }
+
+  get remirrorContext(): RemirrorContextProps<Combined> {
+    return {
+      ...this.frameworkHelpers,
+      getRootProps: this.getRootProps,
+      portalContainer: this.manager.store.portalContainer,
+    };
+  }
+
+  /**
+   * Checks whether this is an SSR environment and returns a child array with
+   * the SSR component
+   *
+   * @param children
+   */
+  private renderChildren(child: ReactNode) {
+    const { forceEnvironment, insertPosition = 'end', suppressHydrationWarning } = this.props;
+    const children = isArray(child) ? child : [child];
+
+    if (
+      shouldUseDomEnvironment(forceEnvironment) &&
+      (!suppressHydrationWarning || this.shouldRenderClient)
+    ) {
+      return children;
+    }
+
+    const ssrElement = this.renderSSR();
+
+    return (insertPosition === 'start' ? [ssrElement, ...children] : [...children, ssrElement]).map(
+      addKeyToElement,
+    );
+  }
+
+  /**
+   * Return a JSX Element to be used within the domless environment.
+   */
+  private renderSSR() {
+    return (
+      <RemirrorSSR
+        attributes={this.getAttributes(true)}
+        state={this.getState()}
+        manager={this.manager}
+        editable={this.props.editable ?? true}
+      />
+    );
+  }
+
+  /**
+   * Clones the passed element when `getRootProps` hasn't yet been called.
+   *
+   * This method also supports rendering the children within a domless environment where necessary.
+   */
+  private renderClonedElement(
+    element: JSX.Element,
+    rootProperties?: GetRootPropsConfig<string> | boolean,
+  ) {
+    const [editorElement, ...other] = isArray(element) ? element : [element, null];
+    const { children, ...rest } = getElementProps(editorElement);
+    const properties = isPlainObject(rootProperties) ? { ...rootProperties, ...rest } : rest;
+
+    return (
+      <>
+        {cloneElement(
+          editorElement,
+          this.internalGetRootProps(properties, this.renderChildren(children)),
+        )}
+        {[...other]}
+      </>
+    );
+  }
+
+  /**
+   * Reset the called status of `getRootProps`.
+   */
+  private resetRender() {
+    // Reset the status of roots props being called
+    this.rootPropsConfig.called = false;
+    this.rootPropsConfig.count = 0;
+  }
+
+  /**
+   * Create the react element which renders the text editor. This render method
+   * also provides the `RemirrorPortals` which are used to render custom
+   * component based node views.
+   */
+  generateReactElement(): JSX.Element {
+    this.resetRender();
+
+    const element: JSX.Element | null = this.props.children(this.remirrorContext);
+
+    const { children, ...properties } = getElementProps(element);
+    let renderedElement: JSX.Element;
+
+    if (this.rootPropsConfig.called) {
+      // Simply return the element as this method can never actually be called
+      // within an ssr environment
+      renderedElement = element;
+    } else if (
+      // When called by a provider `getRootProps` can't actually be called until
+      // the jsx is generated. Check if this is being rendered via any remirror
+      // context provider. In this case `getRootProps` **must** be called by the
+      // consumer.
+      isRemirrorContextProvider(element) ||
+      isRemirrorProvider(element)
+    ) {
+      const { childAsRoot } = element.props;
+
+      renderedElement = childAsRoot
+        ? cloneElement(element, properties, this.renderClonedElement(children, childAsRoot))
+        : element;
+    } else {
+      renderedElement = isReactDOMElement(element) ? (
+        this.renderClonedElement(element)
+      ) : (
+        <div {...this.internalGetRootProps(undefined, this.renderChildren(element))} />
+      );
+    }
+
+    this.resetRender();
+
+    return renderedElement;
+  }
+}
+
+export interface ReactEditorProps<Combined extends AnyCombinedUnion> extends BaseProps<Combined> {
+  /**
+   * The render prop that takes the injected remirror params and returns an
+   * element to render. The editor view is automatically attached to the DOM.
+   */
+  children: RenderPropFunction<Combined>;
+
+  /**
+   * Set to true to ignore the hydration warning for a mismatch between the
+   * rendered server and client content.
+   *
+   * @remarks
+   *
+   * This is a potential solution for those who require server side rendering.
+   *
+   * While on the server the prosemirror document is transformed into a react
+   * component so that it can be rendered. The moment it enters the DOM
+   * environment prosemirror takes over control of the root element. The problem
+   * is that this will always see this hydration warning on the client:
+   *
+   * `Warning: Did not expect server HTML to contain a <div> in <div>.`
+   *
+   * Setting this to true removes the warning at the cost of a slightly slower
+   * start up time. It uses the two pass solution mentioned in the react docs.
+   * See {@link https://reactjs.org/docs/react-dom.html#hydrate}.
+   *
+   * For ease of use this prop copies the name used by react for DOM Elements.
+   * See {@link
+   * https://reactjs.org/docs/dom-elements.html#suppresshydrationwarning}.
+   */
+  suppressHydrationWarning?: boolean;
+}
+
+/**
+ * A function that takes the injected remirror params and returns JSX to render.
+ *
+ * @param - injected remirror params
+ */
+type RenderPropFunction<Combined extends AnyCombinedUnion> = (
+  params: RemirrorContextProps<Combined>,
+) => JSX.Element;
+
+/**
+ * The parameter that is passed into the ReactFramework.
+ */
+export interface ReactFrameworkParameter<Combined extends AnyCombinedUnion>
+  extends FrameworkParameter<Combined, ReactEditorProps<Combined>> {
+  getShouldRenderClient: () => boolean | undefined;
+  setShouldRenderClient: SetShouldRenderClient;
+}
+
+export type SetShouldRenderClient = Dispatch<SetStateAction<boolean | undefined>>;

--- a/packages/@remirror/react/src/react-types.ts
+++ b/packages/@remirror/react/src/react-types.ts
@@ -5,8 +5,8 @@ import type {
   AnyExtension,
   BuiltinPreset,
   EditorState,
-  EditorWrapperOutput,
-  EditorWrapperProps,
+  FrameworkOutput,
+  FrameworkProps,
   GetStaticAndDynamic,
   RemirrorManager,
   SchemaFromCombined,
@@ -28,7 +28,7 @@ export type ReactCombinedUnion<Combined extends AnyCombinedUnion> =
   | BuiltinPreset
   | Combined;
 
-export interface BaseProps<Combined extends AnyCombinedUnion> extends EditorWrapperProps<Combined> {
+export interface BaseProps<Combined extends AnyCombinedUnion> extends FrameworkProps<Combined> {
   /**
    * Pass in the extension manager.
    *
@@ -167,7 +167,7 @@ export interface I18nContextProps {
  * your editor.
  */
 export interface RemirrorContextProps<Combined extends AnyCombinedUnion>
-  extends EditorWrapperOutput<Combined> {
+  extends FrameworkOutput<Combined> {
   /**
    * A function that returns props which should be spread on a react element and
    * declare it as the editor root (where the editor is injected in the DOM).

--- a/packages/@remirror/styles/all.css
+++ b/packages/@remirror/styles/all.css
@@ -425,7 +425,7 @@
   background-color: grey;
 }
 
-.remirror-social-editor-wrapper {
+.remirror-social-editor-container {
   position: relative;
   height: 100%;
 }
@@ -478,7 +478,7 @@
   background-color: grey;
 }
 
-.remirror-wysiwyg-editor-wrapper {
+.remirror-wysiwyg-editor-container {
   position: relative;
   height: 100%;
 }

--- a/packages/@remirror/styles/react-social.css
+++ b/packages/@remirror/styles/react-social.css
@@ -189,7 +189,7 @@
   background-color: grey;
 }
 
-.remirror-social-editor-wrapper {
+.remirror-social-editor-container {
   position: relative;
   height: 100%;
 }

--- a/packages/@remirror/styles/react-wysiwyg.css
+++ b/packages/@remirror/styles/react-wysiwyg.css
@@ -46,7 +46,7 @@
   background-color: grey;
 }
 
-.remirror-wysiwyg-editor-wrapper {
+.remirror-wysiwyg-editor-container {
   position: relative;
   height: 100%;
 }

--- a/packages/@remirror/styles/src/dom.tsx
+++ b/packages/@remirror/styles/src/dom.tsx
@@ -446,7 +446,7 @@ export const reactSocialStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -501,7 +501,7 @@ export const reactWysiwygStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1154,7 +1154,7 @@ export const allStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1207,7 +1207,7 @@ export const allStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }

--- a/packages/@remirror/styles/src/emotion.tsx
+++ b/packages/@remirror/styles/src/emotion.tsx
@@ -693,7 +693,7 @@ export const reactSocialStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -891,7 +891,7 @@ export const ReactSocialStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -946,7 +946,7 @@ export const reactWysiwygStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1001,7 +1001,7 @@ export const ReactWysiwygStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1873,7 +1873,7 @@ export const allStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1926,7 +1926,7 @@ export const allStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -2577,7 +2577,7 @@ export const AllStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -2630,7 +2630,7 @@ export const AllStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }

--- a/packages/@remirror/styles/src/styled-components.tsx
+++ b/packages/@remirror/styles/src/styled-components.tsx
@@ -692,7 +692,7 @@ export const reactSocialStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -890,7 +890,7 @@ export const ReactSocialStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -945,7 +945,7 @@ export const reactWysiwygStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1000,7 +1000,7 @@ export const ReactWysiwygStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1872,7 +1872,7 @@ export const allStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -1925,7 +1925,7 @@ export const allStyledCss = css`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }
@@ -2576,7 +2576,7 @@ export const AllStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-social-editor-wrapper {
+  .remirror-social-editor-container {
     position: relative;
     height: 100%;
   }
@@ -2629,7 +2629,7 @@ export const AllStyledComponent = styled.div`
     background-color: grey;
   }
 
-  .remirror-wysiwyg-editor-wrapper {
+  .remirror-wysiwyg-editor-container {
     position: relative;
     height: 100%;
   }

--- a/packages/jest-remirror/src/jest-remirror-types.ts
+++ b/packages/jest-remirror/src/jest-remirror-types.ts
@@ -6,7 +6,7 @@ import type {
   NodeAttributes,
   ProsemirrorNode,
 } from '@remirror/core';
-import type { DomEditorWrapperProps } from '@remirror/dom';
+import type { DomFrameworkProps } from '@remirror/dom';
 import type { CreateCoreManagerOptions } from '@remirror/preset-core';
 
 export interface BaseFactoryParameter<Schema extends EditorSchema = EditorSchema>
@@ -105,7 +105,7 @@ export type NodeWithoutAttributes<Names extends string> = {
 
 export interface RenderEditorParameter<Combined extends AnyCombinedUnion>
   extends CreateCoreManagerOptions {
-  props?: Partial<Omit<DomEditorWrapperProps<Combined>, 'manager'>>;
+  props?: Partial<Omit<DomFrameworkProps<Combined>, 'manager'>>;
 
   /**
    * Whether to automatically cleanup the dom once the test finishes.

--- a/support/examples/with-next/src/pages/editor/positioner.tsx
+++ b/support/examples/with-next/src/pages/editor/positioner.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 
 import { EMPTY_PARAGRAPH_NODE } from 'remirror/core';
 import { BoldExtension } from 'remirror/extension/bold';
@@ -8,7 +8,7 @@ import { UnderlineExtension } from 'remirror/extension/underline';
 import { ListPreset } from 'remirror/preset/list';
 import { RemirrorProvider, useManager, usePositioner, useRemirror } from 'remirror/react';
 
-const EXTENSIONS = [
+const EXTENSIONS = () => [
   new HeadingExtension(),
   new BoldExtension(),
   new ItalicExtension(),
@@ -52,7 +52,7 @@ function Menu() {
 /**
  * This component contains the editor and any toolbars/chrome it requires.
  */
-const SmallEditor = () => {
+const SmallEditor: FC = () => {
   const { getRootProps } = useRemirror();
   return (
     <div>
@@ -62,7 +62,7 @@ const SmallEditor = () => {
   );
 };
 
-const SmallEditorWrapper = () => {
+const SmallEditorContainer: FC = () => {
   const extensionManager = useManager(EXTENSIONS);
   const [value, setValue] = useState(
     extensionManager.createState({ content: EMPTY_PARAGRAPH_NODE }),
@@ -79,4 +79,4 @@ const SmallEditorWrapper = () => {
   );
 };
 
-export default SmallEditorWrapper;
+export default SmallEditorContainer;

--- a/support/root/.eslintrc.js
+++ b/support/root/.eslintrc.js
@@ -356,6 +356,7 @@ module.exports = {
         '**/*extension.ts',
         '**/*extension.tsx',
         'packages/@remirror/core/src/manager/remirror-manager.ts',
+        'packages/@remirror/core/src/framework/*.ts',
         'packages/@remirror/core/src/extension/extension-base.ts',
       ],
       rules: { '@typescript-eslint/method-signature-style': 'off' },

--- a/support/website/src/theme/ReactLiveScope/index.tsx
+++ b/support/website/src/theme/ReactLiveScope/index.tsx
@@ -44,7 +44,7 @@ const exampleUsers = [
     href: '//test.com/tope',
     id: 'tope',
   },
-];
+].map((user) => ({ ...user, label: `@${user.username}` }));
 
 const exampleTags = [
   { tag: 'FunTime', href: '//test.com/funtime', id: 'funtime' },
@@ -55,7 +55,7 @@ const exampleTags = [
   { tag: 'BeStrong', href: '//test.com/bestrong', id: 'bestrong' },
   { tag: 'YouAreMighty', href: '//test.com/youaremighty', id: 'youaremighty' },
   { tag: 'WelcomeChampion', href: '//test.com/welcomechampion', id: 'welcomechampion' },
-];
+].map((tag) => ({ ...tag, label: `#${tag.tag}` }));
 
 /**
  * The globals available to the live editor scope.


### PR DESCRIPTION
### Description

Refactor `RemirrorManager` and rename `EditorWrapper` to `Framework`.

- New `BaseFramework` interface which is implemented by the abstract `Framework` class and used by the `RemirrorManager` to keep hold of an instance of the `Framework`.
- New `attachFramework` method on the manager.
- Update `doc` property to `document` throughout the codebase. `doc` could be confused with the `doc` node or the actual document. Now it's clearer. Any time `doc` is mentioned in the code base it refers to the `ProseMirror` node. Any time `document` is mentioned it is referring to the DOM.
- Remove `SocialEditorWrapperComponent` export from `@remirror/react-social`.

Fixes #559 
Fixes #664

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
