### PR TITLE
Add `mousedown` and `mouseup` handlers to `EventsExtension`

### DIFF
--- a/.changeset/dry-chairs-decide.md
+++ b/.changeset/dry-chairs-decide.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': minor
+---
+
+Add support for `mousedown` and `mouseup` events in `EventsExtension`

--- a/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
+++ b/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
@@ -31,4 +31,30 @@ describe('events', () => {
 
     expect(blurHandler).toHaveBeenCalled();
   });
+
+  it('responds to editor `mousedown` events', () => {
+    const eventsExtension = new EventsExtension();
+    const mouseDownHandler = jest.fn(() => true);
+    const editor = renderEditor([eventsExtension]);
+    const { doc, p } = editor.nodes;
+    eventsExtension.addHandler('mousedown', mouseDownHandler);
+
+    editor.add(doc(p('first')));
+    fireEvent.mouseDown(editor.dom);
+
+    expect(mouseDownHandler).toHaveBeenCalled();
+  });
+
+  it('responds to editor `mouseup` events', () => {
+    const eventsExtension = new EventsExtension();
+    const mouseUpHandler = jest.fn(() => true);
+    const editor = renderEditor([eventsExtension]);
+    const { doc, p } = editor.nodes;
+    eventsExtension.addHandler('mouseup', mouseUpHandler);
+
+    editor.add(doc(p('first')));
+    fireEvent.mouseUp(editor.dom);
+
+    expect(mouseUpHandler).toHaveBeenCalled();
+  });
 });

--- a/packages/@remirror/extension-events/src/events-extension.ts
+++ b/packages/@remirror/extension-events/src/events-extension.ts
@@ -14,6 +14,20 @@ export interface EventsOptions {
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
   focus: Handler<(event: FocusEvent) => boolean | undefined>;
+
+  /**
+   * Listens for mousedown events on the editor.
+   *
+   * Return `true` to prevent any other prosemirror listeners from firing.
+   */
+  mousedown: Handler<(event: MouseEvent) => boolean | undefined>;
+
+  /**
+   * Listens for mouseup events on the editor.
+   *
+   * Return `true` to prevent any other prosemirror listeners from firing.
+   */
+  mouseup: Handler<(event: MouseEvent) => boolean | undefined>;
 }
 
 /**
@@ -23,8 +37,13 @@ export interface EventsOptions {
  * TODO - add more events based on user feedback.
  */
 @extensionDecorator<EventsOptions>({
-  handlerKeys: ['blur', 'focus'],
-  handlerKeyOptions: { blur: { earlyReturnValue: true }, focus: { earlyReturnValue: true } },
+  handlerKeys: ['blur', 'focus', 'mousedown', 'mouseup'],
+  handlerKeyOptions: {
+    blur: { earlyReturnValue: true },
+    focus: { earlyReturnValue: true },
+    mousedown: { earlyReturnValue: true },
+    mouseup: { earlyReturnValue: true },
+  },
 })
 export class EventsExtension extends PlainExtension<EventsOptions> {
   get name() {
@@ -40,6 +59,12 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
           },
           blur: (_, event) => {
             return this.options.blur(event as FocusEvent) ?? false;
+          },
+          mousedown: (_, event) => {
+            return this.options.mousedown(event as MouseEvent) ?? false;
+          },
+          mouseup: (_, event) => {
+            return this.options.mouseup(event as MouseEvent) ?? false;
           },
         },
       },


### PR DESCRIPTION
### Description

Adds support for `mousedown` and `mouseup` events in @remirror/extension-events

```jsx
import { EventsExtension } from 'remirror/extension/events';
import { useExtension } from 'remirror/react';
const Editor = () => {
  useExtension(
    EventsExtension,
    ({ addHandler }) => {
      addHandler('mousedown', () => log('Mouse down!'));
    },
    [],
  );
};
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

