### PR TITLE
Fix `toggleList` command

### DIFF
--- a/.changeset/nice-tools-notice.md
+++ b/.changeset/nice-tools-notice.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core-utils': patch
+'@remirror/core': patch
+---
+
+Fixes `toggleList` command to only update the transaction when dispatch is provided \[[#669](https://github.com/remirror/remirror/issues/669)].

--- a/packages/@remirror/core-utils/src/command-utils.ts
+++ b/packages/@remirror/core-utils/src/command-utils.ts
@@ -197,11 +197,7 @@ export function toggleList(type: NodeType, itemType: NodeType): CommandFunction 
       }
 
       if (isList(parentList.node, schema) && type.validContent(parentList.node.content)) {
-        tr.setNodeMarkup(parentList.pos, type);
-
-        if (dispatch) {
-          dispatch(tr);
-        }
+        dispatch?.(tr.setNodeMarkup(parentList.pos, type));
 
         return true;
       }


### PR DESCRIPTION
### Description

Fix `toggleList` command to only update the transaction when dispatch is provided.

Fixes #669


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
