### PR TITLE
Remove `endsWith` from `ValidityTest`s

### DIFF
--- a/.changeset/fifty-deers-ring.md
+++ b/.changeset/fifty-deers-ring.md
@@ -1,0 +1,5 @@
+---
+'jest-remirror': patch
+---
+
+Fix incorrect usage of `endsWith` in `ValidityTest`s.

--- a/packages/jest-remirror/src/jest-remirror-validator.ts
+++ b/packages/jest-remirror/src/jest-remirror-validator.ts
@@ -30,7 +30,7 @@ export function extensionValidityTest<Type extends AnyExtensionConstructor>(
 ): void {
   describe(`\`${Extension.name}\``, () => {
     it(`has the right properties`, () => {
-      expect(Extension.name).toEndWith('Extension');
+      expect(Extension.name.endsWith('Extension')).toBe(true);
 
       const extension = new Extension(options);
       expect(extension.name).toBe(Extension.instanceName);
@@ -138,7 +138,7 @@ export function presetValidityTest<Type extends AnyPresetConstructor>(
 ): void {
   describe(`\`${Preset.name}\``, () => {
     it(`has the right properties`, () => {
-      expect(Preset.name).toEndWith('Preset');
+      expect(Preset.name.endsWith('Preset')).toBe(true);
 
       const preset = new Preset(options);
       expect(preset.name).toBe(Preset.instanceName);


### PR DESCRIPTION
### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
