### PR TITLE
Prevent extra space when reselecting mentions 

### DIFF
--- a/.changeset/rotten-maps-clean.md
+++ b/.changeset/rotten-maps-clean.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Support `EditorState | Selection | ResolvedPos` for the `findParentNodeOfType` function.

--- a/.changeset/soft-boxes-mate.md
+++ b/.changeset/soft-boxes-mate.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-mention': minor
+---
+
+Pass through `defaultAppendTextValue` property to `onChange` handler of `MentionExtension`.

--- a/.changeset/tasty-drinks-camp.md
+++ b/.changeset/tasty-drinks-camp.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-hooks': minor
+---
+
+Don't append text to `useMention` hook command when content after starts with whitespaces.

--- a/packages/@remirror/extension-mention/src/mention-extension.ts
+++ b/packages/@remirror/extension-mention/src/mention-extension.ts
@@ -435,7 +435,10 @@ export class MentionExtension extends MarkExtension<MentionOptions> {
             mentionExitHandler(parameter, attrs);
           }
 
-          this.options.onChange(parameter, command);
+          this.options.onChange(
+            { ...parameter, defaultAppendTextValue: this.options.appendText },
+            command,
+          );
         },
         checkNextValidSelection: ($pos, tr) => {
           const range = getMarkRange($pos, this.type);
@@ -630,13 +633,20 @@ export interface MentionExtensionMatcher
 
 export type MentionChangeHandlerCommand = (attrs?: MentionChangeHandlerCommandAttributes) => void;
 
+export interface MentionChangeHandlerParameter extends SuggestChangeHandlerParameter {
+  /**
+   * The default text to be appended if text should be appended.
+   */
+  defaultAppendTextValue: string;
+}
+
 /**
  * A handler that will be called whenever the the active matchers are updated or
  * exited. The second argument which is the exit command is a function which is
  * only available when the matching suggester has been exited.
  */
 export type MentionChangeHandler = (
-  handlerState: SuggestChangeHandlerParameter,
+  handlerState: MentionChangeHandlerParameter,
   command: (attrs?: MentionChangeHandlerCommandAttributes) => void,
 ) => void;
 

--- a/packages/@remirror/extension-positioner/src/positioners.ts
+++ b/packages/@remirror/extension-positioner/src/positioners.ts
@@ -23,13 +23,14 @@ export const emptyVirtualPosition: VirtualPosition = {
 };
 
 /**
- * Render a floating selection positioner.
+ * Render a floating selection positioner when the current selected node is empty.
  *
  * - `rect` provides a viewport position which spans the width of the editor
  *   with a height identical to the cursor height.
  * - `top` - the top of the cursor.
  * - `bottom` - the bottom of the cursor.
- * - `left
+ * - `left` - the left side of the editor.
+ * - `right` - the right side of the editor.
  */
 export const floatingSelectionPositioner = Positioner.create<Coords>({
   hasChanged: hasStateChanged,

--- a/packages/@remirror/react-hooks/src/__tests__/use-mention.spec.tsx
+++ b/packages/@remirror/react-hooks/src/__tests__/use-mention.spec.tsx
@@ -43,7 +43,48 @@ describe('useMention', () => {
         editor.insertText('@a');
       },
       () => {
-        result.state?.command({ ...result.items[0], appendText: NON_BREAKING_SPACE_CHAR });
+        result.state?.command({ ...result.items[0] });
+      },
+      () => {
+        editor.insertText('more to come');
+      },
+    ]);
+
+    expect(editor.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        Initial content
+        <a role="presentation"
+           href="//test.com/aa"
+           class="mention mention-at"
+           data-mention-id="aa"
+           data-mention-name="at"
+        >
+          @aa
+        </a>
+        &nbsp;more to come
+      </p>
+    `);
+  });
+
+  it('should not append space multiple times', () => {
+    const { editor, Wrapper, result } = createEditor();
+
+    strictRender(<Wrapper />);
+    acts([
+      () => {
+        editor.insertText('@a');
+      },
+      () => {
+        result.state?.command({ ...result.items[0] });
+      },
+      () => {
+        editor.selectText(19);
+      },
+      () => {
+        result.state?.command({ ...result.items[0] });
+      },
+      () => {
+        editor.selectText('end');
       },
       () => {
         editor.insertText('more to come');
@@ -168,7 +209,7 @@ describe('useMention', () => {
         >
           #AAi
         </a>
-        more to come
+        &nbsp;more to come
       </p>
     `);
   });
@@ -209,6 +250,7 @@ function createEditor() {
   const manager = createReactManager(() => [
     new MentionExtension({
       extraAttributes: { role: 'presentation', href: { default: null } },
+      appendText: NON_BREAKING_SPACE_CHAR,
       matchers: [
         { name: 'at', char: '@', appendText: ' ' },
         { name: 'tag', char: '#', appendText: ' ' },

--- a/packages/@remirror/react-hooks/src/use-mention.ts
+++ b/packages/@remirror/react-hooks/src/use-mention.ts
@@ -56,7 +56,17 @@ function useMentionChangeHandler<
    */
   const onChange: MentionChangeHandler = useCallback(
     (parameter, cmd) => {
-      const { query, text, range, ignoreNextExit, name, exitReason, changeReason } = parameter;
+      const {
+        query,
+        text,
+        range,
+        ignoreNextExit,
+        name,
+        exitReason,
+        changeReason,
+        textAfter,
+        defaultAppendTextValue,
+      } = parameter;
 
       // Ignore the next exit since it has been triggered manually but
       // only when this is caused by a change. This is because the command
@@ -67,9 +77,14 @@ function useMentionChangeHandler<
           // generated.
           ignoreNextExit();
 
-          // Default to append text when this command is called. However, this
-          // can be overridden by the user, if appending text is not ideal.
-          cmd({ appendText: ' ', ...attrs });
+          const regex = /^\s+/;
+
+          const appendText = regex.test(textAfter) ? '' : defaultAppendTextValue;
+
+          // Default to append text only when the textAfter the match does not
+          // start with a whitespace character. However, this can be overridden
+          // by the user.
+          cmd({ appendText, ...attrs });
 
           // Reset the state, since the query has been exited.
           setState(null);

--- a/packages/@remirror/react-social/src/social-utils.ts
+++ b/packages/@remirror/react-social/src/social-utils.ts
@@ -22,7 +22,7 @@ export function socialManagerArgs<Combined extends AnyCombinedUnion>(
   }
 
   return [
-    () => [...getLazyArray(combined), new SocialPreset(social)],
+    () => [...getLazyArray(combined), new SocialPreset({ appendText: ' ', ...social })],
     {
       ...rest,
       extraAttributes: [

--- a/packages/prosemirror-suggest/src/__tests__/suggest-plugin.spec.ts
+++ b/packages/prosemirror-suggest/src/__tests__/suggest-plugin.spec.ts
@@ -36,6 +36,25 @@ describe('suggester', () => {
       });
   });
 
+  it('supports `textBefore` and `textAfter` `onChange`', () => {
+    const expected = 'suggest';
+    const exit = jest.fn();
+    const onChange: SuggestChangeHandler = jest.fn((param) => {
+      const { exitReason, textBefore, textAfter } = param;
+
+      if (exitReason) {
+        exit({ textBefore, textAfter });
+      }
+    });
+    const plugin = suggest({ char: '@', name: 'at', onChange, matchOffset: 0 });
+
+    createEditor(doc(p('hello'), p(strong('Hello'), ' <cursor>friend')), { plugins: [plugin] })
+      .insertText(`@${expected} `)
+      .callback(() => {
+        expect(exit).toHaveBeenCalledWith({ textBefore: 'Hello ', textAfter: ' friend' });
+      });
+  });
+
   it('supports priority', () => {
     const _1 = jest.fn();
     const _2 = jest.fn();
@@ -230,7 +249,7 @@ describe('suggester', () => {
 
         jest.clearAllMocks();
       })
-      .jumpTo(5)
+      .selectText(5)
       .callback(() => {
         expect(change1).toHaveBeenCalledTimes(1);
         expect(exit1).not.toHaveBeenCalled();
@@ -316,27 +335,27 @@ describe('Suggest Ignore', () => {
       .callback(() => {
         jest.clearAllMocks();
       })
-      .jumpTo(2)
+      .selectText(2)
       .callback(() => {
         expect(onChangeAt).not.toHaveBeenCalled();
 
         clear.at('at');
       })
-      .jumpTo(3)
+      .selectText(3)
       .callback(() => {
         expect(onChangeAt).toHaveBeenCalledTimes(1);
       })
-      .jumpTo(7)
+      .selectText(7)
       .callback(() => {
         expect(onChangeTag).not.toHaveBeenCalled();
 
         clear.tag('tag');
       })
-      .jumpTo(8)
+      .selectText(8)
       .callback(() => {
         expect(onChangeTag).toHaveBeenCalledTimes(1);
       })
-      .jumpTo('end')
+      .selectText('end')
       .callback(() => {
         expect(exitAt).toHaveBeenCalledTimes(1);
         expect(exitTag).toHaveBeenCalledTimes(1);
@@ -412,7 +431,7 @@ describe('validity', () => {
 
     jest.resetAllMocks();
 
-    editor.jumpTo(8).insertText('@abc ');
+    editor.selectText(8).insertText('@abc ');
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -427,7 +446,7 @@ describe('validity', () => {
 
     jest.resetAllMocks();
 
-    editor.jumpTo(8).insertText('@abc ');
+    editor.selectText(8).insertText('@abc ');
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -455,7 +474,7 @@ describe('validity', () => {
       plugins: [plugin],
     })
       .insertText('abc')
-      .jumpTo(10);
+      .selectText(10);
     expect(onChange).toHaveBeenCalledTimes(4);
 
     jest.resetAllMocks();

--- a/packages/prosemirror-suggest/src/suggest-types.ts
+++ b/packages/prosemirror-suggest/src/suggest-types.ts
@@ -651,6 +651,16 @@ export interface SuggestMatch<Schema extends EditorSchema = EditorSchema>
    * property to be a regex which included matching capture group segments.
    */
   match: RegExpExecArray;
+
+  /**
+   * The text after full match, up until the end of the text block.
+   */
+  textAfter: string;
+
+  /**
+   * The text before the full match, up until the beginning of the node.
+   */
+  textBefore: string;
 }
 
 export interface DocChangedParameter {

--- a/packages/prosemirror-suggest/src/suggest-utils.ts
+++ b/packages/prosemirror-suggest/src/suggest-utils.ts
@@ -124,6 +124,8 @@ function findPosition<Schema extends EditorSchema = EditorSchema>(
             full: match[0].slice(charMatch.length),
           },
           text: { partial: match[0].slice(0, matchLength), full: match[0] },
+          textAfter: $pos.doc.textBetween(to, $pos.end(), NULL_CHARACTER, NULL_CHARACTER),
+          textBefore: $pos.doc.textBetween(start, from, NULL_CHARACTER, NULL_CHARACTER),
           suggester,
         };
       }

--- a/support/root/.eslintrc.js
+++ b/support/root/.eslintrc.js
@@ -64,7 +64,7 @@ let config = {
     'jest/prefer-spy-on': ['warn'],
     'jest/prefer-todo': ['warn'],
     'jest/prefer-hooks-on-top': ['error'],
-    'jest/no-large-snapshots': ['warn', { maxSize: 12 }],
+    'jest/no-large-snapshots': ['warn', { maxSize: 20 }],
     'jest/no-duplicate-hooks': ['error'],
     'jest/no-if': ['error'],
     'jest/no-restricted-matchers': [

--- a/support/website/package.json
+++ b/support/website/package.json
@@ -8,6 +8,7 @@
     "build": "docusaurus build",
     "deploy": "docusaurus deploy",
     "start": "docusaurus start",
+    "start:shared": "docusaurus start -h $HOSTNAME --port 8000",
     "swizzle": "docusaurus swizzle"
   },
   "browserslist": [


### PR DESCRIPTION
### Description

- Support `EditorState | Selection | ResolvedPos` for the `findParentNodeOfType` function.
- Pass through `defaultAppendTextValue` property to `onChange` handler of `MentionExtension`.
- Don't append text to `useMention` hook command when content after starts with whitespaces.

Fixes #752

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-10-15 13 09 38](https://user-images.githubusercontent.com/1160934/96121444-fd030580-0ee7-11eb-998a-b8137e79c09b.gif)

