### PR TITLE
Remove annotations when their content is deleted

### DIFF
--- a/.changeset/cyan-lizards-reflect.md
+++ b/.changeset/cyan-lizards-reflect.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Remove annotations when their content is deleted
+
+Users can create annotations on pieces of content. The annotations are automatically updated as the content is moved around, e.g. if a new word is inserted before the annotation. Yet, the extension missed the case that all annotated content is deleted. Before, this would lead to an empty annotation (to and from parameter are equal). With this commit, annotations are automatically removed when the content is completed deleted.

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -155,16 +155,16 @@ describe('plugin#apply', () => {
       commands,
     } = create();
 
-    add(doc(p('<start>H<end>')));
-    commands.addAnnotation({ id: '1', className: 'custom-annotation' });
+    add(doc(p('<start>Hello<end>')));
+    commands.addAnnotation({ id: '1' });
 
     // Pre-condition
     expect(helpers.getAnnotations()).toHaveLength(1);
+
+    // Delete all annotated content
     commands.delete();
 
     expect(helpers.getAnnotations()).toHaveLength(0);
-
-    add(doc(p('<start>H<end>')));
   });
 });
 

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -146,6 +146,28 @@ describe('commands', () => {
   });
 });
 
+describe('plugin#apply', () => {
+  it('removes annotations when content is deleted', () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
+    add(doc(p('<start>H<end>')));
+    commands.addAnnotation({ id: '1', className: 'custom-annotation' });
+
+    // Pre-condition
+    expect(helpers.getAnnotations()).toHaveLength(1);
+    commands.delete();
+
+    expect(helpers.getAnnotations()).toHaveLength(0);
+
+    add(doc(p('<start>H<end>')));
+  });
+});
+
 describe('styling', () => {
   it('annotation-specific classname', () => {
     const {

--- a/packages/@remirror/extension-annotation/src/annotation-plugin.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-plugin.ts
@@ -33,13 +33,16 @@ export class AnnotationState<A extends Annotation = Annotation> {
       return this;
     }
 
-    // Adjust annotation positions based on changes in the editor, e.g.
-    // if new text was added before the decoration
-    this.annotations = this.annotations.map((annotation) => ({
-      ...annotation,
-      from: tr.mapping.map(annotation.from),
-      to: tr.mapping.map(annotation.to),
-    }));
+    this.annotations = this.annotations
+      // Adjust annotation positions based on changes in the editor, e.g.
+      // if new text was added before the decoration
+      .map((annotation) => ({
+        ...annotation,
+        from: tr.mapping.map(annotation.from),
+        to: tr.mapping.map(annotation.to),
+      }))
+      // Remove annotations for which all containing content was deleted
+      .filter((annotation) => annotation.to !== annotation.from);
 
     let newAnnotations: Array<AnnotationWithoutText<A>> | undefined;
 


### PR DESCRIPTION
### Description

Users can create annotations on pieces of content. The annotations are automatically updated as the content is moved around, e.g. if a new word is inserted before the annotation.
Yet, the extension missed the case that all annotated content is deleted. Before, this would lead to an empty annotation (to and from parameter are equal). With this commit, annotations are automatically removed when the content is completed deleted.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
