### PR TITLE
Add `blockSeparator` option for multi-block annotations

### DIFF
--- a/.changeset/swift-ears-draw.md
+++ b/.changeset/swift-ears-draw.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-annotation': minor
+---
+
+Configure blockseparator to concat multi-block content
+
+getAnnotations() return all currently set annotations and enriches them with the text of the annotation. This can be used e.g. to show a list of all annotations outside the editor context. Before, text from multiple blocks (in a multi-block annotation) was concatenated without any separated. Now, one can define via the "blockseparator" option which string to use as separator. For example, one could use a newline character to separate text from different blocks.

--- a/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
+++ b/packages/@remirror/extension-annotation/src/__tests__/annotation-extension.spec.ts
@@ -352,6 +352,28 @@ describe('helpers', () => {
     expect(helpers.getAnnotations()[0].text).toBeUndefined();
   });
 
+  it('#getAnnotations concats multi-block content with configured blockseparator', () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = create({
+      blockSeparator: '<NEWLINE>',
+    });
+
+    add(doc(p('Hello'), p('World')));
+    commands.setAnnotations([
+      {
+        id: '1',
+        from: 1,
+        to: 13,
+      },
+    ]);
+
+    expect(helpers.getAnnotations()[0].text).toEqual('Hello<NEWLINE>World');
+  });
+
   it('#getAnnotationsAt', () => {
     const {
       add,

--- a/packages/@remirror/extension-annotation/src/annotation-extension.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-extension.ts
@@ -31,6 +31,7 @@ function defaultGetStyle<A extends Annotation>(annotations: Array<AnnotationWith
 @extensionDecorator<AnnotationOptions<Annotation>>({
   defaultOptions: {
     getStyle: defaultGetStyle,
+    blockSeparator: '\n',
   },
   defaultPriority: ExtensionPriority.Low,
 })
@@ -186,7 +187,7 @@ export class AnnotationExtension<A extends Annotation = Annotation> extends Plai
       // This can happen if content/annotations are set at different points.
       const text =
         annotation.to <= doc.content.size
-          ? doc.textBetween(annotation.from, annotation.to)
+          ? doc.textBetween(annotation.from, annotation.to, this.options.blockSeparator)
           : undefined;
       return {
         ...annotation,

--- a/packages/@remirror/extension-annotation/src/annotation-extension.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-extension.ts
@@ -31,7 +31,7 @@ function defaultGetStyle<A extends Annotation>(annotations: Array<AnnotationWith
 @extensionDecorator<AnnotationOptions<Annotation>>({
   defaultOptions: {
     getStyle: defaultGetStyle,
-    blockSeparator: '\n',
+    blockSeparator: undefined,
   },
   defaultPriority: ExtensionPriority.Low,
 })

--- a/packages/@remirror/extension-annotation/src/types.ts
+++ b/packages/@remirror/extension-annotation/src/types.ts
@@ -1,3 +1,5 @@
+import type { AcceptUndefined } from '@remirror/core';
+
 export type GetStyle<A extends Annotation> = (
   annotations: Array<AnnotationWithoutText<A>>,
 ) => string | undefined;
@@ -20,7 +22,7 @@ export interface AnnotationOptions<A extends Annotation = Annotation> {
    *
    * @see PromirrorNode.textBetween
    */
-  blockSeparator?: string | undefined;
+  blockSeparator?: AcceptUndefined<string>;
 }
 
 export interface Annotation {

--- a/packages/@remirror/extension-annotation/src/types.ts
+++ b/packages/@remirror/extension-annotation/src/types.ts
@@ -11,6 +11,16 @@ export interface AnnotationOptions<A extends Annotation = Annotation> {
    * the amount of annotations in a segment.
    */
   getStyle?: GetStyle<A>;
+
+  /**
+   * Allows to format the text returned for each annotation.
+   *
+   * When `blockSeparator` is given, it will be inserted whenever a new
+   * block node is started.
+   *
+   * @see PromirrorNode.textBetween
+   */
+  blockSeparator?: string | undefined;
 }
 
 export interface Annotation {


### PR DESCRIPTION
### Description

`getAnnotations()` returns all currently set annotations and enriches them with the text of the annotation. This can be used e.g. to show a list of all annotations outside the editor context.
Before, text from multiple blocks (in a multi-block annotation) was concatenated without any separated. Now, one can define via the `blockseparator` option which string to use as separator. For example, one could use a newline character to separate text from different blocks.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
