### PR TITLE
Fix `removeMark` when `dispatch=undefined`

### DIFF
--- a/.changeset/hot-olives-obey.md
+++ b/.changeset/hot-olives-obey.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Fix `removeMark` when called with `dispatch = undefined`. This means that `command.<NAME>.isEnabled()` checks should all be fixed if they are using `removeMark` as mentioned in [#784](https://github.com/remirror/remirror/issues/784).

--- a/packages/@remirror/core-utils/src/__tests__/command-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/command-utils.spec.ts
@@ -46,6 +46,23 @@ describe('removeMark', () => {
       to,
     });
   });
+
+  it('does not mutate the provided transaction', () => {
+    const from = doc(p('start ', strong('bo<cursor>ld'), ' and not'));
+    const editor = createEditor(from);
+    const tr = editor.state.tr;
+    const view = editor.view;
+
+    removeMark({ type })({ state: editor.state, tr, view });
+    removeMark({ type })({ state: editor.state, tr, view });
+
+    // Make sure that no steps have been added when dispatch is not enabled.
+    expect(tr.steps).toHaveLength(0);
+
+    // Dispatch the transaction to make sure nothing has changed.
+    view.dispatch(tr);
+    expect(editor.view.state.doc).toEqualProsemirrorNode(from);
+  });
 });
 
 describe('replaceText', () => {

--- a/packages/@remirror/core-utils/src/command-utils.ts
+++ b/packages/@remirror/core-utils/src/command-utils.ts
@@ -348,11 +348,7 @@ export function removeMark(parameter: RemoveMarkParameter): CommandFunction {
         : { from, to });
     }
 
-    tr.removeMark(from, isNumber(to) ? to : from, type);
-
-    if (dispatch) {
-      dispatch(tr);
-    }
+    dispatch?.(tr.removeMark(from, isNumber(to) ? to : from, type));
 
     return true;
   };


### PR DESCRIPTION
### Description

Fix `removeMark` when called with `dispatch = undefined`. This means that `command.<NAME>.isEnabled()` checks should all be fixed if they are using `removeMark` as mentioned in [#784](https://github.com/remirror/remirror/issues/784).

Closes #784

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
