### PR TITLE
Fix bottom value for multi-line annotations in positioner

### DIFF
--- a/.changeset/itchy-colts-tap.md
+++ b/.changeset/itchy-colts-tap.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Support multi-line annotations in positioner
+
+The annotation positioner placed the bottom on the bottom of the first line. This meant that a popup placed on the bottom would overlay the rest of a multi-line annotation. Now, the positioner returns the bottom of the last line, allowing to place the popup below all content.

--- a/packages/@remirror/extension-annotation/src/positioners.ts
+++ b/packages/@remirror/extension-annotation/src/positioners.ts
@@ -7,13 +7,16 @@ import {
 
 import type { Annotation } from './types';
 
+type MinimalAnnotation = Pick<Annotation, 'from' | 'to'> & {
+  text: string | undefined;
+};
 /**
  * You can pass `helpers.getAnnotationsAt`, which implements the required
  * behavior.
  *
  * @returns the annotations at a specific position
  */
-type GetAnnotationsAt = (pos: number) => Annotation[];
+type GetAnnotationsAt = (pos: number) => MinimalAnnotation[];
 
 /**
  * Render a positioner which is centered around a selected annotation.
@@ -54,7 +57,8 @@ export const createCenteredAnnotationPositioner = (getAnnotationsAt: GetAnnotati
       // there is the possibility that the shorter annotations aren't selectable
       // because they might be fully overlapped by the longer annotation.
       const shortestAnnotation = annotations.sort(
-        (annotation1, annotation2) => annotation1.text.length - annotation2.text.length,
+        (annotation1, annotation2) =>
+          (annotation1.text ?? '').length - (annotation2.text ?? '').length,
       )[0];
 
       const start = view.coordsAtPos(shortestAnnotation.from);

--- a/packages/@remirror/extension-annotation/src/positioners.ts
+++ b/packages/@remirror/extension-annotation/src/positioners.ts
@@ -88,7 +88,7 @@ export const createCenteredAnnotationPositioner = (getAnnotationsAt: GetAnnotati
         Math.max(calculatedLeft, elementBox.width / 2),
       );
       const top = Math.trunc(start.top - parentBox.top);
-      const bottom = Math.trunc(start.bottom - parentBox.top);
+      const bottom = Math.trunc(end.bottom - parentBox.top);
       const rect = new DOMRect(
         start.left,
         start.top,


### PR DESCRIPTION
### Description

The annotation positioner placed the bottom on the bottom of the first line. This meant that a popup placed on the bottom would overlay the rest of a multi-line annotation. Now, the positioner returns the bottom of the last line, allowing to place the popup below all content.

This commit contains also an addition to the storybook to actually see the problem (as there aren't any unit tests for positioners today).

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
