### PR TITLE
Improve performance of `CodeBlockExtension`

### DIFF
--- a/.changeset/loud-pandas-happen.md
+++ b/.changeset/loud-pandas-happen.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-code-block': minor
+---
+
+Improve performance of the `CodeBlockExtension` by only updating syntax highlighting for the changed code block(s).

--- a/.changeset/slow-lobsters-tickle.md
+++ b/.changeset/slow-lobsters-tickle.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core-utils': minor
+---
+
+Add new helpers `getChangedRanges`, `getChangedNodeRanges` and `getChangedNodes` which take a transaction and return a list of changed ranges, node ranges or nodes with positions.
+
+This is useful for increasing the performance and only checking the parts of the document that have changed between updates.

--- a/packages/@remirror/core-utils/src/index.ts
+++ b/packages/@remirror/core-utils/src/index.ts
@@ -67,6 +67,8 @@ export {
   startPositionOfParent,
   toDom,
   toHtml,
+  getChangedRanges,
+  getChangedNodeRanges,
 } from './core-utils';
 
 export { environment } from './environment';
@@ -94,6 +96,7 @@ export {
   findChildrenByNode,
   findInlineNodes,
   findTextNodes,
+  getChangedNodes,
 } from './prosemirror-node-utils';
 
 export type {

--- a/packages/@remirror/core-utils/src/prosemirror-utils.ts
+++ b/packages/@remirror/core-utils/src/prosemirror-utils.ts
@@ -223,7 +223,7 @@ export function findElementAtPosition<Schema extends EditorSchema = EditorSchema
  *
  * ```ts
  * const predicate = node => node.type === schema.nodes.blockquote;
- * const parent = findParentNode({predicate, selection});
+ * const parent = findParentNode({ predicate, selection });
  * ```
  */
 export function findParentNode(
@@ -240,13 +240,7 @@ export function findParentNode(
       const start = $from.start(depth);
       const end = pos + node.nodeSize;
 
-      return {
-        pos,
-        depth,
-        node,
-        start,
-        end,
-      };
+      return { pos, depth, node, start, end };
     }
   }
 
@@ -265,13 +259,7 @@ export function findNodeAtPosition($pos: ResolvedPos): FindProsemirrorNodeResult
   const start = $pos.start(depth);
   const end = pos + node.nodeSize;
 
-  return {
-    pos,
-    start,
-    node,
-    end,
-    depth,
-  };
+  return { pos, start, node, end, depth };
 }
 
 /**

--- a/packages/@remirror/extension-code-block/src/code-block-extension.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-extension.ts
@@ -369,8 +369,8 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
         init(_, state) {
           return pluginState.init(state);
         },
-        apply(tr, _, oldState, newState) {
-          return pluginState.apply({ tr, oldState, newState });
+        apply(tr) {
+          return pluginState.apply(tr);
         },
       },
       props: {

--- a/packages/@remirror/extension-code-block/src/code-block-plugin.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-plugin.ts
@@ -1,33 +1,19 @@
 import {
-  CompareStateParameter,
   EditorState,
   findChildrenByNode,
-  isNodeOfType,
+  getChangedNodes,
   NodeExtension,
   NodeType,
   NodeWithPosition,
-  ProsemirrorNodeParameter,
+  ProsemirrorNode,
   Transaction,
-  TransactionParameter,
 } from '@remirror/core';
-import type { Step } from '@remirror/pm/transform';
 import { DecorationSet } from '@remirror/pm/view';
 
 import type { CodeBlockOptions } from './code-block-types';
-import {
-  createDecorations,
-  getNodeInformationFromState,
-  lengthHasChanged,
-  NodeInformation,
-  posWithinRange,
-} from './code-block-utils';
+import { createDecorations } from './code-block-utils';
 
 export class CodeBlockState {
-  /**
-   * Keep track of all document codeBlocks
-   */
-  #blocks: NodeWithPosition[] = [];
-
   #extension: NodeExtension<CodeBlockOptions>;
 
   /**
@@ -41,7 +27,7 @@ export class CodeBlockState {
   #deleted = false;
 
   /**
-   * The set of cached decorations to minimise dom updates
+   * The set of cached decorations to minimize dom updates
    */
   decorationSet!: DecorationSet;
 
@@ -53,9 +39,12 @@ export class CodeBlockState {
   /**
    * Creates the initial set of decorations
    */
-  init(state: EditorState) {
+  init(state: EditorState): this {
+    // Find all the `codeBlocks` in the editor.
     const blocks = findChildrenByNode({ node: state.doc, type: this.#type });
-    this.refreshDecorationSet({ blocks, node: state.doc });
+
+    // Update the `codeBlocks` with the relevant syntax highlighting.
+    this.refreshDecorationSet(state.doc, blocks);
 
     return this;
   }
@@ -63,94 +52,39 @@ export class CodeBlockState {
   /**
    * Recreate all the decorations again for all the provided blocks.
    */
-  private refreshDecorationSet({ blocks, node }: RefreshDecorationSetParameter) {
+  private refreshDecorationSet(doc: ProsemirrorNode, blocks: NodeWithPosition[]) {
     const decorations = createDecorations({
       blocks,
       skipLast: this.#deleted,
       defaultLanguage: this.#extension.options.defaultLanguage,
       plainTextClassName: this.#extension.options.plainTextClassName ?? undefined,
     });
-    this.decorationSet = DecorationSet.create(node, decorations);
-    this.#blocks = blocks;
+
+    // Store the decoration set to be applied to the editor by the plugin.
+    this.decorationSet = DecorationSet.create(doc, decorations);
   }
 
   /**
-   * Run through each step in the transaction and check whether the change
-   * occurred within one of the active code blocks.
-   *
-   * TODO this should actually be used to update the decorations for the blocks.
+   * Apply the state and update decorations when a change has happened in the
+   * editor.
    */
-  private numberOfChangedBlocks(steps: Step[]) {
-    let changes = 0;
-
-    // Urm yeah this is a loop within a loop within a loop and it makes my head hurt.
-    for (const { node, pos: from } of this.#blocks) {
-      let hasChanged = false;
-
-      for (const step of steps) {
-        step.getMap().forEach((oldStart, oldEnd) => {
-          const to = from + node.nodeSize;
-
-          if (
-            posWithinRange({ from, to, pos: oldStart }) ||
-            posWithinRange({ from, to, pos: oldEnd })
-          ) {
-            hasChanged = true;
-          }
-        });
-
-        if (hasChanged) {
-          break;
-        }
-      }
-
-      if (hasChanged) {
-        changes++;
-      }
-    }
-
-    return changes;
-  }
-
-  /**
-   * True when number of blocks in the document has changed.
-   */
-  private sizeHasChanged(blocks: NodeWithPosition[]) {
-    return lengthHasChanged(blocks, this.#blocks);
-  }
-
-  /**
-   * True when more than one codeBlock has changed content.
-   */
-  private multipleChangesToBlocks(blocks: NodeWithPosition[], tr: Transaction) {
-    return blocks.length > 1 && this.numberOfChangedBlocks(tr.steps) >= 2;
-  }
-
-  /**
-   * Apply the state and update decorations when something has changed.
-   */
-  apply({ tr, oldState, newState }: ApplyParameter): this {
+  apply(tr: Transaction): this {
     if (!tr.docChanged) {
       return this;
     }
 
-    // Get all the codeBlocks in the document
-    const blocks = findChildrenByNode({ node: tr.doc, type: this.#type });
-
     this.decorationSet = this.decorationSet.map(tr.mapping, tr.doc);
 
-    if (
-      // When the number of blocks has changed since the last content update
-      this.sizeHasChanged(blocks) ||
-      // When there are multiple blocks and 2 or more blocks have changed
-      this.multipleChangesToBlocks(blocks, tr)
-    ) {
-      this.refreshDecorationSet({ blocks, node: tr.doc });
-    } else {
-      const current = getNodeInformationFromState(newState);
-      const previous = getNodeInformationFromState(oldState);
-      this.manageDecorationSet({ current, previous, tr });
-    }
+    // I was thinking I would need to check for deletions, but, since the
+    // `decorationSet` is mapped over the previous change all decorations from a
+    // deleted node will automatically be deleted. All that is needed is to find
+    // the changed nodes and update their decorations.
+    const changedNodes = getChangedNodes(tr, {
+      descend: true,
+      predicate: (node) => node.type === this.#type,
+      StepTypes: [],
+    });
+    this.updateDecorationSet(tr, changedNodes);
 
     return this;
   }
@@ -159,15 +93,21 @@ export class CodeBlockState {
    * Removes all decorations which relate to the changed block node before creating new decorations
    * and adding them to the decorationSet.
    */
-  private updateDecorationSet({
-    nodeInfo: { from, to, node, pos },
-    tr,
-  }: UpdateDecorationSetParameter) {
-    const decorationSet = this.decorationSet.remove(this.decorationSet.find(from, to));
+  private updateDecorationSet(tr: Transaction, blocks: NodeWithPosition[]) {
+    if (blocks.length === 0) {
+      return;
+    }
+
+    let decorationSet = this.decorationSet;
+
+    for (const { node, pos } of blocks) {
+      decorationSet = this.decorationSet.remove(this.decorationSet.find(pos, pos + node.nodeSize));
+    }
+
     this.decorationSet = decorationSet.add(
       tr.doc,
       createDecorations({
-        blocks: [{ node, pos }],
+        blocks,
         skipLast: this.#deleted,
         defaultLanguage: this.#extension.options.defaultLanguage,
         plainTextClassName: this.#extension.options.plainTextClassName ?? undefined,
@@ -175,41 +115,10 @@ export class CodeBlockState {
     );
   }
 
-  private manageDecorationSet({ previous, current, tr }: ManageDecorationSetParameter) {
-    // Update the previous first although this could be buggy when deleting (possibly)
-    if (
-      isNodeOfType({ types: this.#type, node: previous.node }) &&
-      !previous.node.eq(current.node)
-    ) {
-      this.updateDecorationSet({ nodeInfo: previous, tr });
-    }
-
-    if (current.type === this.#type) {
-      this.updateDecorationSet({ nodeInfo: current, tr });
-    }
-  }
-
   /**
    * Flags that a deletion has just occurred.
    */
-  setDeleted(deleted: boolean) {
+  setDeleted(deleted: boolean): void {
     this.#deleted = deleted;
   }
-}
-
-interface ApplyParameter extends TransactionParameter, CompareStateParameter {}
-interface RefreshDecorationSetParameter extends ProsemirrorNodeParameter {
-  /**
-   * The positioned nodes
-   */
-  blocks: NodeWithPosition[];
-}
-
-interface ManageDecorationSetParameter extends TransactionParameter {
-  previous: NodeInformation;
-  current: NodeInformation;
-}
-
-interface UpdateDecorationSetParameter extends TransactionParameter {
-  nodeInfo: NodeInformation;
 }

--- a/packages/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-utils.ts
@@ -5,7 +5,6 @@ import {
   bool,
   CommandFunction,
   DOMOutputSpec,
-  EditorState,
   findParentNodeOfType,
   flattenArray,
   FromToParameter,
@@ -19,7 +18,6 @@ import {
   PosParameter,
   ProsemirrorAttributes,
   ProsemirrorNode,
-  ProsemirrorNodeParameter,
   TextParameter,
 } from '@remirror/core';
 import { TextSelection } from '@remirror/pm/state';
@@ -159,48 +157,6 @@ export function createDecorations(parameter: CreateDecorationsParameter): Decora
   return decorations;
 }
 
-interface PosWithinRangeParameter extends PosParameter, FromToParameter {}
-
-/**
- * Check if the position is within the range.
- */
-export function posWithinRange({ from, to, pos }: PosWithinRangeParameter): boolean {
-  return from <= pos && to >= pos;
-}
-
-/**
- * Check whether the length of an array has changed
- */
-export function lengthHasChanged<Type>(previous: ArrayLike<Type>, next: ArrayLike<Type>): boolean {
-  return next.length !== previous.length;
-}
-
-export interface NodeInformation
-  extends NodeTypeParameter,
-    FromToParameter,
-    ProsemirrorNodeParameter,
-    PosParameter {}
-
-/**
- * Retrieves helpful node information from the current state.
- */
-export function getNodeInformationFromState(state: EditorState): NodeInformation {
-  const { $head } = state.selection;
-  const depth = $head.depth;
-  const from = $head.start(depth);
-  const to = $head.end(depth);
-  const node = $head.parent;
-  const type = node.type;
-  const pos = depth > 0 ? $head.before(depth) : 0;
-  return {
-    from,
-    to,
-    type,
-    node,
-    pos,
-  };
-}
-
 /**
  * Check that the attributes exist and are valid for the codeBlock
  * updateAttributes.
@@ -281,8 +237,8 @@ export function getLanguage(parameter: GetLanguageParameter): string {
 }
 
 /**
- * Used to provide a `toDom` function for the code block for both the browser and
- * non browser environments.
+ * Used to provide a `toDom` function for the code block. Currently this only
+ * support the browser runtime.
  */
 export function codeBlockToDOM(
   node: ProsemirrorNode,


### PR DESCRIPTION
### Description

- Improve performance of the `CodeBlockExtension` by only updating syntax highlighting for the changed code block(s).

- Add new helpers `getChangedRanges`, `getChangedNodeRanges` and `getChangedNodes` which take a transaction and return a list of changed ranges, node ranges or nodes with positions.

This is useful for increasing the performance and only checking the parts of the document that have changed between updates.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

