### PR TITLE
Allow sync options to be passed to yjs extension

### DIFF
--- a/.changeset/large-ligers-begin.md
+++ b/.changeset/large-ligers-begin.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-hooks': patch
+---
+
+Fix bug in `useMentionAtom` where asynchronous exits, like clicking, would not trigger an exit. Now the state is manually reset when the command is run.

--- a/.changeset/pretty-rice-sneeze.md
+++ b/.changeset/pretty-rice-sneeze.md
@@ -1,0 +1,9 @@
+---
+'@remirror/extension-yjs': major
+---
+
+Add new options to the `YjsExtension` to support full configuration of the `y-prosemirror` plugins.
+
+**BREAKING:** 💥 Remove `WebrtcProvider`. It was always required via TypeScript but now the default implementation throws an error if you don't install and provide the [provider](https://github.com/yjs/yjs#providers) you want to use. The `readme` has been updated to reflect this change.
+
+**BREAKING:** 💥 `yjs` is now a `peerDependency` and you will need to install it in your codebase in order to consume the `YjsExtension`. This change follows from the above breaking change. For example, to configure any provider will need to provide your desired `Doc` from the `yjs` package.

--- a/.changeset/tame-shirts-wonder.md
+++ b/.changeset/tame-shirts-wonder.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-positioner': minor
+---
+
+Support scroll updates by default for all positioners.

--- a/.github/workflows/label-sponsors.yml
+++ b/.github/workflows/label-sponsors.yml
@@ -1,7 +1,7 @@
 name: label sponsor
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened]
   issues:
     types: [opened]

--- a/packages/@remirror/extension-positioner/src/positioner.ts
+++ b/packages/@remirror/extension-positioner/src/positioner.ts
@@ -166,7 +166,10 @@ export class Positioner<Data = any> {
    *
    * This is useful when you want to modify parts of the positioner.
    */
-  static fromPositioner<Data>(positioner: Positioner, base: Partial<BasePositioner<Data>>) {
+  static fromPositioner<Data>(
+    positioner: Positioner,
+    base: Partial<BasePositioner<Data>>,
+  ): Positioner<Data> {
     return Positioner.create({ ...positioner.basePositioner, ...base });
   }
 
@@ -198,13 +201,13 @@ export class Positioner<Data = any> {
     this.#getPosition = parameter.getPosition;
     this.#getID = parameter.getID;
     this.hasChanged = parameter.hasChanged;
-    this.events = parameter.events ?? ['state'];
+    this.events = parameter.events ?? ['state', 'scroll'];
   }
 
   /**
    * Get the active element setters.
    */
-  onActiveChanged(parameter: GetActiveParameter) {
+  onActiveChanged(parameter: GetActiveParameter): void {
     const active = this.#getActive(parameter);
     this.#active = active;
     this.#parameters = new Map();

--- a/packages/@remirror/extension-yjs/package.json
+++ b/packages/@remirror/extension-yjs/package.json
@@ -30,17 +30,18 @@
   "dependencies": {
     "@babel/runtime": "^7.11.0",
     "linaria": "^2.0.0-rc.3",
-    "y-prosemirror": "^0.3.7",
-    "y-webrtc": "^10.1.6",
-    "yjs": "^13.4.0"
+    "y-prosemirror": "^0.3.7"
   },
   "devDependencies": {
     "@remirror/core": "1.0.0-next.45",
-    "@remirror/pm": "1.0.0-next.44"
+    "@remirror/pm": "1.0.0-next.44",
+    "y-webrtc": "^10.1.6",
+    "yjs": "^13.4.0"
   },
   "peerDependencies": {
     "@remirror/core": "1.0.0-next.45",
-    "@remirror/pm": "1.0.0-next.44"
+    "@remirror/pm": "1.0.0-next.44",
+    "yjs": "^13.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@remirror/extension-yjs/readme.md
+++ b/packages/@remirror/extension-yjs/readme.md
@@ -16,16 +16,29 @@
 
 ```bash
 # yarn
-yarn add @remirror/extension-yjs@next @remirror/pm@next
+yarn add yjs @remirror/extension-yjs@next @remirror/pm@next
 
 # pnpm
-pnpm add @remirror/extension-yjs@next @remirror/pm@next
+pnpm add yjs @remirror/extension-yjs@next @remirror/pm@next
 
 # npm
-npm install @remirror/extension-yjs@next @remirror/pm@next
+npm install yjs @remirror/extension-yjs@next @remirror/pm@next
 ```
 
-This is included by default when you install the recommended `remirror` package. All exports are also available via the entry-point, `remirror/extension/yjs`.
+This is package is included by default when you install the recommended `remirror` package. All exports are also available via the entry-point, `remirror/extension/yjs`.
+
+You will also need to install your preferred [`YjsRealtimeProvider`](https://github.com/yjs/yjs#providers).
+
+```bash
+# yarn
+yarn add y-webrtc
+
+# pnpm
+pnpm add y-webrtc
+
+# npm
+npm install y-webrtc
+```
 
 ## Usage
 
@@ -33,6 +46,10 @@ The following code creates an instance of this extension.
 
 ```ts
 import { YjsExtension } from 'remirror/extension/yjs';
+import { WebrtcProvider } from 'y-webrtc';
+import { Doc } from 'yjs';
 
-const extension = new YjsExtension();
+const extension = new YjsExtension({
+  getProvider: () => new WebrtcProvider('global', new Doc()),
+});
 ```

--- a/packages/@remirror/extension-yjs/src/__tests__/yjs-extension.spec.ts
+++ b/packages/@remirror/extension-yjs/src/__tests__/yjs-extension.spec.ts
@@ -1,5 +1,9 @@
 import { extensionValidityTest } from 'jest-remirror';
+import { WebrtcProvider } from 'y-webrtc';
+import { Doc } from 'yjs';
 
 import { YjsExtension } from '..';
 
-extensionValidityTest(YjsExtension, {} as any);
+extensionValidityTest(YjsExtension, {
+  getProvider: () => new WebrtcProvider('global', new Doc()),
+});

--- a/packages/@remirror/react-hooks/src/use-mention-atom.ts
+++ b/packages/@remirror/react-hooks/src/use-mention-atom.ts
@@ -67,7 +67,18 @@ function useMentionHandlers<Data extends MentionAtomNodeAttributes = MentionAtom
       const index = changeReason === ChangeReason.Move ? currentIndex : 0;
 
       // Reset the active index so that the dropdown is back to the top.
-      setState({ query, range, name, reason: changeReason, text, command, index });
+      setState({
+        query,
+        range,
+        name,
+        reason: changeReason,
+        text,
+        command: (attrs) => {
+          command(attrs);
+          setState(null);
+        },
+        index,
+      });
     },
     [currentIndex, setState],
   );
@@ -99,7 +110,6 @@ function useMentionAtomKeyBindings<
       }
 
       const { index } = state;
-
       const direction = arrowKey === 'down' ? 'next' : 'previous';
 
       const activeIndex = indexFromArrowPress({

--- a/packages/remirror/package.json
+++ b/packages/remirror/package.json
@@ -97,13 +97,15 @@
     "@types/react": "^16.9.51",
     "@types/react-dom": "^16.9.8",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "yjs": "^13.4.0"
   },
   "peerDependencies": {
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.0",
+    "yjs": "^13.4.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -116,6 +118,9 @@
       "optional": true
     },
     "react-dom": {
+      "optional": true
+    },
+    "yjs": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,11 +783,11 @@ importers:
       '@babel/runtime': 7.11.2
       linaria: 2.0.0-rc.3
       y-prosemirror: 0.3.7_yjs@13.4.0
-      y-webrtc: 10.1.6
-      yjs: 13.4.0
     devDependencies:
       '@remirror/core': 'link:../core'
       '@remirror/pm': 'link:../pm'
+      y-webrtc: 10.1.6
+      yjs: 13.4.0
     specifiers:
       '@babel/runtime': ^7.11.0
       '@remirror/core': 1.0.0-next.45
@@ -1654,6 +1654,7 @@ importers:
       '@types/react-dom': 16.9.8
       react: 16.13.1
       react-dom: 16.13.1_react@16.13.1
+      yjs: 13.4.0
     specifiers:
       '@babel/runtime': ^7.11.0
       '@remirror/core': 1.0.0-next.45
@@ -1715,6 +1716,7 @@ importers:
       '@types/react-dom': ^16.9.8
       react: ^16.13.1
       react-dom: ^16.13.1
+      yjs: ^13.4.0
   packages/test-keyboard:
     dependencies:
       '@babel/runtime': 7.11.2
@@ -13944,7 +13946,7 @@ packages:
     resolution:
       integrity: sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
   /get-browser-rtc/1.0.2:
-    dev: false
+    dev: true
     resolution:
       integrity: sha1-u81AyEUaftTvXDc7gWmkCd0dEdk=
   /get-caller-file/2.0.5:
@@ -16098,7 +16100,6 @@ packages:
     resolution:
       integrity: sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
   /isomorphic.js/0.1.5:
-    dev: false
     resolution:
       integrity: sha512-MkX5lLQApx/8IAIU31PKvpAZosnu2Jqcj1rM8TzxyA4CR96tv3SgMKQNTCxL58G7696Q57zd7ubHV/hTg+5fNA==
   /isstream/0.1.2:
@@ -17294,7 +17295,6 @@ packages:
   /lib0/0.2.34:
     dependencies:
       isomorphic.js: 0.1.5
-    dev: false
     engines:
       node: '>=10'
     resolution:
@@ -21986,7 +21986,7 @@ packages:
     resolution:
       integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
   /queue-microtask/1.1.4:
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA==
   /quick-lru/1.1.0:
@@ -22036,7 +22036,6 @@ packages:
   /randombytes/2.1.0:
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
     resolution:
       integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   /randomfill/1.0.4:
@@ -22782,7 +22781,6 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    dev: false
     engines:
       node: '>= 6'
     resolution:
@@ -23943,7 +23941,7 @@ packages:
       queue-microtask: 1.1.4
       randombytes: 2.1.0
       readable-stream: 3.6.0
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-xeMyxa9B4V0eA6mf17fVr8nm2QhAYFu+ZZv8zkSFFTjJETGF227CshwobrIYZuspJglMD63egcevQXGOrTIsuA==
   /simple-swizzle/0.2.2:
@@ -24634,7 +24632,6 @@ packages:
   /string_decoder/1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
     resolution:
       integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   /stringify-entities/3.0.1:
@@ -26260,7 +26257,6 @@ packages:
     resolution:
       integrity: sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==
   /util-deprecate/1.0.2:
-    dev: false
     resolution:
       integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
   /util.promisify/1.0.0:
@@ -27135,7 +27131,7 @@ packages:
   /y-protocols/1.0.1:
     dependencies:
       lib0: 0.2.34
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-QP3fCM7c2gGfUi2nqf8gspyO4VW23zv3kNqPNdD3wNxMbuNQenMyoDVZYEo12jzR4RQ3aaDfPK62Sf31SVOmfg==
   /y-webrtc/10.1.6:
@@ -27143,7 +27139,7 @@ packages:
       lib0: 0.2.34
       simple-peer: 9.7.2
       y-protocols: 1.0.1
-    dev: false
+    dev: true
     engines:
       node: '>=10'
     hasBin: true
@@ -27254,7 +27250,7 @@ packages:
   /yjs/13.4.0:
     dependencies:
       lib0: 0.2.34
-    dev: false
+    dev: true
     resolution:
       integrity: sha512-7Uk28QwLILYoTjfOYL9LwGJpcLL8Nfs52u7pVLrBKiyGkH9D6dj3k+M5/BlRx7g4S4FvuG/yezsGU/UVLuV6Lg==
   /yn/3.1.1:

--- a/support/website/src/pages/playground.tsx
+++ b/support/website/src/pages/playground.tsx
@@ -30,8 +30,8 @@ const PlaygroundPage = (props: any) => {
             {/* TODO: Do not assume that it is in english language site */}
             <html lang='en' />
             <script src='https://unpkg.com/@babel/standalone/babel.min.js'></script>
-            <script src='https://unpkg.com/prettier@2.0.5/standalone.js'></script>
-            <script src='https://unpkg.com/prettier@2.0.5/parser-typescript.js'></script>
+            <script src='https://unpkg.com/prettier@2.1.2/standalone.js'></script>
+            <script src='https://unpkg.com/prettier@2.1.2/parser-typescript.js'></script>
             <title>Remirror Playground</title>
             <meta property='og:title' content='Remirror Playground' />
             {favicon ?? <link rel='shortcut icon' href={faviconUrl} />}


### PR DESCRIPTION
### Description

Support scroll updates by default for all positioners.

Add new options to the `YjsExtension` to support full configuration of the `y-prosemirror` plugins.

- Fixes #742

**BREAKING:** 💥 Remove `WebrtcProvider`. It was always required via TypeScript but now the default implementation throws an error if you don't install and provide the [provider](https://github.com/yjs/yjs#providers) you want to use. The `readme` has been updated to reflect this change.

**BREAKING:** 💥 `yjs` is now a `peerDependency` and you will need to install it in your codebase in order to consume the `YjsExtension`. This change follows from the above breaking change. For example, to configure any provider will need to provide your desired `Doc` from the `yjs` package.

Fix bug in `useMentionAtom` where asynchronous exits, like clicking, would not trigger an exit. Now the state is manually reset when the command is run.

- Fixes #737

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-10-08 10 24 30](https://user-images.githubusercontent.com/1160934/95441915-a24f3400-0952-11eb-8e50-0f226d7ebfae.gif)
