### PR TITLE
Prevent merging callouts, when deleting content in between callout nodes

### DIFF
--- a/.changeset/warm-pugs-unite.md
+++ b/.changeset/warm-pugs-unite.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-callout': minor
+---
+
+Prevent callouts being merged when removing content in between callout nodes

--- a/packages/@remirror/extension-callout/src/callout-extension.ts
+++ b/packages/@remirror/extension-callout/src/callout-extension.ts
@@ -3,11 +3,15 @@ import {
   CommandFunction,
   extensionDecorator,
   ExtensionTag,
+  findNodeAtSelection,
   isElementDomNode,
+  KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
   toggleWrap,
 } from '@remirror/core';
+import { TextSelection } from '@remirror/pm/state';
+
 import type { CalloutAttributes, CalloutOptions } from './callout-types';
 import { dataAttributeType, updateNodeAttributes } from './callout-utils';
 
@@ -88,6 +92,64 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
        */
       updateCallout: (attributes: CalloutAttributes): CommandFunction =>
         updateNodeAttributes(this.type)(attributes),
+    };
+  }
+
+  /**
+   * Create specific keyboard bindings for the code block.
+   */
+  createKeymap(): KeyBindings {
+    return {
+      Backspace: ({ dispatch, tr }) => {
+        // Aims to stop merging callouts when deleting content in between
+        const { selection } = tr;
+
+        // If the selection is not empty return false and let other extension
+        // (ie: BaseKeymapExtension) to do the deleting operation.
+        if (!selection.empty) {
+          return false;
+        }
+
+        const { $from } = selection;
+
+        // If not at the start of current node, no joining will happen
+        if ($from.parentOffset !== 0) {
+          return false;
+        }
+
+        const previousPosition = $from.before($from.depth) - 1;
+
+        // If nothing above to join with
+        if (previousPosition < 1) {
+          return false;
+        }
+
+        const previousPos = tr.doc.resolve(previousPosition);
+
+        // If resolving previous position fails, bail out
+        if (!previousPos?.parent) {
+          return false;
+        }
+
+        const previousNode = previousPos.parent;
+        const { node, pos } = findNodeAtSelection(selection);
+
+        // If previous node is a callout, cut current node's content into it
+        if (node.type !== this.type && previousNode.type === this.type) {
+          const { content, nodeSize } = node;
+          tr.delete(pos, pos + nodeSize);
+          tr.setSelection(TextSelection.create(tr.doc, previousPosition - 1));
+          tr.insert(previousPosition - 1, content);
+
+          if (dispatch) {
+            dispatch(tr);
+          }
+
+          return true;
+        }
+
+        return false;
+      },
     };
   }
 }

--- a/packages/@remirror/playground/src/_remirror.tsx
+++ b/packages/@remirror/playground/src/_remirror.tsx
@@ -15,6 +15,7 @@ export const IMPORT_CACHE: { [moduleName: string]: any } = {
   'remirror/extension/bidi': require('remirror/extension/bidi'),
   'remirror/extension/blockquote': require('remirror/extension/blockquote'),
   'remirror/extension/bold': require('remirror/extension/bold'),
+  'remirror/extension/callout': require('remirror/extension/callout'),
   'remirror/extension/code': require('remirror/extension/code'),
   'remirror/extension/code-block': require('remirror/extension/code-block'),
   'remirror/extension/collaboration': require('remirror/extension/collaboration'),
@@ -110,6 +111,10 @@ export const INTERNAL_MODULES: Array<{ moduleName: string; exports: string[] }> 
   {
     moduleName: 'remirror/extension/bold',
     exports: ['BoldExtension'],
+  },
+  {
+    moduleName: 'remirror/extension/callout',
+    exports: ['CalloutExtension'],
   },
   {
     moduleName: 'remirror/extension/code',


### PR DESCRIPTION
### Description

Given this scenario, pressing `backspace` would merge two callout nodes

<img width="567" alt="Screenshot 2020-11-09 at 17 22 04" src="https://user-images.githubusercontent.com/2003804/98575238-d5b61300-22b0-11eb-93e7-bfe09853e539.png">

**Before**: 
<img width="551" alt="Screenshot 2020-11-09 at 17 26 26" src="https://user-images.githubusercontent.com/2003804/98575299-eebec400-22b0-11eb-8773-31c47eb692a9.png">

**After**:
<img width="569" alt="Screenshot 2020-11-09 at 17 22 18" src="https://user-images.githubusercontent.com/2003804/98575324-f7af9580-22b0-11eb-957f-dde309114c30.png">

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

