### PR TITLE
Style overlapping annotations

### DIFF
--- a/.changeset/lemon-ducks-breathe.md
+++ b/.changeset/lemon-ducks-breathe.md
@@ -1,0 +1,8 @@
+---
+'@remirror/extension-annotation': minor
+'@remirror/storybook': minor
+---
+
+Visualize the amount of overlapping annotations
+
+The annotation-extension would allow to style individual annotations via a CSS class. This led to issues with overlapping annotations. For example, if an annotation with a red background and another with a green background were overlapping, the editor would show (more or less) randomly one of the two colors. Now, the annotation-extension allows users to style decorations based on all overlapping annotations within a given decoration. The default implementation visualizes overlapping annotations by showing a darker shade the more annotations are overlapping.

--- a/.changeset/lemon-ducks-breathe.md
+++ b/.changeset/lemon-ducks-breathe.md
@@ -1,6 +1,5 @@
 ---
 '@remirror/extension-annotation': minor
-'@remirror/storybook': minor
 ---
 
 Visualize the amount of overlapping annotations

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -91,7 +91,6 @@ describe('commands', () => {
         id: '1',
         from: 3,
         to: 13,
-        text: '<IGNORE>>',
       },
     ]);
 

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -10,21 +10,23 @@ function create(options?: AnnotationOptions) {
 }
 
 describe('commands', () => {
-  const {
-    add,
-    view,
-    nodes: { p, doc },
-    commands,
-  } = create();
-
   it('#addAnnotation', () => {
+    const {
+      add,
+      view,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
     add(doc(p('An <start>important<end> note')));
     commands.addAnnotation({ id: '1' });
 
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
       <p>
         An
-        <span class="selection annotation">
+        <span class="selection"
+              style="background: rgb(215, 215, 255);"
+        >
           important
         </span>
         note
@@ -33,6 +35,13 @@ describe('commands', () => {
   });
 
   it('#updateAnnotation', () => {
+    const {
+      add,
+      view,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
     const id = '1';
 
     add(doc(p('An <start>important<end> note')));
@@ -42,7 +51,9 @@ describe('commands', () => {
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
       <p>
         An
-        <span class="selection annotation">
+        <span class="selection"
+              style="background: rgb(215, 215, 255);"
+        >
           important
         </span>
         note
@@ -56,7 +67,9 @@ describe('commands', () => {
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
       <p>
         An
-        <span class="selection annotation updated">
+        <span class="selection updated"
+              style="background: rgb(215, 215, 255);"
+        >
           important
         </span>
         note
@@ -65,6 +78,13 @@ describe('commands', () => {
   });
 
   it('#setAnnotations', () => {
+    const {
+      add,
+      view,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
     add(doc(p('An important note')));
     commands.setAnnotations([
       {
@@ -78,7 +98,7 @@ describe('commands', () => {
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
           <p>
             An
-            <span class="annotation">
+            <span style="background: rgb(215, 215, 255);">
               important
             </span>
             note
@@ -87,6 +107,13 @@ describe('commands', () => {
   });
 
   it('#removeAnnotation', () => {
+    const {
+      add,
+      view,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
     const id = '1';
 
     add(doc(p('An <start>important<end> note')));
@@ -95,7 +122,9 @@ describe('commands', () => {
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
       <p>
         An
-        <span class="selection annotation">
+        <span class="selection"
+              style="background: rgb(215, 215, 255);"
+        >
           important
         </span>
         note
@@ -107,7 +136,9 @@ describe('commands', () => {
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
       <p>
         An
-        <span class="selection">
+        <span class="selection"
+              style
+        >
           important
         </span>
         note
@@ -117,26 +148,6 @@ describe('commands', () => {
 });
 
 describe('styling', () => {
-  it('options', () => {
-    const {
-      add,
-      view: { dom },
-      nodes: { p, doc },
-      commands,
-    } = create({ annotationClassName: 'test-class-name' });
-
-    add(doc(p('<start>Hello<end>')));
-    commands.addAnnotation({ id: '1' });
-
-    expect(dom.innerHTML).toMatchInlineSnapshot(`
-      <p>
-        <span class="selection test-class-name">
-          Hello
-        </span>
-      </p>
-    `);
-  });
-
   it('annotation-specific classname', () => {
     const {
       add,
@@ -150,7 +161,9 @@ describe('styling', () => {
 
     expect(dom.innerHTML).toMatchInlineSnapshot(`
       <p>
-        <span class="selection annotation custom-annotation">
+        <span class="selection custom-annotation"
+              style="background: rgb(215, 215, 255);"
+        >
           Hello
         </span>
       </p>
@@ -260,13 +273,19 @@ describe('custom annotations', () => {
 
     expect(dom.innerHTML).toMatchInlineSnapshot(`
       <p>
-        <span class="annotation">
+        <span class
+              style="background: rgb(215, 215, 255);"
+        >
           Hell
         </span>
-        <span class="annotation selection custom">
+        <span class="selection custom"
+              style="background: rgb(175, 175, 255);"
+        >
           o
         </span>
-        <span class="selection annotation custom">
+        <span class="selection custom"
+              style="background: rgb(215, 215, 255);"
+        >
           my frie
         </span>
         nd

--- a/packages/@remirror/extension-annotation/src/__tests__/segments.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/segments.spec.ts
@@ -1,0 +1,123 @@
+import { toSegments } from '../segments';
+import type { Annotation } from '../types';
+
+let idCounter = 0;
+
+function createAnnotation(from: number, to: number): Annotation {
+  return {
+    id: `a-${idCounter++}`,
+    from,
+    to,
+    text: '-',
+  };
+}
+
+describe('#toSegments', () => {
+  it('creates segment for single annotation', () => {
+    const annotation1 = createAnnotation(2, 4);
+
+    const segments = toSegments([annotation1]);
+
+    expect(segments).toEqual([
+      {
+        from: 2,
+        to: 4,
+        annotations: [annotation1],
+      },
+    ]);
+  });
+
+  it('creates segments for non-overlapping annotations', () => {
+    const annotation1 = createAnnotation(2, 4);
+    const annotation2 = createAnnotation(6, 8);
+
+    const segments = toSegments([annotation1, annotation2]);
+
+    expect(segments).toEqual([
+      {
+        from: 2,
+        to: 4,
+        annotations: [annotation1],
+      },
+      {
+        from: 6,
+        to: 8,
+        annotations: [annotation2],
+      },
+    ]);
+  });
+
+  it('creates segments for overlapping annotations', () => {
+    const annotation1 = createAnnotation(2, 4);
+    const annotation2 = createAnnotation(3, 5);
+
+    const segments = toSegments([annotation1, annotation2]);
+
+    expect(segments).toEqual([
+      {
+        from: 2,
+        to: 3,
+        annotations: [annotation1],
+      },
+      {
+        from: 3,
+        to: 4,
+        annotations: [annotation1, annotation2],
+      },
+      {
+        from: 4,
+        to: 5,
+        annotations: [annotation2],
+      },
+    ]);
+  });
+
+  it('returns empty for no annotations', () => {
+    expect(toSegments([])).toEqual([]);
+  });
+
+  it('creates segment for annotation at begin of content', () => {
+    const annotation1 = createAnnotation(0, 2);
+
+    const segments = toSegments([annotation1]);
+
+    expect(segments).toEqual([
+      {
+        from: 0,
+        to: 2,
+        annotations: [annotation1],
+      },
+    ]);
+  });
+
+  it('creates segments for multiple overlapping annotations', () => {
+    const annotation1 = createAnnotation(2, 4);
+    const annotation2 = createAnnotation(3, 5);
+    const annotation3 = createAnnotation(4, 6);
+
+    const segments = toSegments([annotation1, annotation2, annotation3]);
+
+    expect(segments).toEqual([
+      {
+        from: 2,
+        to: 3,
+        annotations: [annotation1],
+      },
+      {
+        from: 3,
+        to: 4,
+        annotations: [annotation1, annotation2],
+      },
+      {
+        from: 4,
+        to: 5,
+        annotations: [annotation2, annotation3],
+      },
+      {
+        from: 5,
+        to: 6,
+        annotations: [annotation3],
+      },
+    ]);
+  });
+});

--- a/packages/@remirror/extension-annotation/src/actions.ts
+++ b/packages/@remirror/extension-annotation/src/actions.ts
@@ -1,4 +1,4 @@
-import type { Annotation, AnnotationData } from './types';
+import type { Annotation, AnnotationData, AnnotationWithoutText } from './types';
 
 export enum ActionType {
   ADD_ANNOTATION,
@@ -27,5 +27,5 @@ export interface RemoveAnnotationsAction {
 
 export interface SetAnnotationsAction<A extends Annotation> {
   type: ActionType.SET_ANNOTATIONS;
-  annotations: A[];
+  annotations: Array<AnnotationWithoutText<A>>;
 }

--- a/packages/@remirror/extension-annotation/src/annotation-plugin.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-plugin.ts
@@ -1,0 +1,106 @@
+import type { TransactionParameter } from '@remirror/core';
+import { Decoration, DecorationSet } from '@remirror/pm/view';
+
+import {
+  ActionType,
+  AddAnnotationAction,
+  RemoveAnnotationsAction,
+  SetAnnotationsAction,
+  UpdateAnnotationAction,
+} from './actions';
+import { toSegments } from './segments';
+import type { Annotation, AnnotationWithoutText, GetStyle } from './types';
+
+interface ApplyParameter extends TransactionParameter {
+  action: any;
+}
+
+export class AnnotationState<A extends Annotation = Annotation> {
+  annotations: Array<AnnotationWithoutText<A>> = [];
+
+  /**
+   * Decorations are computed based on the annotations. The state contains a
+   * copy of the decoration for performance optimization.
+   */
+  decorationSet = DecorationSet.empty;
+
+  constructor(private getStyle: GetStyle<A>) {}
+
+  apply({ tr, action }: ApplyParameter): this {
+    const actionType = action?.type;
+
+    if (!action && !tr.docChanged) {
+      return this;
+    }
+
+    // Adjust annotation positions based on changes in the editor, e.g.
+    // if new text was added before the decoration
+    this.annotations = this.annotations.map((annotation) => ({
+      ...annotation,
+      from: tr.mapping.map(annotation.from),
+      to: tr.mapping.map(annotation.to),
+    }));
+
+    let newAnnotations: Array<AnnotationWithoutText<A>> | undefined;
+
+    if (actionType === ActionType.ADD_ANNOTATION) {
+      const addAction = action as AddAnnotationAction<A>;
+      const newAnnotation = {
+        ...addAction.annotationData,
+        from: addAction.from,
+        to: addAction.to,
+      } as AnnotationWithoutText<A>;
+      newAnnotations = this.annotations.concat(newAnnotation);
+    }
+
+    if (actionType === ActionType.UPDATE_ANNOTATION) {
+      const updateAction = action as UpdateAnnotationAction<A>;
+      const annotationIndex = this.annotations.findIndex(
+        (annotation) => annotation.id === updateAction.annotationId,
+      );
+      const updatedAnnotation = {
+        ...this.annotations[annotationIndex],
+        ...updateAction.annotationData,
+      };
+      newAnnotations = [
+        ...this.annotations.slice(0, annotationIndex),
+        updatedAnnotation,
+        ...this.annotations.slice(annotationIndex + 1),
+      ];
+    }
+
+    if (actionType === ActionType.REMOVE_ANNOTATIONS) {
+      const removeAction = action as RemoveAnnotationsAction;
+      newAnnotations = this.annotations.filter((a) => !removeAction.annotationIds.includes(a.id));
+    }
+
+    if (actionType === ActionType.SET_ANNOTATIONS) {
+      const setAction = action as SetAnnotationsAction<A>;
+      newAnnotations = setAction.annotations;
+    }
+
+    if (newAnnotations) {
+      // Recalculate decorations when annotations changed
+      const decos = toSegments(newAnnotations).map((segment) => {
+        const classNames = segment.annotations
+          .map((a) => a.className)
+          .filter((className) => className);
+        const style = this.getStyle(segment.annotations);
+
+        return Decoration.inline(segment.from, segment.to, {
+          class: classNames.length > 0 ? classNames.join(' ') : undefined,
+          style,
+        });
+      });
+
+      this.annotations = newAnnotations;
+      this.decorationSet = DecorationSet.create(tr.doc, decos);
+    } else {
+      // Performance optimization: Adjust decoration positions based on changes
+      // in the editor, e.g. if new text was added before the decoration
+      this.decorationSet = this.decorationSet.map(tr.mapping, tr.doc);
+    }
+
+    return this;
+  }
+}

--- a/packages/@remirror/extension-annotation/src/segments.ts
+++ b/packages/@remirror/extension-annotation/src/segments.ts
@@ -1,0 +1,93 @@
+import type { Annotation } from './types';
+
+/**
+ * Reflects one non-overlapping segment
+ */
+export interface Segment<A extends Annotation> {
+  from: number;
+  to: number;
+  annotations: Array<AnnotationWithoutText<A>>;
+}
+
+interface Item<A extends Annotation> {
+  type: 'start' | 'end';
+  annotation: AnnotationWithoutText<A>;
+}
+
+type AnnotationWithoutText<A extends Annotation> = Omit<A, 'text'>;
+/**
+ * Creates non-overlapping segments based on overlapping annotations.
+ *
+ * Prosemirror combines overlapping inline decorations by creating
+ * segments in which the props of each overlapping decoration
+ * are merged.
+ * The Prosemirror approach doesn't allow to calculate styles based
+ * on multiple annotations, e.g. a darker background shade if there
+ * are multiple annotations.
+ * To overcome this limitations, this method calculates non-overlapping
+ * segments with overlapping annotations. These segments can be used
+ * to create Prosemirror decorations with a style that reflects all
+ * all annotations within the segment.
+ *
+ * Approach was confirmed by Marijn: https://discuss.prosemirror.net/t/how-to-style-overlapping-inline-decorations/3162
+ */
+export function toSegments<A extends Annotation>(
+  annotations: Array<AnnotationWithoutText<A>>,
+): Array<Segment<A>> {
+  // Create index of start/end annotations per index
+  const indexItems = annotations.reduce(
+    (acc, annotation) => ({
+      ...acc,
+      [annotation.from]: (acc[annotation.from] || []).concat({
+        type: 'start',
+        annotation,
+      }),
+      [annotation.to]: (acc[annotation.to] || []).concat({
+        type: 'end',
+        annotation,
+      }),
+    }),
+    {} as { [key: string]: Array<Item<A>> },
+  );
+
+  // Tracks the annotations active in the currently analyzed segment
+  let activeAnnotations: Array<AnnotationWithoutText<A>> = [];
+  // Tracks the last from state
+  let from = 0;
+  return (
+    Object.keys(indexItems)
+      // Sort nummerically
+      .sort((index1, index2) => Number(index1) - Number(index2))
+      .reduce((acc, index) => {
+        // Find starting/ending annotations for current index
+        const items = indexItems[index];
+        const startingAnnotations = items
+          .filter((item) => item.type === 'start')
+          .map((item) => item.annotation);
+        const endingAnnotationIds = new Set(
+          items.filter((item) => item.type === 'end').map((item) => item.annotation.id),
+        );
+
+        const indexAsNumber = Number(index);
+
+        // Create segment if there are any active annotations
+        if (activeAnnotations.length > 0) {
+          const segment = {
+            from,
+            to: indexAsNumber,
+            annotations: activeAnnotations,
+          };
+          acc.push(segment);
+        }
+
+        from = indexAsNumber;
+
+        // Update active annotations based on starting/ending annotations
+        activeAnnotations = activeAnnotations
+          .concat(...startingAnnotations)
+          .filter((a) => !endingAnnotationIds.has(a.id));
+
+        return acc;
+      }, [] as Array<Segment<A>>)
+  );
+}

--- a/packages/@remirror/extension-annotation/src/types.ts
+++ b/packages/@remirror/extension-annotation/src/types.ts
@@ -1,14 +1,16 @@
-export interface AnnotationOptions {
+export type GetStyle<A extends Annotation> = (
+  annotations: Array<AnnotationWithoutText<A>>,
+) => string | undefined;
+export interface AnnotationOptions<A extends Annotation = Annotation> {
   /**
-   * Class name to set for all annotations.
+   * Method to calculate styles for a segment with one or more annotations
    *
    * @remarks
    *
-   * Set this option to use a custom style for
-   * annotation. Note that you can style additionally individual annotations via
-   * Annotation.className.
+   * This can be used e.g. to assign different shades of a color depending on
+   * the amount of annotations in a segment.
    */
-  annotationClassName?: string;
+  getStyle?: GetStyle<A>;
 }
 
 export interface Annotation {
@@ -41,7 +43,9 @@ export interface Annotation {
   className?: string;
 }
 
+export type AnnotationWithoutText<A extends Annotation> = Omit<A, 'text'>;
+
 /**
  * Annotation without the fields managed by Prosemirror
  */
-export type AnnotationData<A extends Annotation> = Omit<A, 'from' | 'to' | 'text'>;
+export type AnnotationData<A extends Annotation> = Omit<AnnotationWithoutText<A>, 'from' | 'to'>;

--- a/packages/@remirror/extension-annotation/src/utils.ts
+++ b/packages/@remirror/extension-annotation/src/utils.ts
@@ -7,17 +7,16 @@ interface ToDecorationOptions<A extends Annotation> {
   from: number;
   to: number;
   annotationData: AnnotationData<A>;
-  annotationClassName: string;
 }
 export function toDecoration<A extends Annotation>(options: ToDecorationOptions<A>): Decoration {
   const { annotationData: annotation } = options;
 
-  // Mixes extension-level styling for all annotations with annotation-specific styling
-  const combinedClassName = [options.annotationClassName, annotation.className]
-    .filter((className) => className)
-    .join(' ');
-
-  return Decoration.inline(options.from, options.to, { class: combinedClassName }, { annotation });
+  return Decoration.inline(
+    options.from,
+    options.to,
+    { class: annotation.className },
+    { annotation },
+  );
 }
 
 interface ToAnnotationOptions {

--- a/support/storybook/stories/annotation.stories.tsx
+++ b/support/storybook/stories/annotation.stories.tsx
@@ -1,0 +1,61 @@
+import React, { FC, useEffect } from 'react';
+import { AnnotationExtension } from 'remirror/extension/annotation';
+import { RemirrorProvider, useManager, useRemirror } from 'remirror/react';
+
+export default { title: 'Editor with annotation' };
+
+const SAMPLE_TEXT = 'This is a sample text';
+
+const SmallEditor: FC = () => {
+  const { getRootProps, setContent, commands } = useRemirror();
+
+  useEffect(() => {
+    setContent({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: SAMPLE_TEXT,
+            },
+          ],
+        },
+      ],
+    });
+    commands.setAnnotations([
+      {
+        id: 'a-1',
+        from: 1,
+        to: SAMPLE_TEXT.length + 1,
+      },
+      {
+        id: 'a-2',
+        from: 9,
+        to: SAMPLE_TEXT.length + 1,
+      },
+      {
+        id: 'a-3',
+        from: 11,
+        to: 17,
+      },
+    ]);
+  }, [setContent, commands]);
+
+  return (
+    <div>
+      <div {...getRootProps()} />
+    </div>
+  );
+};
+
+export const Basic = () => {
+  const extensionManager = useManager([new AnnotationExtension()]);
+
+  return (
+    <RemirrorProvider manager={extensionManager}>
+      <SmallEditor />
+    </RemirrorProvider>
+  );
+};


### PR DESCRIPTION
### Description

The annotation-extension would allow to style individual annotations via a CSS class. This led to issues with overlapping annotations. For example, if an annotation with a red background and another with a green background were overlapping, the editor would show (more or less) randomly one of the two colors.
Now, the annotation-extension allows users to style decorations based on all overlapping annotations within a given decoration. The default implementation visualizes overlapping annotations by showing a darker shade the more annotations are overlapping.
 
The approach was confirmed by Marijn: https://discuss.prosemirror.net/t/how-to-style-overlapping-inline-decorations/3162

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/9339055/93930585-e79e1f80-fd1d-11ea-8cc0-bc727b470083.png)
