### PR TITLE
Remove references to the deprecated `jsdomExtras()`

### DIFF
--- a/packages/jest-remirror/readme.md
+++ b/packages/jest-remirror/readme.md
@@ -47,16 +47,13 @@ Create a `jest.framework.dom.ts` file and add the following
 ```ts
 /* jest.framework.dom.ts */
 
-import { jsdomExtras, jsdomPolyfill, remirrorMatchers } from 'jest-remirror';
+import { jsdomPolyfill, remirrorMatchers } from 'jest-remirror';
 
 /* Add jest-remirror assertions */
 expect.extend(remirrorMatchers);
 
 /* Polyfills for jsdom */
 jsdomPolyfill();
-
-/* Extras for prosemirror testing */
-jsdomExtras();
 ```
 
 In your `jest.config.js` file add this to the configuration


### PR DESCRIPTION
### Description

As per the deprecation notice, and the fact that https://github.com/remirror/remirror/blob/7a52b28f4137f1ed11e6473ac5701dd1d081a9aa/packages/jest-remirror/src/jsdom-polyfills.ts#L39-L47 is empty anyways.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] ~My code follows the code style of this project and `pnpm fix` completed successfully.~ Documentation change
- [x] I have updated the documentation where necessary.
- [x] ~New code is unit tested and all current tests pass when running `pnpm test`.~ No new code

