### PR TITLE
Add strike mark to the jest-prosemirror schema

### DIFF
--- a/.changeset/famous-tips-march.md
+++ b/.changeset/famous-tips-march.md
@@ -1,0 +1,5 @@
+---
+'jest-prosemirror': minor
+---
+
+Add strike mark to the `jest-prosemirror` schema

--- a/packages/@remirror/core/src/builtins/__tests__/schema-extension.spec.ts
+++ b/packages/@remirror/core/src/builtins/__tests__/schema-extension.spec.ts
@@ -95,6 +95,7 @@ test('custom schema', () => {
       "em",
       "strong",
       "code",
+      "strike",
     ]
   `);
 });

--- a/packages/jest-prosemirror/src/__tests__/__snapshots__/jest-prosemirror.spec.ts.snap
+++ b/packages/jest-prosemirror/src/__tests__/__snapshots__/jest-prosemirror.spec.ts.snap
@@ -339,6 +339,22 @@ Prosemirror schema: {
           "tag": "code"
         }
       ]
+    },
+    "strike": {
+      "parseDOM": [
+        {
+          "tag": "s"
+        },
+        {
+          "tag": "del"
+        },
+        {
+          "tag": "strike"
+        },
+        {
+          "style": "text-decoration"
+        }
+      ]
     }
   }
 }

--- a/packages/jest-prosemirror/src/jest-prosemirror-schema.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-schema.ts
@@ -2,7 +2,7 @@ import { marks, nodes } from 'prosemirror-schema-basic';
 import { tableNodes } from 'prosemirror-tables';
 
 import { NodeGroup } from '@remirror/core-constants';
-import { NodeSpec, Schema } from '@remirror/pm/model';
+import { NodeSpec, MarkSpec, Schema } from '@remirror/pm/model';
 import {
   bulletList as baseBulletList,
   listItem as baseListItem,
@@ -20,6 +20,7 @@ const {
   hard_break,
   image,
 } = nodes;
+const { link, em, strong, code } = marks;
 const { table, table_cell, table_header, table_row } = tableNodes({
   tableGroup: 'block',
   cellContent: 'block+',
@@ -94,6 +95,27 @@ const containerWithRestrictedContent: NodeSpec = {
   },
 };
 
+const strike: MarkSpec = {
+  parseDOM: [
+    {
+      tag: 's',
+    },
+    {
+      tag: 'del',
+    },
+    {
+      tag: 'strike',
+    },
+    {
+      style: 'text-decoration',
+      getAttrs: (node) => (node === 'line-through' ? {} : false),
+    },
+  ],
+  toDOM: () => {
+    return ['s', 0];
+  },
+};
+
 export const schema = new Schema({
   nodes: {
     doc,
@@ -117,5 +139,11 @@ export const schema = new Schema({
     hard_break,
     image,
   },
-  marks,
+  marks: {
+    link,
+    em,
+    strong,
+    code,
+    strike,
+  },
 });


### PR DESCRIPTION
### Description

The schema provided by `jest-prosemirror` does not include the strike mark. This PR adds it.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
