### PR TITLE
Fix `onStateUpdate` method for `TablePreset`

### DIFF
--- a/.changeset/honest-beans-poke.md
+++ b/.changeset/honest-beans-poke.md
@@ -1,0 +1,5 @@
+---
+'@remirror/dom': patch
+---
+
+Add `tr` and `transactions` property to `onStateUpdate` for DOM framework implementation.

--- a/.changeset/nice-dolphins-teach.md
+++ b/.changeset/nice-dolphins-teach.md
@@ -1,0 +1,5 @@
+---
+'@remirror/preset-table': patch
+---
+
+Fix broken `TableExtension` lifecycle method for `onStateUpdate`. Fixes #677.

--- a/packages/@remirror/dom/src/dom-framework.ts
+++ b/packages/@remirror/dom/src/dom-framework.ts
@@ -71,7 +71,7 @@ export class DomFramework<Combined extends AnyCombinedUnion> extends Framework<
    * Responsible for managing state updates.
    */
   protected updateState(parameter: UpdateStateParameter<SchemaFromCombined<Combined>>): void {
-    const { state, tr, triggerChange = true } = parameter;
+    const { state, tr, transactions, triggerChange = true } = parameter;
 
     // Update the internal prosemirror state. This happens before we update
     // the component's copy of the state.
@@ -81,7 +81,7 @@ export class DomFramework<Combined extends AnyCombinedUnion> extends Framework<
       this.onChange({ state, tr });
     }
 
-    this.manager.onStateUpdate({ previousState: this.previousState, state });
+    this.manager.onStateUpdate({ previousState: this.previousState, state, tr, transactions });
   }
 
   get domOutput(): DomFrameworkOutput<Combined> {

--- a/packages/@remirror/preset-table/src/table-extensions.ts
+++ b/packages/@remirror/preset-table/src/table-extensions.ts
@@ -77,7 +77,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
   onStateUpdate(parameter: StateUpdateLifecycleParameter): void {
     const { tr, state } = parameter;
 
-    if (tr?.getMeta(fixTablesKey).fixTables) {
+    if (tr?.getMeta(fixTablesKey)?.fixTables) {
       this.#lastGoodState = state;
     }
   }


### PR DESCRIPTION
### Description

- Add `tr` and `transactions` property to `onStateUpdate` for DOM framework implementation.
- Fix broken `TableExtension` lifecycle method for `onStateUpdate`. Fixes #677.

Fixes #677

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
