### PR TITLE
Make `insertImage` command chainable

### DIFF
--- a/.changeset/dull-chicken-decide.md
+++ b/.changeset/dull-chicken-decide.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-image': patch
+---
+
+Make `insertImage` command chainable.

--- a/.changeset/hungry-suits-agree.md
+++ b/.changeset/hungry-suits-agree.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-code-block': patch
+---
+
+Make `formatCodeBlock` command chainable.

--- a/.changeset/khaki-cups-pretend.md
+++ b/.changeset/khaki-cups-pretend.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Make annotation commands chainable.

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -144,6 +144,46 @@ describe('commands', () => {
       </p>
     `);
   });
+
+  it('supports chaining commands', () => {
+    const {
+      manager,
+      add,
+      view,
+      nodes: { p, doc },
+      chain,
+    } = create();
+
+    const id = '1';
+
+    add(doc(p('An <start>important<end> note')));
+    chain.addAnnotation({ id }).selectText('end').insertText(' awesome!');
+
+    expect(manager.tr.getMeta(AnnotationExtension.name)).toMatchInlineSnapshot(`
+      Object {
+        "annotationData": Object {
+          "id": "1",
+        },
+        "from": 4,
+        "to": 13,
+        "type": 0,
+      }
+    `);
+    expect(manager.tr.steps).toHaveLength(1);
+
+    chain.run();
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        An
+        <span class
+              style="background: rgb(215, 215, 255);"
+        >
+          important
+        </span>
+        note awesome!
+      </p>
+    `);
+  });
 });
 
 describe('plugin#apply', () => {

--- a/packages/@remirror/extension-code-block/src/code-block-utils.ts
+++ b/packages/@remirror/extension-code-block/src/code-block-utils.ts
@@ -259,9 +259,9 @@ interface FormatCodeBlockFactoryParameter
  * one located at the provided position).
  */
 export function formatCodeBlockFactory(parameter: FormatCodeBlockFactoryParameter) {
-  return ({ pos }: Partial<PosParameter> = object()): CommandFunction => ({ state, dispatch }) => {
+  return ({ pos }: Partial<PosParameter> = object()): CommandFunction => ({ tr, dispatch }) => {
     const { type, formatter, defaultLanguage: fallback } = parameter;
-    const { tr, selection } = state;
+    const { selection } = tr;
 
     const { from, to } = pos ? { from: pos, to: pos } : selection;
 

--- a/packages/@remirror/extension-image/src/__tests__/image-extension.spec.ts
+++ b/packages/@remirror/extension-image/src/__tests__/image-extension.spec.ts
@@ -1,5 +1,22 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { ImageExtension } from '../..';
 
 extensionValidityTest(ImageExtension);
+
+describe('commands', () => {
+  describe('insertImage', () => {
+    it('can insert images', () => {
+      const editor = renderEditor(() => [new ImageExtension()]);
+      const { doc, p } = editor.nodes;
+      const { image } = editor.attributeNodes;
+
+      editor.add(doc(p('content <cursor>')));
+      editor.commands.insertImage({ src: 'https://test.com' });
+
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(p('content ', image({ src: 'https://test.com' })())),
+      );
+    });
+  });
+});

--- a/packages/@remirror/extension-image/src/image-extension.ts
+++ b/packages/@remirror/extension-image/src/image-extension.ts
@@ -7,9 +7,9 @@ import {
   extensionDecorator,
   ExtensionTag,
   isElementDomNode,
+  NodeAttributes,
   NodeExtension,
   NodeExtensionSpec,
-  ProsemirrorAttributes,
 } from '@remirror/core';
 import type { ResolvedPos } from '@remirror/pm/model';
 
@@ -64,17 +64,15 @@ export class ImageExtension extends NodeExtension {
 
   createCommands() {
     return {
-      insertImage: (
-        attributes: ProsemirrorAttributes<ImageExtensionAttributes>,
-      ): CommandFunction => ({ state, dispatch }) => {
-        const { selection } = state;
+      insertImage: (attributes: NodeAttributes<ImageExtensionAttributes>): CommandFunction => ({
+        tr,
+        dispatch,
+      }) => {
+        const { selection } = tr;
         const position = hasCursor(selection) ? selection.$cursor.pos : selection.$to.pos;
         const node = this.type.create(attributes);
-        const transaction = state.tr.insert(position, node);
 
-        if (dispatch) {
-          dispatch(transaction);
-        }
+        dispatch?.(tr.insert(position, node));
 
         return true;
       },


### PR DESCRIPTION
### Description

- Make `insertImage` command chainable.
- Make `formatCodeBlock` command chainable.
- Make annotation commands chainable.

Fixes #724
Fixes #726

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

