### PR TITLE
Extract text from mark range

### DIFF
--- a/.changeset/stupid-glasses-end.md
+++ b/.changeset/stupid-glasses-end.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Add `text` property to the return value from `getMarkRange`. It's a common use case when getting the range of the mark to also extract the text content.

--- a/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
@@ -13,6 +13,7 @@ import {
 import { renderEditor } from 'jest-remirror';
 
 import { object } from '@remirror/core-helpers';
+import { Mark } from '@remirror/pm/model';
 import { TextSelection } from '@remirror/pm/state';
 import {
   BlockquoteExtension,
@@ -226,6 +227,15 @@ describe('getMarkRange', () => {
     const { state, schema } = createEditor(doc(p('Some<start>thing', em('is<end> italic'))));
 
     expect(getMarkRange(state.selection.$from, schema.marks.em)).toBeUndefined();
+  });
+
+  it('provides the text and a mark', () => {
+    const expected = 'is italic';
+    const { state, schema } = createEditor(doc(p('Something <cursor>', em(expected))));
+    const range = getMarkRange(state.selection.$from, schema.marks.em);
+
+    expect(range?.mark).toBeInstanceOf(Mark);
+    expect(range?.text).toBe(expected);
   });
 });
 

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -1,4 +1,4 @@
-import { ErrorConstant } from '@remirror/core-constants';
+import { ErrorConstant, LEAF_NODE_REPLACING_CHARACTER } from '@remirror/core-constants';
 import {
   bool,
   Cast,
@@ -282,11 +282,16 @@ export function getMarkAttributes(
   return false;
 }
 
-interface GetMarkRangeParameter extends FromToParameter {
+interface GetMarkRange extends FromToParameter {
   /**
    * The mark that was found within the active range.
    */
   mark: Mark;
+
+  /**
+   * The text contained by this mark.
+   */
+  text: string;
 }
 
 /**
@@ -298,7 +303,7 @@ interface GetMarkRangeParameter extends FromToParameter {
  * @param $pos - the resolved ProseMirror position
  * @param type - the mark type
  */
-export function getMarkRange($pos: ResolvedPos, type: MarkType): GetMarkRangeParameter | undefined {
+export function getMarkRange($pos: ResolvedPos, type: MarkType): GetMarkRange | undefined {
   // Nothing can be done if neither the position or the type have been provided.
   if (!$pos || !type) {
     return;
@@ -330,7 +335,10 @@ export function getMarkRange($pos: ResolvedPos, type: MarkType): GetMarkRangePar
     startPos -= $pos.parent.child(startIndex).nodeSize;
   }
 
-  return { from: startPos, to: startPos + start.node.nodeSize, mark };
+  const [from, to] = [startPos, startPos + start.node.nodeSize];
+  const text = $pos.doc.textBetween(from, to, LEAF_NODE_REPLACING_CHARACTER, '\n\n');
+
+  return { from, to, text, mark };
 }
 
 /**


### PR DESCRIPTION
### Description

Add `text` property to the return value from `getMarkRange`. It's a common use case when getting the range of the mark to also extract the text content.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
