### PR TITLE
fix: input rules combined with codeblock

### DIFF
--- a/.changeset/happy-olives-care.md
+++ b/.changeset/happy-olives-care.md
@@ -1,0 +1,11 @@
+---
+'@remirror/core': minor
+---
+
+Add new primitive commands to `CommandsExtension`.
+
+- `setBlockNodeType`
+- `toggleWrappingNode`
+- `toggleBlockNodeItem`
+- `wrapInNode`
+- `removeMark`

--- a/.changeset/silly-hairs-live.md
+++ b/.changeset/silly-hairs-live.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Fix `getChangedNodeRanges` when resolving content that may no longer be within the range of the full document. This addresses the issues raised in [#797](https://github.com/remirror/remirror/issues/797) and [#764](https://github.com/remirror/remirror/issues/764).

--- a/.changeset/sour-oranges-agree.md
+++ b/.changeset/sour-oranges-agree.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Improve type signatures of command utility functions to also include an optional range.

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -427,15 +427,19 @@ export function getChangedNodeRanges(
   const ranges = getChangedRanges(tr, StepTypes);
 
   for (const range of ranges) {
-    const $from = tr.doc.resolve(range.from);
-    const $to = tr.doc.resolve(range.to);
+    try {
+      const $from = tr.doc.resolve(range.from);
+      const $to = tr.doc.resolve(range.to);
 
-    // Find the node range for this provided range.
-    const nodeRange = $from.blockRange($to);
+      // Find the node range for this provided range.
+      const nodeRange = $from.blockRange($to);
 
-    // Make sure a valid node is available.
-    if (nodeRange) {
-      nodeRanges.push(nodeRange);
+      // Make sure a valid node is available.
+      if (nodeRange) {
+        nodeRanges.push(nodeRange);
+      }
+    } catch {
+      // Changed ranged outside the document
     }
   }
 

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -20,7 +20,15 @@ import type {
   Static,
   Transaction,
 } from '@remirror/core-types';
-import { findNodeAtPosition, getTextSelection } from '@remirror/core-utils';
+import {
+  findNodeAtPosition,
+  getTextSelection,
+  removeMark,
+  setBlockType,
+  toggleBlockItem,
+  toggleWrap,
+  wrapIn,
+} from '@remirror/core-utils';
 import { EditorState, TextSelection } from '@remirror/pm/state';
 import { Decoration, DecorationSet, EditorView } from '@remirror/pm/view';
 
@@ -488,6 +496,36 @@ export class CommandsExtension extends PlainExtension<CommandOptions> {
           ? (dispatch?.(tr), true)
           : false;
       },
+
+      /**
+       * Set the block type of the current selection or the provided range.
+       */
+      setBlockNodeType: setBlockType,
+
+      /**
+       * Toggle between wrapping an inactive node with the provided node type, and
+       * lifting it up into it's parent.
+       *
+       * @param nodeType - the node type to toggle
+       * @param attrs - the attrs to use for the node
+       */
+      toggleWrappingNode: toggleWrap,
+
+      /**
+       * Toggle a block between the provided type and toggleType.
+       */
+      toggleBlockNodeItem: toggleBlockItem,
+
+      /**
+       * Wrap the selection or the provided text in a node of the given type with the
+       * given attributes.
+       */
+      wrapInNode: wrapIn,
+
+      /**
+       * Removes a mark from the current selection or provided range.
+       */
+      removeMark,
     };
 
     return commands;


### PR DESCRIPTION
### Description

Improve type signatures of command utility functions to also include an optional range.

Add new primitive commands to `CommandsExtension`.

- `setBlockNodeType`
- `toggleWrappingNode`
- `toggleBlockNodeItem`
- `wrapInNode`
- `removeMark`

Fix `getChangedNodeRanges` when resolving content that may no longer be within the range of the full document. This addresses the issues raised in [#797](https://github.com/remirror/remirror/issues/797) and [#764](https://github.com/remirror/remirror/issues/764).

- Closes #797
- Closes #764

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2020-11-19 16 05 43](https://user-images.githubusercontent.com/1160934/99691510-37306b80-2a81-11eb-8ff1-5745e62a710f.gif)

![2020-11-19 16 06 09](https://user-images.githubusercontent.com/1160934/99691518-3992c580-2a81-11eb-9096-e3a229d7fb7b.gif)
