### PR TITLE
Support custom annotations for custom styling

### DIFF
--- a/.changeset/rare-chefs-eat.md
+++ b/.changeset/rare-chefs-eat.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Support custom annotations for custom styling (typing)

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -316,7 +316,7 @@ describe('custom styling', () => {
 
     expect(dom.innerHTML).toMatchInlineSnapshot(`
       <p>
-        <span class
+        <span class="selection"
               style="background: red;"
         >
           Hello

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -292,3 +292,37 @@ describe('custom annotations', () => {
     `);
   });
 });
+
+describe('custom styling', () => {
+  interface ColoredAnnotation extends Annotation {
+    color: string;
+  }
+
+  it('should use custom styling', () => {
+    const getStyle = (annotations: Array<Omit<ColoredAnnotation, 'text'>>) => {
+      return `background: ${annotations[0].color}`;
+    };
+
+    const {
+      dom,
+      add,
+      nodes: { p, doc },
+      commands,
+    } = renderEditor([new AnnotationExtension<ColoredAnnotation>({ getStyle })]);
+
+    add(doc(p('<start>Hello<end> my friend')));
+
+    commands.addAnnotation({ id: '1', color: 'red' });
+
+    expect(dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <span class
+              style="background: red;"
+        >
+          Hello
+        </span>
+        my friend
+      </p>
+    `);
+  });
+});

--- a/packages/@remirror/extension-annotation/src/annotation-extension.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-extension.ts
@@ -34,14 +34,14 @@ function defaultGetStyle<A extends Annotation>(annotations: Array<AnnotationWith
  * Extend the Annotation interface to store application specific
  * information like tags or color.
  */
-@extensionDecorator<AnnotationOptions>({
+@extensionDecorator<AnnotationOptions<Annotation>>({
   defaultOptions: {
     getStyle: defaultGetStyle,
   },
   defaultPriority: ExtensionPriority.Low,
 })
 export class AnnotationExtension<A extends Annotation = Annotation> extends PlainExtension<
-  AnnotationOptions
+  AnnotationOptions<A>
 > {
   get name() {
     return 'annotation' as const;
@@ -50,8 +50,8 @@ export class AnnotationExtension<A extends Annotation = Annotation> extends Plai
   /**
    * Create the custom code block plugin which handles the delete key amongst other things.
    */
-  createPlugin(): CreatePluginReturn<AnnotationState> {
-    const pluginState = new AnnotationState(this.options.getStyle);
+  createPlugin(): CreatePluginReturn<AnnotationState<A>> {
+    const pluginState = new AnnotationState<A>(this.options.getStyle);
 
     return {
       state: {


### PR DESCRIPTION
### Description

The styling method `getStyle` could already handle custom annotations, e.g. annotations that contain a custom `color` property. Yet, the Typescript declaration didn't expose this.

This PR exposes the functionality via Typescript and adds a test case, demonstrating how to use it.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
