### PR TITLE
Fix `updateMark` to return `false` when not applicable

### DIFF
--- a/.changeset/real-dancers-search.md
+++ b/.changeset/real-dancers-search.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-link': patch
+---
+
+The behaviour of `commands.updateLink.isEnabled()` has been **fixed** to return `false` when the `link` mark can't be applied to the selection. This was fixed by a change in the `@remirror/core-utils` package.

--- a/packages/@remirror/core-utils/src/__tests__/command-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/command-utils.spec.ts
@@ -1,4 +1,14 @@
-import { atomInline, blockquote, createEditor, doc, h1, p, schema, strong } from 'jest-prosemirror';
+import {
+  atomInline,
+  blockquote,
+  codeBlock,
+  createEditor,
+  doc,
+  h1,
+  p,
+  schema,
+  strong,
+} from 'jest-prosemirror';
 
 import { removeMark, replaceText, toggleBlockItem, toggleWrap, updateMark } from '../command-utils';
 
@@ -97,11 +107,36 @@ describe('replaceText', () => {
   });
 });
 
-test('updateMark', () => {
-  const from = doc(p('Make <start>bold<end>'));
-  const to = doc(p('Make ', strong('bold')));
+describe('updateMark', () => {
+  const type = schema.marks.strong;
 
-  expect(updateMark({ type: schema.marks.strong })).toTransform({ from, to });
+  it('adds the mark to the selection', () => {
+    const from = doc(p('Make <start>bold<end>'));
+    const to = doc(p('Make ', strong('bold')));
+
+    expect(updateMark({ type })).toTransform({ from, to });
+  });
+
+  it('does not add the mark if it is not applicable', () => {
+    const from = doc(codeBlock('Not <start>bold<end> in code block'));
+    const to = doc(codeBlock('Not bold in code block'));
+
+    expect(updateMark({ type })).toTransform({ from, to });
+  });
+
+  it('adds the mark to a custom range', () => {
+    const from = doc(p('Make bold with range<cursor>'));
+    const to = doc(p('Make ', strong('bold'), ' with range'));
+
+    expect(updateMark({ type, range: { from: 6, to: 10 } })).toTransform({ from, to });
+  });
+
+  it('does not add the mark to a custom range if it is not applicable', () => {
+    const from = doc(codeBlock('Not bold in code block<cursor>'));
+    const to = doc(codeBlock('Not bold in code block'));
+
+    expect(updateMark({ type, range: { from: 5, to: 9 } })).toTransform({ from, to });
+  });
 });
 
 describe('toggleWrap', () => {


### PR DESCRIPTION
### Description

Fix `updateMark` so it returns `false` if the mark cannot be applied to the selection or range

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

