### PR TITLE
Various small changes

### DIFF
--- a/.changeset/nice-mugs-smash.md
+++ b/.changeset/nice-mugs-smash.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': major
+---
+
+**BREAKING:** 💥 Rename `Remirror.All` to `Remirror.AllExtensionUnion`.

--- a/.changeset/popular-frogs-count.md
+++ b/.changeset/popular-frogs-count.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': major
+---
+
+🎉 Add `findPositionerTracker`, `findAllPositionTrackers` and `isSelectionEmpty` to builtin helpers.

--- a/.changeset/quick-rings-jump.md
+++ b/.changeset/quick-rings-jump.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react': patch
+---
+
+Add `Remirror.AllExtensionUnion` to the `useRemirror` hook. Now the commands and helpers for all extensions should automatically discover their API's.

--- a/.changeset/young-schools-remain.md
+++ b/.changeset/young-schools-remain.md
@@ -1,0 +1,5 @@
+---
+'multishift': patch
+---
+
+Fix global types not being imported automatically when consuming `multishift`.

--- a/docs/concepts/error-handling.md
+++ b/docs/concepts/error-handling.md
@@ -37,13 +37,9 @@ const EditorWrapper = () => {
     return transformers.remove(json, invalidContent);
   }, []);
 
-  const manager = useManager([new WysiwygPreset()]);
+  const manager = useManager([new WysiwygPreset()], { onError });
 
-  return (
-    <RemirrorProvider manager={manager} onError={onError}>
-      <div />
-    </RemirrorProvider>
-  );
+  return <RemirrorProvider manager={manager} />;
 };
 ```
 

--- a/packages/@remirror/core/src/builtins/builtin-preset.ts
+++ b/packages/@remirror/core/src/builtins/builtin-preset.ts
@@ -148,6 +148,6 @@ declare global {
       | KeymapExtension
       | PersistentSelectionExtension;
 
-    type All = ValueOf<AllExtensions>;
+    type AllExtensionUnion = ValueOf<AllExtensions>;
   }
 }

--- a/packages/@remirror/core/src/builtins/helpers-extension.ts
+++ b/packages/@remirror/core/src/builtins/helpers-extension.ts
@@ -1,7 +1,7 @@
 import { ErrorConstant, ExtensionPriority } from '@remirror/core-constants';
 import { entries, object } from '@remirror/core-helpers';
 import type { AnyFunction, EmptyShape, ProsemirrorAttributes, Value } from '@remirror/core-types';
-import { isMarkActive, isNodeActive } from '@remirror/core-utils';
+import { isMarkActive, isNodeActive, isSelectionEmpty } from '@remirror/core-utils';
 
 import { extensionDecorator } from '../decorators';
 import {
@@ -74,7 +74,12 @@ export class HelpersExtension extends PlainExtension {
   }
 
   createHelpers() {
-    return {};
+    return {
+      /**
+       * Check whether the selection is empty.
+       */
+      isSelectionEmpty: () => isSelectionEmpty(this.store.view.state),
+    };
   }
 }
 

--- a/packages/@remirror/core/src/extension/extension-base.ts
+++ b/packages/@remirror/core/src/extension/extension-base.ts
@@ -712,7 +712,7 @@ declare global {
    */
   namespace Remirror {
     /**
-     * This interface is used to store all the currently installed extensions.
+     * This interface stores all the currently installed extensions.
      * As a result it can be used to set the default loaded extensions to
      * include all available within `node_modules`. By extending this extension
      * in the global `Remirror` namespace the key is ignored but the value is

--- a/packages/@remirror/react/src/hooks/editor-hooks.ts
+++ b/packages/@remirror/react/src/hooks/editor-hooks.ts
@@ -25,7 +25,6 @@ import { I18nContext, RemirrorContext } from '../react-contexts';
 import { createReactManager } from '../react-helpers';
 import type {
   CreateReactManagerOptions,
-  DefaultReactCombined,
   I18nContextProps,
   ReactCombinedUnion,
   ReactFrameworkOutput,
@@ -109,7 +108,7 @@ import { useEffectWithWarning, useForceUpdate } from './core-hooks';
  * In this case the component only re-renders when the bold formatting is no
  * longer active.
  */
-export function useRemirror<Combined extends AnyCombinedUnion = DefaultReactCombined>(
+export function useRemirror<Combined extends AnyCombinedUnion = Remirror.AllExtensionUnion>(
   handler?: RemirrorEventListener<Combined> | { autoUpdate: boolean },
 ): ReactFrameworkOutput<Combined> {
   // This is not null when rendering within the `RemirrorProvider`. The majority

--- a/packages/multishift/src/index.ts
+++ b/packages/multishift/src/index.ts
@@ -2,6 +2,7 @@ export type { SpecialKey, DropdownType } from './multishift-constants';
 export { Type, MultishiftActionTypes } from './multishift-constants';
 
 export { useMultishift } from './multishift';
+export { Actions } from './multishift-action-creators';
 
 export type {
   A11yStatusMessageParameter,

--- a/packages/multishift/src/multishift-action-creators.ts
+++ b/packages/multishift/src/multishift-action-creators.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { MultishiftActionTypes } from './multishift-constants';
 import type {
   CreateMultishiftAction,
@@ -19,200 +20,293 @@ export interface ItemsPayload<Item = any> {
 /**
  * Select the provided items.
  */
-export const selectItems = <Item = any>(items: Item[], keepHighlights = false) => ({
-  type: MultishiftActionTypes.SelectItems,
-  payload: { items, keepHighlights },
-});
+function selectItems<Item = any>(items: Item[], keepHighlights = false) {
+  return {
+    type: MultishiftActionTypes.SelectItems,
+    payload: { items, keepHighlights },
+  };
+}
 
 /**
  * Select the provided item.
  */
-export const selectItem = <Item = any>(item: Item, keepHighlights = false) => ({
-  type: MultishiftActionTypes.SelectItem,
-  payload: { items: [item], keepHighlights },
-});
+function selectItem<Item = any>(item: Item, keepHighlights = false) {
+  return {
+    type: MultishiftActionTypes.SelectItem,
+    payload: { items: [item], keepHighlights },
+  };
+}
 
 /**
  * Remove the provided items from the current selection.
  */
-export const removeSelectedItems = <Item = any>(items: Item[], keepHighlights = false) => ({
-  type: MultishiftActionTypes.RemoveSelectedItems,
-  payload: { items, keepHighlights },
-});
+function removeSelectedItems<Item = any>(items: Item[], keepHighlights = false) {
+  return {
+    type: MultishiftActionTypes.RemoveSelectedItems,
+    payload: { items, keepHighlights },
+  };
+}
 
 /**
  * Remove the provided item from the current selection.
  */
-export const removeSelectedItem = <Item = any>(item: Item, keepHighlights = false) => ({
-  type: MultishiftActionTypes.RemoveSelectedItem,
-  payload: { items: [item], keepHighlights },
-});
+function removeSelectedItem<Item = any>(item: Item, keepHighlights = false) {
+  return {
+    type: MultishiftActionTypes.RemoveSelectedItem,
+    payload: { items: [item], keepHighlights },
+  };
+}
 
 /**
  * Remove the provided item from the current selection.
  */
-export const clearSelection = () => ({
-  type: MultishiftActionTypes.ClearSelection,
-});
+function clearSelection() {
+  return {
+    type: MultishiftActionTypes.ClearSelection,
+  };
+}
 
 /**
  * Set the `hoverIndex` to a certain value.
  */
-export const setHoverItemIndex = (payload: number) => ({
-  type: MultishiftActionTypes.SetHoverItemIndex,
-  payload,
-});
+function setHoverItemIndex(payload: number) {
+  return {
+    type: MultishiftActionTypes.SetHoverItemIndex,
+    payload,
+  };
+}
 
 /**
  * Toggle the `isOpen` status of the menu.
  */
-export const toggleMenu = () => ({
-  type: MultishiftActionTypes.ToggleMenu,
-});
+function toggleMenu() {
+  return {
+    type: MultishiftActionTypes.ToggleMenu,
+  };
+}
 
 /**
  * Set isOpen to false (closing the menu).
  */
-export const closeMenu = () => ({
-  type: MultishiftActionTypes.CloseMenu,
-});
+function closeMenu() {
+  return {
+    type: MultishiftActionTypes.CloseMenu,
+  };
+}
 
 /**
  * Set `isOpen` to true (opening the menu).
  */
-export const openMenu = () => ({
-  type: MultishiftActionTypes.OpenMenu,
-});
+function openMenu() {
+  return {
+    type: MultishiftActionTypes.OpenMenu,
+  };
+}
 
 /**
  * Set the highlighted item indexes.
  */
-export const setHighlightedIndexes = (payload: number[]) => ({
-  type: MultishiftActionTypes.SetHighlightedIndexes,
-  payload,
-});
+function setHighlightedIndexes(payload: number[]) {
+  return {
+    type: MultishiftActionTypes.SetHighlightedIndexes,
+    payload,
+  };
+}
 
 /**
  * Set the highlighted item index.
  */
-export const setHighlightedIndex = (index: number) => ({
-  type: MultishiftActionTypes.SetHighlightedIndex,
-  payload: [index],
-});
+function setHighlightedIndex(index: number) {
+  return {
+    type: MultishiftActionTypes.SetHighlightedIndex,
+    payload: [index],
+  };
+}
 
 /**
  * Removes all the highlighted items including the hover.
  */
-export const clearHighlighted = () => ({
-  type: MultishiftActionTypes.ClearHighlighted,
-});
+function clearHighlighted() {
+  return {
+    type: MultishiftActionTypes.ClearHighlighted,
+  };
+}
 
 /**
  * Reset the state of the reducer.
  */
-export const reset = () => ({
-  type: MultishiftActionTypes.Reset,
-});
+function reset() {
+  return {
+    type: MultishiftActionTypes.Reset,
+  };
+}
 
 /**
  * Dispatched when the mouse hovers over an item
  */
-export const itemMouseMove = (payload: number) => ({
-  type: MultishiftActionTypes.ItemMouseMove,
-  payload,
-});
+function itemMouseMove(payload: number) {
+  return {
+    type: MultishiftActionTypes.ItemMouseMove,
+    payload,
+  };
+}
 
-export const itemMouseLeave = (payload: number) => ({
-  type: MultishiftActionTypes.ItemMouseLeave,
-  payload,
-});
+function itemMouseLeave(payload: number) {
+  return {
+    type: MultishiftActionTypes.ItemMouseLeave,
+    payload,
+  };
+}
 
 /**
  * Reports when a user has clicked on an item's element.
  */
-export const itemClick = (payload: ItemClickPayload) => ({
-  type: MultishiftActionTypes.ItemClick,
-  payload,
-});
+function itemClick(payload: ItemClickPayload) {
+  return {
+    type: MultishiftActionTypes.ItemClick,
+    payload,
+  };
+}
 
 /**
  * Called when the menu is blurred.
  */
-export const menuBlur = () => ({
-  type: MultishiftActionTypes.MenuBlur,
-});
+function menuBlur() {
+  return {
+    type: MultishiftActionTypes.MenuBlur,
+  };
+}
 
-export const inputBlur = () => ({
-  type: MultishiftActionTypes.InputBlur,
-});
+function inputBlur() {
+  return {
+    type: MultishiftActionTypes.InputBlur,
+  };
+}
 
-export const toggleButtonBlur = () => ({
-  type: MultishiftActionTypes.ToggleButtonBlur,
-});
+function toggleButtonBlur() {
+  return {
+    type: MultishiftActionTypes.ToggleButtonBlur,
+  };
+}
 
 /**
  * Clears the jump text value.
  */
-export const clearJumpText = () => ({
-  type: MultishiftActionTypes.ClearJumpText,
-});
+function clearJumpText() {
+  return {
+    type: MultishiftActionTypes.ClearJumpText,
+  };
+}
 
-export const clearInputValue = () => ({
-  type: MultishiftActionTypes.ClearInputValue,
-});
+function clearInputValue() {
+  return {
+    type: MultishiftActionTypes.ClearInputValue,
+  };
+}
 
 /**
  * Dispatches the action for clicking the toggle button
  */
-export const toggleButtonClick = () => ({
-  type: MultishiftActionTypes.ToggleButtonClick,
-});
+function toggleButtonClick() {
+  return {
+    type: MultishiftActionTypes.ToggleButtonClick,
+  };
+}
 
-export const outerTouchEnd = () => ({
-  type: MultishiftActionTypes.OuterTouchEnd,
-});
+function outerTouchEnd() {
+  return {
+    type: MultishiftActionTypes.OuterTouchEnd,
+  };
+}
 
-export const outerMouseUp = () => ({
-  type: MultishiftActionTypes.OuterMouseUp,
-});
+function outerMouseUp() {
+  return {
+    type: MultishiftActionTypes.OuterMouseUp,
+  };
+}
 
 /**
  * Handle the menu key down event.
  */
-export const menuSpecialKeyDown = (payload: SpecialKeyDownPayload) => ({
-  type: MultishiftActionTypes.MenuSpecialKeyDown,
-  payload,
-});
+function menuSpecialKeyDown(payload: SpecialKeyDownPayload) {
+  return {
+    type: MultishiftActionTypes.MenuSpecialKeyDown,
+    payload,
+  };
+}
 
-export const toggleButtonSpecialKeyDown = (payload: SpecialKeyDownPayload) => ({
-  type: MultishiftActionTypes.ToggleButtonSpecialKeyDown,
-  payload,
-});
+function toggleButtonSpecialKeyDown(payload: SpecialKeyDownPayload) {
+  return {
+    type: MultishiftActionTypes.ToggleButtonSpecialKeyDown,
+    payload,
+  };
+}
 
-export const inputSpecialKeyDown = (payload: SpecialKeyDownPayload) => ({
-  type: MultishiftActionTypes.InputSpecialKeyDown,
-  payload,
-});
+function inputSpecialKeyDown(payload: SpecialKeyDownPayload) {
+  return {
+    type: MultishiftActionTypes.InputSpecialKeyDown,
+    payload,
+  };
+}
 
-export const menuCharacterKeyDown = (payload: string) => ({
-  type: MultishiftActionTypes.MenuCharacterKeyDown,
-  payload,
-});
+function menuCharacterKeyDown(payload: string) {
+  return {
+    type: MultishiftActionTypes.MenuCharacterKeyDown,
+    payload,
+  };
+}
 
-// export const toggleButtonCharacterKeyDown = (payload: string) => ({
-//   type: MultishiftActionTypes.ToggleButtonCharacterKeyDown,
-//   payload,
-// });
+function inputValueChange(payload: string) {
+  return {
+    type: MultishiftActionTypes.InputValueChange,
+    payload,
+  };
+}
 
-export const inputValueChange = (payload: string) => ({
-  type: MultishiftActionTypes.InputValueChange,
-  payload,
-});
+function setState<Item = any>(payload: MultishiftStateProps<Item>) {
+  return {
+    type: MultishiftActionTypes.SetState,
+    payload,
+  };
+}
 
-export const setState = <Item = any>(payload: MultishiftStateProps<Item>) => ({
-  type: MultishiftActionTypes.SetState,
-  payload,
-});
+/* eslint-enable @typescript-eslint/explicit-module-boundary-types */
+
+/**
+ * The action creators which can be dispatched via the reducer.
+ */
+export const Actions = {
+  itemMouseMove,
+  itemMouseLeave,
+  itemClick,
+  menuBlur,
+  toggleButtonBlur,
+  inputBlur,
+  toggleButtonClick,
+  menuSpecialKeyDown,
+  toggleButtonSpecialKeyDown,
+  inputSpecialKeyDown,
+  menuCharacterKeyDown,
+  outerTouchEnd,
+  outerMouseUp,
+  selectItems,
+  selectItem,
+  removeSelectedItems,
+  removeSelectedItem,
+  setState,
+  clearSelection,
+  setHoverItemIndex,
+  inputValueChange,
+  clearInputValue,
+  toggleMenu,
+  closeMenu,
+  openMenu,
+  setHighlightedIndexes,
+  setHighlightedIndex,
+  clearHighlighted,
+  reset,
+  clearJumpText,
+};
 
 declare global {
   namespace Multishift {
@@ -232,7 +326,6 @@ declare global {
       toggleButtonSpecialKeyDown: typeof toggleButtonSpecialKeyDown;
       inputSpecialKeyDown: typeof inputSpecialKeyDown;
       menuCharacterKeyDown: typeof menuCharacterKeyDown;
-      // toggleButtonCharacterKeyDown: typeof toggleButtonCharacterKeyDown;
       outerTouchEnd: typeof outerTouchEnd;
       outerMouseUp: typeof outerMouseUp;
     }

--- a/packages/multishift/src/multishift-types.ts
+++ b/packages/multishift/src/multishift-types.ts
@@ -125,8 +125,8 @@ export interface ActionCreatorsMapObject<A = any> {
   [key: string]: ActionCreator<A>;
 }
 
-export type ActionCreatorMapToDispatch<GCreatorMap extends ActionCreatorsMapObject> = {
-  [P in keyof GCreatorMap]: (...args: Parameters<GCreatorMap[P]>) => void;
+export type ActionCreatorMapToDispatch<CreatorMap extends ActionCreatorsMapObject> = {
+  [P in keyof CreatorMap]: (...args: Parameters<CreatorMap[P]>) => void;
 };
 
 /**
@@ -502,8 +502,8 @@ export interface MultishiftStateChangeset<Item = any> {
 export type CreateMultishiftAction<
   Type extends string,
   Payload = any,
-  GArgs extends any[] = [Payload]
-> = (...args: GArgs) => ActionWithPayload<Type, Payload>;
+  Args extends any[] = [Payload]
+> = (...args: Args) => ActionWithPayload<Type, Payload>;
 
 export interface GetRemoveButtonOptions<Element extends HTMLElement = any, Item = any>
   extends HTMLProps<Element> {

--- a/packages/multishift/src/multishift.ts
+++ b/packages/multishift/src/multishift.ts
@@ -21,7 +21,7 @@ import {
   object,
 } from '@remirror/core-helpers';
 
-import * as MultishiftActions from './multishift-action-creators';
+import { Actions } from './multishift-action-creators';
 import {
   SPECIAL_INPUT_KEYS,
   SPECIAL_MENU_KEYS,
@@ -38,7 +38,6 @@ import {
   useTimeouts,
 } from './multishift-hooks';
 import type {
-  AllMultishiftDispatchActions,
   GetComboBoxPropsOptions,
   GetComboBoxPropsReturn,
   GetItemPropsOptions,
@@ -100,10 +99,7 @@ export const useMultishift = <Item = any>(props: MultishiftProps<Item>): Multish
     getItemId = defaultGetItemId,
   } = props;
   const [state, dispatch] = useMultishiftReducer<Item>(props);
-  const actions = useMemo(
-    () => bindActionCreators(MultishiftActions, dispatch) as AllMultishiftDispatchActions<Item>,
-    [dispatch],
-  );
+  const actions = useMemo(() => bindActionCreators(Actions, dispatch), [dispatch]);
 
   useSetA11y({ state, items, customA11yStatusMessage, getA11yStatusMessage });
 
@@ -120,8 +116,6 @@ export const useMultishift = <Item = any>(props: MultishiftProps<Item>): Multish
   } = stateProps;
 
   const { getItemA11yId, labelId, menuId, toggleButtonId, inputId } = useElementIds(props);
-
-  // const [setInternalTimeout] = useTimeouts();
 
   // Refs
   const refs = useElementRefs();


### PR DESCRIPTION
### Description

- **BREAKING:** 💥 Rename `Remirror.All` to `Remirror.AllExtensionUnion`.
- 🎉 Add `findPositionerTracker`, `findAllPositionTrackers` and `isSelectionEmpty` to builtin helpers.
- Add `Remirror.AllExtensionUnion` to the `useRemirror` hook. Now the commands and helpers for all extensions should automatically discover their API's.
- Fix global type not being imported automatically.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

