### PR TITLE
Allow links to be clickable

### DIFF
--- a/.changeset/honest-birds-do.md
+++ b/.changeset/honest-birds-do.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-link': minor
+---
+
+Allow links to be clickable
+
+Anchor tags in contenteditable are not clickable by default. To allow users nonetheless to open them, this commit adds an optional clickhandler to open the link.

--- a/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
+++ b/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
@@ -399,6 +399,23 @@ describe('plugin', () => {
         expect({ start, end }).toEqual({ start: 1, end: 5 });
       });
   });
+
+  it('clickHandler opens link when clicked', () => {
+    const {
+      add,
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = create({ openLinkOnClick: true });
+    const testLink = link({ href });
+
+    global.open = jest.fn();
+
+    add(doc(p(testLink('Li<cursor>nk'))))
+      .fire({ event: 'click' })
+      .callback(() => {
+        expect(global.open).toBeCalled();
+      });
+  });
 });
 
 describe('autolinking', () => {

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -65,6 +65,11 @@ export interface LinkOptions {
   selectTextOnClick?: boolean;
 
   /**
+   * Weather the link is opened when being clicked
+   */
+  openLinkOnClick?: boolean;
+
+  /**
    * Whether automatic links should be created.
    *
    * @default false
@@ -107,6 +112,7 @@ export type LinkAttributes = MarkAttributes<{
     autoLink: false,
     defaultProtocol: '',
     selectTextOnClick: false,
+    openLinkOnClick: false,
     autoLinkRegex: /(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/\S*)?/,
   },
   staticKeys: ['autoLinkRegex'],
@@ -466,7 +472,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     return {
       props: {
         handleClick: (view, pos) => {
-          if (!this.options.selectTextOnClick) {
+          if (!this.options.selectTextOnClick && !this.options.openLinkOnClick) {
             return false;
           }
 
@@ -477,11 +483,19 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
             return false;
           }
 
-          const $start = doc.resolve(range.from);
-          const $end = doc.resolve(range.to);
-          const transaction = tr.setSelection(new TextSelection($start, $end));
+          if (this.options.openLinkOnClick) {
+            const href = range.mark.attrs.href;
+            window.open(href, '_blank');
+          }
 
-          view.dispatch(transaction);
+          if (this.options.selectTextOnClick) {
+            const $start = doc.resolve(range.from);
+            const $end = doc.resolve(range.to);
+            const transaction = tr.setSelection(new TextSelection($start, $end));
+
+            view.dispatch(transaction);
+          }
+
           return true;
         },
       },

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -65,7 +65,7 @@ export interface LinkOptions {
   selectTextOnClick?: boolean;
 
   /**
-   * Weather the link is opened when being clicked
+   * Whether the link is opened when being clicked
    */
   openLinkOnClick?: boolean;
 

--- a/support/storybook/stories/link-extension.stories.tsx
+++ b/support/storybook/stories/link-extension.stories.tsx
@@ -1,0 +1,50 @@
+import React, { FC, useEffect, useMemo } from 'react';
+import { LinkExtension, LinkOptions } from 'remirror/extension/link';
+import { RemirrorProvider, useManager, useRemirror } from 'remirror/react';
+
+export default { title: 'Link extension' };
+
+const SmallEditor: FC = () => {
+  const { getRootProps, setContent, commands } = useRemirror();
+
+  useEffect(() => {
+    setContent({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'www.remirror.io',
+              marks: [
+                {
+                  type: 'link',
+                  attrs: {
+                    href: 'https://www.remirror.io',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  }, [setContent, commands]);
+
+  return <div {...getRootProps()} />;
+};
+
+export const Basic = (args: LinkOptions) => {
+  const extensionManager = useManager([new LinkExtension(args)]);
+
+  return (
+    <RemirrorProvider manager={extensionManager}>
+      <SmallEditor />
+    </RemirrorProvider>
+  );
+};
+Basic.args = {
+  autoLink: true,
+  openLinkOnClick: true,
+};

--- a/support/storybook/stories/link-extension.stories.tsx
+++ b/support/storybook/stories/link-extension.stories.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { FC, useEffect } from 'react';
 import { LinkExtension, LinkOptions } from 'remirror/extension/link';
 import { RemirrorProvider, useManager, useRemirror } from 'remirror/react';
 


### PR DESCRIPTION
### Description

Anchor tags in contenteditable are not clickable by default. To allow users nonetheless to open them, this commit adds an optional clickhandler to open the link.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
