### PR TITLE
Make `draggability` configurable for atom mentions

### DIFF
--- a/.changeset/tidy-files-guess.md
+++ b/.changeset/tidy-files-guess.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-mention-atom': minor
+---
+
+Make `draggability` configurable for `MentionAtomExtension` as mentioned in [#777](https://github.com/remirror/remirror/issues/777).

--- a/packages/@remirror/extension-mention-atom/src/mention-atom-extension.ts
+++ b/packages/@remirror/extension-mention-atom/src/mention-atom-extension.ts
@@ -41,6 +41,13 @@ export interface MentionAtomOptions
   selectable?: Static<boolean>;
 
   /**
+   * Whether mentions should be draggable.
+   *
+   * @default false
+   */
+  draggable?: Static<boolean>;
+
+  /**
    * Provide a custom tag for the mention
    */
   mentionTag?: Static<string>;
@@ -91,6 +98,7 @@ export interface MentionAtomOptions
 @extensionDecorator<MentionAtomOptions>({
   defaultOptions: {
     selectable: true,
+    draggable: false,
     mentionTag: 'span' as const,
     matchers: [],
     appendText: ' ',
@@ -125,6 +133,7 @@ export class MentionAtomExtension extends NodeExtension<MentionAtomOptions> {
       },
       inline: true,
       selectable: this.options.selectable,
+      draggable: this.options.draggable,
       atom: true,
 
       parseDOM: [


### PR DESCRIPTION
### Description

- Make `draggability` configurable for `MentionAtomExtension` as mentioned in [#777](https://github.com/remirror/remirror/issues/777).

Closes #777

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
