### PR TITLE
Support exiting inline marks in block nodes

### DIFF
--- a/.changeset/chilled-rats-join.md
+++ b/.changeset/chilled-rats-join.md
@@ -1,0 +1,12 @@
+---
+'@remirror/core': minor
+'@remirror/core-constants': minor
+---
+
+Add `MarkSupportsExit` tag to `ExtensionTag` constant export.
+
+Add `KeymapExtension` option `exitMarksOnArrowPress` which allows the user to exit marks with the `MarkSupportExit` tag from the beginning or the end of the document.
+
+Store tags as `markTags`, `nodeTags`, `plainTags` and deprecate the helper methods which were previously doing this.
+
+Add `extraTags` option to the extension and `RemirrorManager` now extra can be added as part of the configuration.

--- a/.changeset/great-pans-do.md
+++ b/.changeset/great-pans-do.md
@@ -1,0 +1,6 @@
+---
+'jest-prosemirror': patch
+'jest-remirror': patch
+---
+
+Fix `node` cursor selection. Now it selects the right node position.

--- a/.changeset/honest-kids-search.md
+++ b/.changeset/honest-kids-search.md
@@ -1,0 +1,5 @@
+---
+'@remirror/dom': minor
+---
+
+Support lazy functions which return an extension list in the `createDomManager`.

--- a/.changeset/neat-worms-applaud.md
+++ b/.changeset/neat-worms-applaud.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-code': minor
+---
+
+Add support for exiting code mark at the end of a block node.

--- a/packages/@remirror/core-constants/src/core-constants.ts
+++ b/packages/@remirror/core-constants/src/core-constants.ts
@@ -207,6 +207,12 @@ const BaseExtensionTag = {
    * A tag that excludes this from input rules.
    */
   ExcludeInputRules: 'excludeFromInputRules',
+
+  /**
+   * A mark that can be exited when at the end and beginning of the document
+   * with an arrow key.
+   */
+  MarkSupportsExit: 'markSupportsExits',
 } as const;
 
 /**

--- a/packages/@remirror/core/src/builtins/__tests__/keymap-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/keymap-extension.spec.ts
@@ -1,8 +1,9 @@
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
+import { CodeExtension } from 'remirror/extension/code';
 
-import { BuiltinPreset } from '@remirror/testing';
+import { ExtensionPriority } from '@remirror/core-constants';
 
-import { KeymapExtension } from '..';
+import { KeymapExtension } from '../../..';
 
 extensionValidityTest(KeymapExtension);
 
@@ -14,7 +15,7 @@ test('supports custom keymaps', () => {
     nodes: { p, doc },
   } = renderEditor([]);
 
-  manager.getPreset(BuiltinPreset).addCustomHandler('keymap', { a: mock });
+  manager.getExtension(KeymapExtension).addCustomHandler('keymap', { a: mock });
 
   add(doc(p('Start<cursor>')))
     .press('a')
@@ -61,10 +62,67 @@ test('it supports updating options at runtime', () => {
     .press('Enter')
     .callback((content) => {
       expect(content.state.doc).toEqualRemirrorDocument(doc(p('Start')));
-      manager.getPreset(BuiltinPreset).setOptions({ excludeBaseKeymap: false });
+      manager.getExtension(KeymapExtension).setOptions({ excludeBaseKeymap: false });
     })
     .press('Enter')
     .callback((content) => {
       expect(content.state.doc).toEqualRemirrorDocument(doc(p('Start'), p('')));
     });
+});
+
+describe('exitMark', () => {
+  const editor = renderEditor([new CodeExtension()], {});
+  const { p, doc } = editor.nodes;
+  const { code } = editor.marks;
+
+  // Simulate key presses for a real browser.
+  editor.manager.getExtension(KeymapExtension).addCustomHandler('keymap', [
+    ExtensionPriority.Lowest,
+    {
+      ArrowRight: ({ tr }) => {
+        editor.selectText(Math.min(tr.selection.from + 1, tr.doc.nodeSize - 2));
+        return true;
+      },
+      ArrowLeft: ({ tr }) => {
+        editor.selectText(Math.max(tr.selection.from - 1, 1));
+        return true;
+      },
+    },
+  ]);
+
+  it('can exit the node backwards', () => {
+    editor
+      .add(doc(p(code('<cursor>this ')), p('the end')))
+      .press('ArrowLeft')
+      .insertText('abc');
+
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p('abc', code('this ')), p('the end')));
+  });
+
+  it('can exit the node forwards', () => {
+    editor
+      .add(doc(p(code('this<cursor>')), p('the end')))
+      .press('ArrowRight')
+      .insertText('abc');
+
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p(code('this'), ' abc'), p('the end')));
+  });
+
+  it('does nothing when not at the end or start', () => {
+    editor.manager.getExtension(KeymapExtension).addCustomHandler('keymap', [
+      ExtensionPriority.Lowest,
+      {
+        ArrowRight: ({ tr }) => {
+          editor.selectText(tr.selection.from + 1);
+          return true;
+        },
+      },
+    ]);
+    editor
+      .add(doc(p(code('this<cursor>hello'))))
+      .press('ArrowRight')
+      .insertText('abc');
+
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p(code('thishabcello'))));
+  });
 });

--- a/packages/@remirror/core/src/builtins/builtin-preset.ts
+++ b/packages/@remirror/core/src/builtins/builtin-preset.ts
@@ -42,6 +42,7 @@ export interface BuiltinOptions
  */
 @presetDecorator<BuiltinOptions>({
   defaultOptions: {
+    exitMarksOnArrowPress: KeymapExtension.defaultOptions.exitMarksOnArrowPress,
     excludeBaseKeymap: KeymapExtension.defaultOptions.excludeBaseKeymap,
     selectParentNodeOnEscape: KeymapExtension.defaultOptions.selectParentNodeOnEscape,
     undoInputRuleOnBackspace: KeymapExtension.defaultOptions.undoInputRuleOnBackspace,

--- a/packages/@remirror/core/src/builtins/input-rules-extension.ts
+++ b/packages/@remirror/core/src/builtins/input-rules-extension.ts
@@ -58,7 +58,7 @@ export class InputRulesExtension extends PlainExtension<InputRulesOptions> {
 
   private loopExtensions() {
     const rules: SkippableInputRule[] = [];
-    const invalidMarks = this.store.tags[ExtensionTag.ExcludeInputRules];
+    const invalidMarks = this.store.markTags[ExtensionTag.ExcludeInputRules];
 
     for (const extension of this.store.extensions) {
       if (

--- a/packages/@remirror/core/src/extension/extension-base.ts
+++ b/packages/@remirror/core/src/extension/extension-base.ts
@@ -672,17 +672,13 @@ export type GetPlainNames<Type> = Type extends AnyPlainExtension ? GetNameUnion<
  * A utility type for retrieving the name of an extension only when it's a mark
  * extension.
  */
-export type GetMarkNameUnion<
-  ExtensionUnion extends AnyExtension
-> = ExtensionUnion extends AnyMarkExtension ? ExtensionUnion['name'] : never;
+export type GetMarkNameUnion<Type> = Type extends AnyMarkExtension ? Type['name'] : never;
 
 /**
  * A utility type for retrieving the name of an extension only when it's a node
  * extension.
  */
-export type GetNodeNameUnion<
-  ExtensionUnion extends AnyExtension
-> = ExtensionUnion extends AnyNodeExtension ? ExtensionUnion['name'] : never;
+export type GetNodeNameUnion<Type> = Type extends AnyNodeExtension ? Type['name'] : never;
 
 /**
  * Gets the editor schema from an extension union.

--- a/packages/@remirror/dom/src/dom.ts
+++ b/packages/@remirror/dom/src/dom.ts
@@ -15,10 +15,10 @@ import { DomFramework, DomFrameworkOutput, DomFrameworkProps } from './dom-frame
  * Create an editor manager. It comes with the `CorePreset` already available.
  */
 export function createDomManager<Combined extends AnyCombinedUnion>(
-  combined: Combined[],
+  combined: Combined[] | (() => Combined[]),
   options?: CreateCoreManagerOptions,
 ): RemirrorManager<CorePreset | BuiltinPreset | Combined> {
-  return createCoreManager([...combined], options);
+  return createCoreManager(combined, options);
 }
 
 /**

--- a/packages/@remirror/extension-code/src/code-extension.ts
+++ b/packages/@remirror/extension-code/src/code-extension.ts
@@ -24,7 +24,7 @@ export class CodeExtension extends MarkExtension {
     return 'code' as const;
   }
 
-  readonly tags = [ExtensionTag.Code];
+  readonly tags = [ExtensionTag.Code, ExtensionTag.MarkSupportsExit];
 
   createMarkSpec(extra: ApplySchemaAttributes): MarkExtensionSpec {
     return {

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -238,7 +238,12 @@ export function dispatchNodeSelection<Schema extends EditorSchema = EditorSchema
 ): void {
   const { view, pos } = parameter;
   const { state } = view;
-  const tr = state.tr.setSelection(NodeSelection.create(state.doc, pos));
+  const tr = state.tr.setSelection(
+    // Node selections should always be at the start of their nodes. This is
+    // impossible to annotate since the first text position is always the `node
+    // + 1` place.
+    NodeSelection.create(state.doc, state.doc.resolve(pos).before()),
+  );
   view.dispatch(tr);
 }
 

--- a/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
@@ -64,7 +64,7 @@ const supportedTags = new Set(['cursor', 'node', 'start', 'end', 'anchor', 'all'
  *
  * @param taggedDoc
  */
-export function taggedDocHasSelection(taggedDoc: TaggedProsemirrorNode) {
+export function taggedDocHasSelection(taggedDoc: TaggedProsemirrorNode): boolean {
   return keys(taggedDoc.tag).some((tag) => supportedTags.has(tag));
 }
 
@@ -77,7 +77,7 @@ export function taggedDocHasSelection(taggedDoc: TaggedProsemirrorNode) {
  */
 export function initSelection<Schema extends EditorSchema = EditorSchema>(
   taggedDoc: TaggedProsemirrorNode<Schema>,
-) {
+): Selection<Schema> | null {
   const { cursor, node, start, end, anchor, head, all, gap } = taggedDoc.tag;
 
   if (isNumber(all)) {
@@ -85,10 +85,7 @@ export function initSelection<Schema extends EditorSchema = EditorSchema>(
   }
 
   if (isNumber(node)) {
-    // Node selections should always be at the start of their nodes. This is
-    // impossible to annotate since the first text position is always the `node
-    // + 1` place.
-    return new NodeSelection<Schema>(taggedDoc.resolve(node - 1));
+    return NodeSelection.create<Schema>(taggedDoc, taggedDoc.resolve(node).before());
   }
 
   if (isNumber(cursor)) {

--- a/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/src/__tests__/jest-remirror-editor.spec.ts
@@ -1,4 +1,5 @@
 import { PlainExtension, toHtml } from '@remirror/core';
+import { NodeSelection } from '@remirror/pm/state';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -255,12 +256,12 @@ describe('tags', () => {
   });
 
   it('supports <node>', () => {
-    // ? Crashes if node is placed at the beginning of the p
-    const { start, end } = add(doc(p('Hello'), p('T<node>ext here')));
+    const { start, end, state } = add(doc(p('Hello'), p('<node>Text here')));
 
-    expect(start).toBe(9);
+    expect(state.selection).toBeInstanceOf(NodeSelection);
+    expect(start).toBe(7);
     expect(start).toBe(view.state.selection.from);
-    expect(end).toBe(17);
+    expect(end).toBe(18);
     expect(end).toBe(view.state.selection.to);
   });
 });

--- a/packages/jest-remirror/src/jest-remirror-editor.ts
+++ b/packages/jest-remirror/src/jest-remirror-editor.ts
@@ -71,11 +71,11 @@ const elements = new Set<Element>();
  * By default it already has the core preset applied.
  */
 export function renderEditor<Combined extends AnyCombinedUnion>(
-  combined: Combined[],
+  combined: Combined[] | (() => Combined[]),
   { props, autoClean, ...options }: RenderEditorParameter<Combined> = object(),
 ): RemirrorTestChain<Combined | CorePreset | BuiltinPreset> {
   const element = createElement(props?.element, autoClean);
-  const manager = createDomManager([...combined], options);
+  const manager = createDomManager(combined, options);
 
   // TODO add the editor to the remirror test chain
   createDomEditor({ ...props, element, manager });


### PR DESCRIPTION
### Description

Add `MarkSupportsExit` tag to `ExtensionTag` constant export.

Add `KeymapExtension` option `exitMarksOnArrowPress` which allows the user to exit marks with the `MarkSupportExit` tag from the beginning or the end of the document.

Store tags as `markTags`, `nodeTags`, `plainTags` and deprecate the helper methods which were previously doing this.

Add `extraTags` option to the extension and `RemirrorManager` now extra can be added as part of the configuration.

- Support lazy functions which return an extension list in the `createDomManager`.
- Fix `node` cursor selection. Now it selects the right node position in `jest-remirror`.
- Add support for exiting code mark at the end of a block node.


Fixes #636

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

#### Exit from the end

![2020-09-09 21 24 51](https://user-images.githubusercontent.com/1160934/92649680-4c4f8800-f2e3-11ea-8e5c-847655cb2b1d.gif)

#### Exit from the start

![2020-09-09 21 25 15](https://user-images.githubusercontent.com/1160934/92649711-58d3e080-f2e3-11ea-8e83-996d91a20748.gif)
