### PR TITLE
Add better support for `autoFocus: true` on iOS support

### DIFF
--- a/.changeset/empty-hats-teach.md
+++ b/.changeset/empty-hats-teach.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Add better **iOS** focus support. Now using `focus` on iOS will actually focus the editor.

--- a/.changeset/selfish-drinks-design.md
+++ b/.changeset/selfish-drinks-design.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Add `isIos` environment flag.

--- a/packages/@remirror/core-utils/src/environment.ts
+++ b/packages/@remirror/core-utils/src/environment.ts
@@ -35,6 +35,13 @@ export const environment = {
   },
 
   /**
+   * True when on an iOS device.
+   */
+  get isIos(): boolean {
+    return environment.isBrowser && /iPod|iPhone|iPad/.test(navigator.platform);
+  },
+
+  /**
    * True when running on macOS
    */
   get isMac(): boolean {

--- a/packages/@remirror/core/src/framework/framework.ts
+++ b/packages/@remirror/core/src/framework/framework.ts
@@ -21,7 +21,13 @@ import type {
   StateJSON,
   Transaction,
 } from '@remirror/core-types';
-import { getDocument, getTextSelection, isElementDomNode, toHtml } from '@remirror/core-utils';
+import {
+  environment,
+  getDocument,
+  getTextSelection,
+  isElementDomNode,
+  toHtml,
+} from '@remirror/core-utils';
 
 import type { UpdatableViewProps } from '../builtins';
 import type { RemirrorManager } from '../manager';
@@ -495,6 +501,19 @@ export abstract class Framework<
   };
 
   /**
+   * Needed on iOS since `requestAnimationFrame` doesn't breaks the focus
+   * implementation.
+   */
+  protected handleIosFocus(): void {
+    if (!environment.isIos) {
+      return;
+    }
+
+    const element = this.view.dom as HTMLElement;
+    element.focus();
+  }
+
+  /**
    * Remove the focus from the editor. If the editor is not focused it will do
    * nothing.
    */
@@ -519,6 +538,8 @@ export abstract class Framework<
     // Set the selection to the requested value
     const transaction = tr.setSelection(selection);
     this.view.dispatch(transaction);
+
+    this.handleIosFocus();
 
     // Wait for the next event loop to set the focus.
     requestAnimationFrame(() => {


### PR DESCRIPTION
Fixes #261

### Description

Add better **iOS** focus support. Now using `focus` on iOS will actually focus the editor.

- Fixes #261

- Add `isIos` environment flag.

`iOS` still won't support focus when the user hasn't interacted with the browser yet.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-10-08 13 20 26](https://user-images.githubusercontent.com/1160934/95458040-94f17400-0969-11eb-953d-02c52b8081f1.gif)
