### PR TITLE
Fix `YjsExtension` redo keybinding

### DIFF
--- a/.changeset/long-phones-enjoy.md
+++ b/.changeset/long-phones-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Export `PrioritizedKeyBindings` from `@remirror/core` and `remirror/core` entry points.

--- a/.changeset/tall-countries-wait.md
+++ b/.changeset/tall-countries-wait.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-yjs': minor
+---
+
+Fix problems around destroying the `YjsExtension` provider and the `CMD+SHIFT+Z` keymap not registering as mentioned in [#772](https://github.com/remirror/remirror/issues/772).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         run: pnpm lint:css
 
       - name: check TS / JS files
-        run: pnpm lint:es -- -f github --quiet
+        run: pnpm lint:es -- -f github
 
       - name: check markdown code blocks
-        run: pnpm lint:md -- -f github --quiet
+        run: pnpm lint:md -- -f github
 
       - name: check formatting
         run: pnpm lint:prettier

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fix": "cross-env TS=true run-s -c fix:*",
     "fix:build": "preconstruct fix",
     "fix:css": "node support/scripts/check-styles.js --fix",
-    "fix:es": "pnpm lint:es -- --fix --quiet",
+    "fix:es": "pnpm lint:es -- --fix",
     "fix:md": "pnpm lint:md -- --fix",
     "fix:prettier": "pnpm run:prettier -- --write",
     "fix:repo": "manypkg fix",

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -148,7 +148,7 @@ export function isAllSelection(value: unknown): value is AllSelection<EditorSche
  *
  * @param value - the value to check
  */
-export function isSelection(value: unknown): value is Selection<EditorSchema> {
+export function isSelection(value: unknown): value is Selection {
   return isObject(value) && value instanceof PMSelection;
 }
 

--- a/packages/@remirror/core/src/index.ts
+++ b/packages/@remirror/core/src/index.ts
@@ -8,6 +8,7 @@ export type {
   IdentifierSchemaAttributes,
   Identifiers,
   KeymapOptions,
+  PrioritizedKeyBindings,
   SuggestOptions,
   UpdatableViewProps,
 } from './builtins';

--- a/packages/@remirror/dev/readme.md
+++ b/packages/@remirror/dev/readme.md
@@ -20,4 +20,31 @@ For in depth usage with proper code example see the [docs](https://remirror.io)
 
 The following will render the development view in your editor. For more information on what's possible see the [docs][prosemirror-dev-tools].
 
+```tsx
+import React from 'react';
+import { BoldExtension } from 'remirror/extension/bold';
+import { ItalicExtension } from 'remirror/extension/italic';
+import { UnderlineExtension } from 'remirror/extension/underline';
+import { CorePreset } from 'remirror/preset/core';
+import { RemirrorProvider } from 'remirror/react';
+import { RemirrorProvider, useManager } from 'remirror/react';
+
+import { ProsemirrorDevTools } from '@remirror/dev';
+
+const Editor = () => {
+  const manager = useManager([
+    new CorePreset(),
+    new BoldExtension(),
+    new ItalicExtension(),
+    new UnderlineExtension(),
+  ]);
+
+  return (
+    <RemirrorProvider manager={manager} autoRender={true}>
+      <ProsemirrorDevTools />
+    </RemirrorProvider>
+  );
+};
+```
+
 [prosemirror-dev-tools]: https://github.com/d4rkr00t/prosemirror-dev-tools

--- a/packages/@remirror/extension-annotation/src/annotation-extension.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-extension.ts
@@ -28,7 +28,7 @@ function defaultGetStyle<A extends Annotation>(annotations: Array<AnnotationWith
  * Extend the Annotation interface to store application specific
  * information like tags or color.
  */
-@extensionDecorator<AnnotationOptions<Annotation>>({
+@extensionDecorator<AnnotationOptions>({
   defaultOptions: {
     getStyle: defaultGetStyle,
     blockSeparator: undefined,

--- a/packages/@remirror/extension-annotation/src/annotation-plugin.ts
+++ b/packages/@remirror/extension-annotation/src/annotation-plugin.ts
@@ -24,7 +24,7 @@ export class AnnotationState<A extends Annotation = Annotation> {
    */
   decorationSet = DecorationSet.empty;
 
-  constructor(private getStyle: GetStyle<A>) {}
+  constructor(private readonly getStyle: GetStyle<A>) {}
 
   apply({ tr, action }: ApplyParameter): this {
     const actionType = action?.type;

--- a/packages/@remirror/extension-callout/src/callout-types.ts
+++ b/packages/@remirror/extension-callout/src/callout-types.ts
@@ -1,4 +1,5 @@
 import type { LiteralUnion } from 'type-fest';
+
 import type { ProsemirrorAttributes } from '@remirror/core';
 
 /**

--- a/packages/@remirror/extension-codemirror/src/codemirror-node-view.ts
+++ b/packages/@remirror/extension-codemirror/src/codemirror-node-view.ts
@@ -17,11 +17,11 @@ export class CodeMirrorNodeView implements NodeView {
   public dom: Node;
 
   private node: ProsemirrorNode;
-  private schema: EditorSchema;
-  private view: EditorView;
-  private getPos: () => number;
+  private readonly schema: EditorSchema;
+  private readonly view: EditorView;
+  private readonly getPos: () => number;
   private incomingChanges: boolean;
-  private cm: CodeMirror.Editor;
+  private readonly cm: CodeMirror.Editor;
   private updating: boolean;
 
   constructor(

--- a/packages/@remirror/extension-history/src/history-extension.ts
+++ b/packages/@remirror/extension-history/src/history-extension.ts
@@ -7,10 +7,10 @@ import {
   extensionDecorator,
   Handler,
   isFunction,
-  KeyBindings,
   nonChainable,
   NonChainableCommandFunction,
   PlainExtension,
+  PrioritizedKeyBindings,
   ProsemirrorCommandFunction,
   ProsemirrorPlugin,
   Static,
@@ -19,16 +19,16 @@ import { history, redo, undo } from '@remirror/pm/history';
 
 export interface HistoryOptions {
   /**
-   * The amount of history events that are collected before the
-   * oldest events are discarded.
+   * The number of history events that are collected before the oldest events
+   * are discarded.
    *
    * @default 100
    */
   depth?: Static<number>;
 
   /**
-   * The delay (ms) between changes after which a new group should be
-   * started. Note that when changes aren't adjacent, a new group is always started.
+   * The delay (ms) between changes after which a new group should be started.
+   * Note that when changes aren't adjacent, a new group is always started.
    *
    * @default 500
    */
@@ -52,9 +52,9 @@ export interface HistoryOptions {
    * @remarks
    *
    * This is only needed when the extension is part of a child editor, e.g.
-   * `ImageCaptionEditor`. By passing in the `getDispatch` method history actions
-   * can be dispatched into the parent editor allowing them to propagate into
-   * the child editor.
+   * `ImageCaptionEditor`. By passing in the `getDispatch` method history
+   * actions can be dispatched into the parent editor allowing them to propagate
+   * into the child editor.
    */
   getDispatch?: AcceptUndefined<() => DispatchFunction>;
 
@@ -117,16 +117,11 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
   /**
    * Adds the default key mappings for undo and redo.
    */
-  createKeymap(): KeyBindings {
-    const notMacOS = !environment.isMac
-      ? { ['Mod-y']: this.wrapMethod(redo, this.options.onRedo) }
-      : undefined;
-
+  createKeymap(): PrioritizedKeyBindings {
     return {
-      'Mod-y': () => false,
+      'Mod-y': !environment.isMac ? this.wrapMethod(redo, this.options.onRedo) : () => false,
       'Mod-z': this.wrapMethod(undo, this.options.onUndo),
       'Shift-Mod-z': this.wrapMethod(redo, this.options.onRedo),
-      ...notMacOS,
     };
   }
 
@@ -145,9 +140,9 @@ export class HistoryExtension extends PlainExtension<HistoryOptions> {
   createCommands() {
     return {
       /**
-       * Undo the last action that occurred. This can be overridden by
-       * setting an `"addToHistory"` metadata property of `false` on a
-       * transaction to prevent it from being rolled back by undo.
+       * Undo the last action that occurred. This can be overridden by setting
+       * an `"addToHistory"` metadata property of `false` on a transaction to
+       * prevent it from being rolled back by undo.
        *
        * ```ts
        * actions.undo()

--- a/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
+++ b/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
@@ -456,12 +456,12 @@ describe('plugin', () => {
     } = create({ openLinkOnClick: true });
     const testLink = link({ href });
 
-    global.open = jest.fn();
+    jest.spyOn(global, 'open').mockImplementation();
 
     add(doc(p(testLink('Li<cursor>nk'))))
       .fire({ event: 'click' })
       .callback(() => {
-        expect(global.open).toBeCalled();
+        expect(global.open).toHaveBeenCalled();
       });
   });
 });

--- a/packages/@remirror/extension-yjs/src/__tests__/__snapshots__/yjs-extension.spec.ts.snap
+++ b/packages/@remirror/extension-yjs/src/__tests__/__snapshots__/yjs-extension.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`configuration throws without a provider 1`] = `
+"An error occurred within an extension. More details should be made available.
+
+You must provide a YJS Provider to the \`YjsExtension\`.
+
+For more information visit https://remirror.io/docs/errors#rmr0100"
+`;

--- a/packages/@remirror/extension-yjs/src/__tests__/yjs-extension.spec.ts
+++ b/packages/@remirror/extension-yjs/src/__tests__/yjs-extension.spec.ts
@@ -1,9 +1,135 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import { WebrtcProvider } from 'y-webrtc';
 import { Doc } from 'yjs';
 
-import { YjsExtension } from '..';
+import { hideConsoleError } from '@remirror/testing';
+
+import { defaultDestroyProvider, YjsExtension, YjsOptions } from '../..';
+
+let provider = new WebrtcProvider('global', new Doc());
+
+beforeEach(() => {
+  provider.destroy();
+  provider = new WebrtcProvider('global', new Doc());
+});
 
 extensionValidityTest(YjsExtension, {
-  getProvider: () => new WebrtcProvider('global', new Doc()),
+  getProvider: () => provider,
 });
+
+describe('configuration', () => {
+  hideConsoleError(true);
+
+  it('throws without a provider', () => {
+    expect(() => renderEditor([new YjsExtension()])).toThrowErrorMatchingSnapshot();
+  });
+
+  it('calls the destroy provider', () => {
+    const destroyProvider = jest.fn(defaultDestroyProvider);
+    const { manager } = create({ destroyProvider });
+
+    manager.destroy();
+    expect(destroyProvider).toHaveBeenCalledTimes(1);
+
+    // Make sure the method is only called once.
+    manager.destroy();
+    expect(destroyProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('can update options dynamically', () => {
+    const { manager } = create();
+    const extension = manager.getExtension(YjsExtension);
+
+    const getProvider = jest.fn(() => provider);
+    const destroyProvider = jest.fn(defaultDestroyProvider);
+
+    extension.setOptions({ getProvider, destroyProvider });
+    expect(extension.options.getProvider).toBe(getProvider);
+    expect(extension.options.destroyProvider).toBe(destroyProvider);
+    expect(destroyProvider).not.toHaveBeenCalled();
+    expect(getProvider).toHaveBeenCalledTimes(1);
+
+    extension.setOptions({ getProvider: () => provider });
+    expect(extension.options.destroyProvider).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('commands', () => {
+  it('can undo', () => {
+    const { nodes, add } = create();
+    const { p, doc } = nodes;
+    add(doc(p('<cursor>')))
+      .insertText('Text goes here')
+      .callback(({ commands }) => {
+        expect(commands.yUndo.isEnabled()).toBeTrue();
+        commands.yUndo();
+        expect(commands.yUndo.isEnabled()).toBeFalse();
+      })
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(doc(p('')));
+      });
+  });
+
+  it('can redo', () => {
+    const { nodes, add } = create();
+    const { p, doc } = nodes;
+
+    add(doc(p('<cursor>')))
+      .insertText('Text goes here')
+      .callback(({ commands }) => {
+        expect(commands.yRedo.isEnabled()).toBeFalse();
+        commands.yUndo();
+        expect(commands.yRedo.isEnabled()).toBeTrue();
+        commands.yRedo();
+        expect(commands.yRedo.isEnabled()).toBeFalse();
+      })
+      .callback(({ state }) => {
+        expect(state.doc).toEqualRemirrorDocument(doc(p('Text goes here')));
+      });
+  });
+});
+
+describe('keymap', () => {
+  it('can undo', () => {
+    const { nodes, add } = create();
+    const { p, doc } = nodes;
+
+    add(doc(p('<cursor>')))
+      .insertText('Text goes here')
+      .shortcut('Mod-z')
+      .callback((content) => {
+        expect(content.state.doc).toEqualProsemirrorNode(doc(p('')));
+      });
+  });
+
+  it('can redo', () => {
+    const { nodes, add } = create();
+    const { p, doc } = nodes;
+
+    add(doc(p('<cursor>')))
+      .insertText('Text goes here')
+      .shortcut('Mod-z')
+      .shortcut('Mod-y')
+      .callback((content) => {
+        expect(content.state.doc).toEqualProsemirrorNode(doc(p('Text goes here')));
+      });
+  });
+});
+
+/**
+ * Create a `yjs` extension.
+ */
+function create(options?: Partial<YjsOptions>, excludeHistory = true) {
+  let excludeExtensions: ['history'] | undefined;
+
+  if (excludeHistory) {
+    excludeExtensions = ['history'];
+  }
+
+  const extension = new YjsExtension({
+    getProvider: () => provider,
+    ...options,
+  });
+
+  return renderEditor([extension], { core: { excludeExtensions } });
+}

--- a/packages/@remirror/extension-yjs/src/index.ts
+++ b/packages/@remirror/extension-yjs/src/index.ts
@@ -1,2 +1,2 @@
 export type { YjsOptions } from './yjs-extension';
-export { YjsExtension } from './yjs-extension';
+export { YjsExtension, defaultDestroyProvider } from './yjs-extension';

--- a/packages/@remirror/react/src/hooks/__tests__/editor-hooks.spec.tsx
+++ b/packages/@remirror/react/src/hooks/__tests__/editor-hooks.spec.tsx
@@ -7,7 +7,7 @@ import { ReactPreset } from '@remirror/preset-react';
 import { BoldExtension } from '@remirror/testing';
 import { act as renderAct, render, strictRender } from '@remirror/testing/react';
 
-import { RemirrorProvider, createReactManager, useManager, useRemirror } from '../../..';
+import { createReactManager, RemirrorProvider, useManager, useRemirror } from '../../..';
 
 jest.mock('@remirror/preset-react', () => {
   const actual = jest.requireActual('@remirror/preset-react');

--- a/packages/@remirror/react/src/react-providers.tsx
+++ b/packages/@remirror/react/src/react-providers.tsx
@@ -2,16 +2,16 @@ import type { CSSProperties, ElementType, ReactElement, ReactNode } from 'react'
 import React, { useEffect } from 'react';
 
 import type { AnyCombinedUnion, MakeOptional } from '@remirror/core';
+import { RemirrorPortals, usePortals } from '@remirror/extension-react-component';
 import { i18n as defaultI18n } from '@remirror/i18n';
 import { RemirrorType } from '@remirror/react-utils';
 import type { RemirrorThemeType } from '@remirror/theme';
 import { createThemeVariables, themeStyles } from '@remirror/theme';
 
 import { useManager, useRemirror } from './hooks';
+import { useReactEditor } from './hooks/use-react-editor';
 import { I18nContext, RemirrorContext } from './react-contexts';
 import type { BaseProps, CreateReactManagerOptions, I18nContextProps } from './react-types';
-import { useReactEditor } from './hooks/use-react-editor';
-import { RemirrorPortals, usePortals } from '@remirror/extension-react-component';
 
 export interface RemirrorProviderProps<Combined extends AnyCombinedUnion>
   extends MakeOptional<BaseProps<Combined>, 'manager'> {

--- a/packages/jest-prosemirror/src/jest-prosemirror-schema.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-schema.ts
@@ -2,7 +2,7 @@ import { marks, nodes } from 'prosemirror-schema-basic';
 import { tableNodes } from 'prosemirror-tables';
 
 import { NodeGroup } from '@remirror/core-constants';
-import { NodeSpec, MarkSpec, Schema } from '@remirror/pm/model';
+import { MarkSpec, NodeSpec, Schema } from '@remirror/pm/model';
 import {
   bulletList as baseBulletList,
   listItem as baseListItem,

--- a/support/root/jest.config.js
+++ b/support/root/jest.config.js
@@ -2,7 +2,9 @@ module.exports = {
   ...require('../jest/jest.config'),
   coverageThreshold: {
     global: {
-      statements: 60,
+      statements: 80,
+      functions: 80,
+      lines: 80,
     },
   },
   collectCoverageFrom: [
@@ -16,16 +18,64 @@ module.exports = {
     '!**/__dts__/**',
     '!**/__fixtures__/**',
     '!support/**',
+
+    // This is internal code and doesn't affect the end user experience.
     '!packages/@remirror/playground/**',
+
+    // Currently can't be tested with JSDOM
     '!packages/@remirror/extension-epic-mode/**',
-    '!packages/@remirror/extension-yjs/**',
+
+    // Tests written but needs more coverage.
+    '!packages/@remirror/extension-codemirror/**',
+
+    // Refactor upcoming for emoji which will change the structure.
+    '!packages/@remirror/extension-emoji/src/data/**',
+
+    // Positions can't be tested properly in JSDOM. This will be addressed again
+    // once the project moves to a new unit test runner.
+    '!packages/@remirror/extension-positioner/**',
+
+    // Themes may be removed at some point, or heavily refactored.
+    '!packages/@remirror/theme/**',
+
+    // Tables are still in a very early stage
+    '!packages/@remirror/preset-table/**',
+
+    // There is still al ot of work needed in order to make renderers useful.
+    '!packages/@remirror/react/src/renderers/**',
+
+    // SSR is currently being looked at, starting from e2e tests.
+    '!packages/@remirror/react/src/ssr/**',
+
+    // Still deciding whether to deprecate and replace with `yjs`.
     '!packages/@remirror/extension-collaboration/**',
+
+    // Still a wip
     '!packages/@remirror/extension-image/**',
+
+    // Still a wip
     '!packages/@remirror/preset-embed/**',
+
+    // Still a wip
     '!packages/@remirror/preset-list/**',
+
+    // Still a wip
     '!packages/@remirror/react-components/**',
+
+    // Deprecated package
+    '!packages/@remirror/react-social/**',
+
+    // Still deciding how best to use this project. It should be moved outside
+    // of remirror for simplification.
+    '!packages/multishift/**',
+
+    // Deprecated package
     '!packages/@remirror/react-wysiwyg/**',
+
+    // Deprecated package
     '!packages/@remirror/showcase/**',
+
+    // Still a wip. No tests at the moment due to lack of usage.
     '!packages/@remirror/cli/**',
   ],
   coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],


### PR DESCRIPTION
### Description

- Export `PrioritizedKeyBindings` from '@remirror/core`and`remirror/core` entrypoints.
- Fix problems around destroying the `YjsExtension` provider and the `CMD+SHIFT+Z` keymap not registering as mentioned in [#772](https://github.com/remirror/remirror/issues/772).

Closes #772

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

