### PR TITLE
Add an `onUpdateLink` event handler to the `LinkExtension`

### DIFF
--- a/.changeset/lemon-berries-pretend.md
+++ b/.changeset/lemon-berries-pretend.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-link': minor
+'@remirror/preset-wysiwyg': minor
+---
+
+Add an `onUpdatedLink` event handler to the link extension for determining when a link has been added to the document.

--- a/packages/@remirror/preset-wysiwyg/src/wysiwyg-preset.ts
+++ b/packages/@remirror/preset-wysiwyg/src/wysiwyg-preset.ts
@@ -55,7 +55,7 @@ export interface WysiwygOptions
     'searchClass',
     'weight',
   ],
-  handlerKeys: ['onActivateLink', 'onSearch'],
+  handlerKeys: ['onActivateLink', 'onUpdateLink', 'onSearch'],
 })
 export class WysiwygPreset extends Preset<WysiwygOptions> {
   get name() {
@@ -120,6 +120,7 @@ export class WysiwygPreset extends Preset<WysiwygOptions> {
 
     const linkExtension = new LinkExtension({ selectTextOnClick: this.options.selectTextOnClick });
     linkExtension.addHandler('onActivateLink', this.options.onActivateLink);
+    linkExtension.addHandler('onUpdateLink', this.options.onUpdateLink);
 
     const { autoUpdate, defaultDirection, excludeNodes } = this.options;
     const bidiExtension = new BidiExtension({ autoUpdate, defaultDirection, excludeNodes });


### PR DESCRIPTION
### Description

Adds an event to the link extension to detect when links are added/updated.

I decided not to change the `onLinkActivated` event as that seems to have auto selection behaviour that I didn't want to break.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
