### PR TITLE
Gracefully handle annotations with positions outside the content

### DIFF
--- a/.changeset/little-crabs-beam.md
+++ b/.changeset/little-crabs-beam.md
@@ -1,0 +1,9 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Gracefully handle annotations with positions outside the content
+
+Annotations are loaded separately from the content into the editor (helpers.setAnnotations vs setContent). This can lead to situations where annotations are pointing to positions that are outside the content. For example, the editor shows content with annotations. Then, the user requests to change the content to an empty document. At this point, until helpers.setAnnotations() is called, the editor will have an empty document but still a list of annotations.
+
+At that point, helpers.getAnnotations() would throw the following error because it couldn't find the matching text for the from/to positions: TypeError: Cannot read property 'nodeSize' of undefined

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -214,7 +214,7 @@ describe('helpers', () => {
     ]);
   });
 
-  it('#getAnnotations gracefully handle misplaced annotations', () => {
+  it('#getAnnotations gracefully handles misplaced annotations', () => {
     const {
       add,
       helpers,

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -214,6 +214,26 @@ describe('helpers', () => {
     ]);
   });
 
+  it('#getAnnotations gracefully handle misplaced annotations', () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
+    add(doc(p('Hello')));
+    commands.setAnnotations([
+      {
+        id: '1',
+        from: 100,
+        to: 110,
+      },
+    ]);
+
+    expect(helpers.getAnnotations()[0].text).toBeUndefined();
+  });
+
   it('#getAnnotationsAt', () => {
     const {
       add,

--- a/packages/@remirror/extension-annotation/src/annotation-extension.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-extension.ts
@@ -161,10 +161,19 @@ export class AnnotationExtension<A extends Annotation = Annotation> extends Plai
 
   createHelpers() {
     // Enrich text at annotation
-    const enrichText = (annotation: AnnotationWithoutText<A>) => ({
-      ...annotation,
-      text: this.store.getState().doc.textBetween(annotation.from, annotation.to),
-    });
+    const enrichText = (annotation: AnnotationWithoutText<A>) => {
+      const { doc } = this.store.getState();
+      // Gracefully handle if annotations point to positions outside the content
+      // This can happen if content/annotations are set at different points.
+      const text =
+        annotation.to <= doc.content.size
+          ? doc.textBetween(annotation.from, annotation.to)
+          : undefined;
+      return {
+        ...annotation,
+        text,
+      };
+    };
 
     return {
       /**


### PR DESCRIPTION
### Description

Annotations are loaded separately from the content into the editor (`helpers.setAnnotations` vs `setContent`). This can lead to situations where annotations are pointing to positions that are outside the content. For example, the editor shows content with annotations. Then, the user requests to change the content to an empty document. At this point, until `helpers.setAnnotations()` is called, the editor will have an empty document but still a list of annotations.

At that point, `helpers.getAnnotations()` would throw the following error because it couldn't find the matching text for the from/to positions:
```
TypeError: Cannot read property 'nodeSize' of undefined
```

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
