### PR TITLE
fix(playground): enable importing react-dom/server

### DIFF
--- a/packages/@remirror/playground/package.json
+++ b/packages/@remirror/playground/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "import-remirror": "echo 'Be sure to run `pnpm build` in root first!' && ts-node -O '{\"module\":\"commonjs\"}' --transpile-only ./scripts/import-remirror.ts"
+    "import-remirror": "echo 'Be sure to run `pnpm build` in root first!' && pnpm -w ts $(pwd)/scripts/import-remirror.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",

--- a/packages/@remirror/playground/package.json
+++ b/packages/@remirror/playground/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "import-remirror": "echo 'Be sure to run `pnpm build` in root first!' && pnpm -w ts $(pwd)/scripts/import-remirror.ts"
+    "import-remirror": "pnpm -w playground:imports"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.0",

--- a/packages/@remirror/playground/scripts/import-remirror.ts
+++ b/packages/@remirror/playground/scripts/import-remirror.ts
@@ -132,6 +132,8 @@ export const IMPORT_CACHE: { [moduleName: string]: any } = {
   '@babel/runtime/helpers/inherits': require('@babel/runtime/helpers/inherits'),
   '@babel/runtime/helpers/defineProperty': require('@babel/runtime/helpers/defineProperty'),
   react: require('react'),
+  'react-dom': require('react-dom'),
+  'react-dom/server': require('react-dom/server'),
 };
 
 export const INTERNAL_MODULES: Array<{ moduleName: string, exports: string[] }> = [

--- a/packages/@remirror/playground/src/_remirror.tsx
+++ b/packages/@remirror/playground/src/_remirror.tsx
@@ -89,6 +89,8 @@ export const IMPORT_CACHE: { [moduleName: string]: any } = {
   '@babel/runtime/helpers/inherits': require('@babel/runtime/helpers/inherits'),
   '@babel/runtime/helpers/defineProperty': require('@babel/runtime/helpers/defineProperty'),
   react: require('react'),
+  'react-dom': require('react-dom'),
+  'react-dom/server': require('react-dom/server'),
 };
 
 export const INTERNAL_MODULES: Array<{ moduleName: string; exports: string[] }> = [
@@ -251,7 +253,7 @@ export const INTERNAL_MODULES: Array<{ moduleName: string; exports: string[] }> 
   },
   {
     moduleName: 'remirror/extension/yjs',
-    exports: ['YjsExtension'],
+    exports: ['YjsExtension', 'defaultDestroyProvider'],
   },
   {
     moduleName: 'remirror/preset/core',


### PR DESCRIPTION
### Description

To emulate SSR, we need `renderToString` (or similar) from `react-dom/server`; this PR adds that to the imports. It also fixes the broken `import-remirror` script in the playground.

Remirror SSR isn't working right now, this PR does not attempt to fix that.

Here's an example of SSR code you can run in the browser (which shows Remirror not SSR-ing):

```ts
import { useRemirrorPlayground } from "@remirror/playground";
import React, { FC } from "react";
import { renderToString } from "react-dom/server";
import { BoldExtension } from "remirror/extension/bold";
import { RemirrorProvider, useManager, useRemirror } from "remirror/react";

const EXTENSIONS = () => [new BoldExtension()];

/**
 * This component contains the editor and any toolbars/chrome it requires.
 */
const SmallEditor: FC = () => {
  const { getRootProps, commands } = useRemirror();

  return (
    <div>
      <button onClick={() => commands.toggleBold()}>bold</button>
      <div {...getRootProps()} />
    </div>
  );
};

const SmallEditorContainer = () => {
  const extensionManager = useManager(EXTENSIONS);

  const docJSON = {
    type: "doc",
    content: [
      {
        type: "paragraph",
        content: [
          {
            type: "text",
            text: "Text ",
          },
          {
            type: "text",
            marks: [
              {
                type: "bold",
              },
            ],
            text: "bold",
          },
          {
            type: "text",
            text: ".",
          },
        ],
      },
    ],
  };
  const value = extensionManager.createState({ content: docJSON });

  return (
    <RemirrorProvider manager={extensionManager} value={value}>
      <SmallEditor />
    </RemirrorProvider>
  );
};

const doc = renderToString(<SmallEditorContainer />);

const SSR = () => (
  <div>
    <h3>SSR</h3>
    <div
      style={{ border: "1px solid red" }}
      dangerouslySetInnerHTML={{ __html: doc }}
    />
    <hr />
    <h3>Client-rendered</h3>
    <div style={{ border: "1px solid green" }}>
      <SmallEditorContainer />
    </div>
  </div>
);

export default SSR;
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] ~~I have updated the documentation where necessary.~~
- [ ] ~~New code is unit tested and all current tests pass when running `pnpm test`.~~

### Screenshots

![Screenshot_20201119_171321](https://user-images.githubusercontent.com/129910/99699981-8af38280-2a8a-11eb-849d-59b9f4a29df7.png)

