### PR TITLE
Fix: Don't extend annotation when typing at end of annotation

### DIFF
--- a/.changeset/orange-stingrays-occur.md
+++ b/.changeset/orange-stingrays-occur.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Fix: Don't extend annotation when typing at end of annotation
+
+Annotations auto-adjust as users enter content, e.g. an annotation grows if the user types in the middle of the annotation. Incorrectly, the annotation also grew when the user added content directly after the annotation. Now, this leads to new, non-annotated content.

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -166,6 +166,44 @@ describe('plugin#apply', () => {
 
     expect(helpers.getAnnotations()).toHaveLength(0);
   });
+
+  it('updates annotation when content is added within an annotation', () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
+    add(doc(p('<start>Hello<end>')));
+    commands.addAnnotation({ id: '1' });
+
+    // Pre-condition
+    expect(helpers.getAnnotations()[0].text).toEqual('Hello');
+
+    commands.insertText('ADDED', { from: 3 });
+
+    expect(helpers.getAnnotations()[0].text).toEqual('HeADDEDllo');
+  });
+
+  it("doesn't extend annotation when content is added at the end of an annotation", () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
+    add(doc(p('<start>Hello<end>')));
+    commands.addAnnotation({ id: '1' });
+
+    // Pre-condition
+    expect(helpers.getAnnotations()[0].text).toEqual('Hello');
+
+    commands.insertText('ADDED', { from: 6 });
+
+    expect(helpers.getAnnotations()[0].text).toEqual('Hello');
+  });
 });
 
 describe('styling', () => {

--- a/packages/@remirror/extension-annotation/src/annotation-plugin.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-plugin.ts
@@ -39,7 +39,9 @@ export class AnnotationState<A extends Annotation = Annotation> {
       .map((annotation) => ({
         ...annotation,
         from: tr.mapping.map(annotation.from),
-        to: tr.mapping.map(annotation.to),
+        // -1 indicates that the annotation isn't extended when the user types
+        // at the end of the annotation
+        to: tr.mapping.map(annotation.to, -1),
       }))
       // Remove annotations for which all containing content was deleted
       .filter((annotation) => annotation.to !== annotation.from);


### PR DESCRIPTION
### Description

Annotations auto-adjust as users enter content, e.g. an annotation grows if the user types in the middle of the annotation.
Incorrectly, the annotation also grew when the user added content directly after the annotation. Now, this leads to new, non-annotated content.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
