### PR TITLE
Avoid `LinkExtension` `pasteRules` when `autoLink` enabled

### DIFF
--- a/.changeset/green-frogs-know.md
+++ b/.changeset/green-frogs-know.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-link': major
+---
+
+**BREAKING** avoid using the paste rule if `autoLink` is enabled for `LinkExtension`

--- a/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
+++ b/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
@@ -448,7 +448,7 @@ describe('autolinking', () => {
     editorText += 'm';
     editor.insertText('m');
 
-    expect(onUpdateLink).toHaveBeenCalledWith('test.com', {
+    expect(onUpdateLink).toHaveBeenCalledWith(editorText, {
       doc: editor.doc,
       selection: editor.view.state.selection,
       range: {

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -238,6 +238,10 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
    * Create the paste rules that can transform a pasted link in the document.
    */
   createPasteRules(): ProsemirrorPlugin[] {
+    if (this.options.autoLink) {
+      return [];
+    }
+
     return [
       markPasteRule({
         regexp: /https?:\/\/(www\.)?[\w#%+.:=@~-]{2,256}\.[a-z]{2,6}\b([\w#%&+./:=?@~-]*)/gi,


### PR DESCRIPTION
### Description

#### Issue

This fixes some inconsistent behaviour when using the `LinkExtension` with `autoLink: true`.

Pasting a link *without* `www.` prefix - `updateLink` command called, and `onUpdateLink` event fired
Pasting a link *with* `www.` prefix - `updateLink` command **not** called, and `onUpdateLink` event not fired

This is because the link created via the [paste rule](https://github.com/remirror/remirror/blob/next/packages/@remirror/extension-link/src/link-extension.ts#L245) was deemed to have [no changes](https://github.com/remirror/remirror/blob/next/packages/@remirror/extension-link/src/link-extension.ts#L438-L446) and would bail out before calling `updateLink`.

#### Change

This change prevents the paste rule from being applied, if `autoLink` is enabled, as auto linking will create the link regardless.

I have added this as breaking change, please let me know if that is incorrect.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

