### PR TITLE
Support forcefully redrawing annotations

### DIFF
--- a/.changeset/forty-numbers-jam.md
+++ b/.changeset/forty-numbers-jam.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-annotation': minor
+---
+
+Support to forcefully redraw annotations
+
+Annotations can be styled with a custom getStyle function. Yet, changes to outcome of the function (e.g. color schema is dynamically adjusted) won't be automatically reflected in the editor. To handle such cases, one can now force to redraw the annotations by calling the `redrawAnnotations` command.

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -145,6 +145,46 @@ describe('commands', () => {
     `);
   });
 
+  it('#redrawAnnotations', () => {
+    let color = 'red';
+    const getStyle = () => `background: ${color};`;
+
+    const {
+      add,
+      view,
+      nodes: { p, doc },
+      commands,
+    } = create({ getStyle });
+
+    const id = '1';
+
+    add(doc(p('<start>Hello<end>')));
+    commands.addAnnotation({ id });
+    // Pre-condition
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <span class="selection"
+              style="background: red;"
+        >
+          Hello
+        </span>
+      </p>
+    `);
+
+    color = 'green';
+    commands.redrawAnnotations();
+
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <span class="selection"
+              style="background: green;"
+        >
+          Hello
+        </span>
+      </p>
+    `);
+  });
+
   it('supports chaining commands', () => {
     const {
       manager,

--- a/packages/@remirror/extension-annotation/src/actions.ts
+++ b/packages/@remirror/extension-annotation/src/actions.ts
@@ -2,6 +2,7 @@ import type { Annotation, AnnotationData, AnnotationWithoutText } from './types'
 
 export enum ActionType {
   ADD_ANNOTATION,
+  REDRAW_ANNOTATIONS,
   REMOVE_ANNOTATIONS,
   SET_ANNOTATIONS,
   UPDATE_ANNOTATION,

--- a/packages/@remirror/extension-annotation/src/annotation-extension.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-extension.ts
@@ -162,6 +162,19 @@ export class AnnotationExtension<A extends Annotation = Annotation> extends Plai
 
         return true;
       },
+
+      /**
+       * Forcefully redraws the annotations
+       *
+       * Call this function if the styling of the annotations changes.
+       *
+       * @see https://discord.com/channels/726035064831344711/745695557976195072/759715559477870603
+       */
+      redrawAnnotations: (): CommandFunction => ({ tr, dispatch }) => {
+        dispatch?.(tr.setMeta(AnnotationExtension.name, { type: ActionType.REDRAW_ANNOTATIONS }));
+
+        return true;
+      },
     };
   }
 

--- a/packages/@remirror/extension-annotation/src/annotation-plugin.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-plugin.ts
@@ -84,6 +84,10 @@ export class AnnotationState<A extends Annotation = Annotation> {
       newAnnotations = setAction.annotations;
     }
 
+    if (actionType === ActionType.REDRAW_ANNOTATIONS) {
+      newAnnotations = this.annotations;
+    }
+
     if (newAnnotations) {
       // Recalculate decorations when annotations changed
       const decos = toSegments(newAnnotations).map((segment) => {


### PR DESCRIPTION
### Description

Annotations can be styled with a custom getStyle function. Yet, changes to outcome of the function (e.g. color schema is dynamically adjusted) won't be automatically reflected in the editor.
To handle such cases, one can now force to redraw the annotations by calling the `redrawAnnotations` command.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
