### PR TITLE
feat(core-utils): export `GetMarkRange` interface

### DIFF
--- a/.changeset/fast-feet-pretend.md
+++ b/.changeset/fast-feet-pretend.md
@@ -1,0 +1,11 @@
+---
+'@remirror/extension-link': minor
+---
+
+Add `onClick` handler to `LinkExtension` which is called with the `event: MouseEvent` and `data: LinkClickData` which includes the `href` and all the `GetMarkRange` properties.
+
+Export extra types from the `@remirror/extension-link` package.
+
+- `LinkAttributes`
+- `LinkClickData`
+- `DefaultProtocol`

--- a/.changeset/four-gorillas-allow.md
+++ b/.changeset/four-gorillas-allow.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-mention': minor
+---
+
+Add `onClick` handler to `MentionExtension` which is called with `event: MouseEvent` and `markRange: GetMarkRange`.

--- a/.changeset/modern-panthers-float.md
+++ b/.changeset/modern-panthers-float.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': minor
+---
+
+Add `click` and `clickMark` handlers to the `EventsExtension`. These new events are available to hooks created with `useExtension(EventsExtension)` and also exposed via the new `createEventHandlers` extension method. These methods provides utilities for determining whether the position clicked was within a specific node or mark.

--- a/.changeset/six-kiwis-double.md
+++ b/.changeset/six-kiwis-double.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Add `GetMarkRange` interface to exports from `@remirror/core-utils`.

--- a/.changeset/violet-dolphins-tickle.md
+++ b/.changeset/violet-dolphins-tickle.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-mention-atom': minor
+---
+
+Add `onClick` handler to `MentionAtomExtension` which is called with the `event: MouseEvent` and `nodeWithPosition: NodeWithPosition`.

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -286,7 +286,7 @@ export function getMarkAttributes(
   return false;
 }
 
-interface GetMarkRange extends FromToParameter {
+export interface GetMarkRange extends FromToParameter {
   /**
    * The mark that was found within the active range.
    */

--- a/packages/@remirror/core-utils/src/index.ts
+++ b/packages/@remirror/core-utils/src/index.ts
@@ -15,6 +15,7 @@ export {
 
 export type {
   CreateDocumentNodeParameter,
+  GetMarkRange,
   InvalidContentBlock,
   InvalidContentHandler,
   InvalidContentHandlerParameter,

--- a/packages/@remirror/core/src/builtins/commands-extension.ts
+++ b/packages/@remirror/core/src/builtins/commands-extension.ts
@@ -340,6 +340,9 @@ export class CommandsExtension extends PlainExtension<CommandOptions> {
         };
       },
 
+      /**
+       * Restore the shared transaction for future chained commands.
+       */
       restore: (): CommandFunction => {
         return () => {
           this.#customTransaction = undefined;

--- a/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
+++ b/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
@@ -57,4 +57,21 @@ describe('events', () => {
 
     expect(mouseUpHandler).toHaveBeenCalled();
   });
+
+  it('responds to editor `click` events', () => {
+    const eventsExtension = new EventsExtension();
+    const clickHandler = jest.fn(() => true);
+    const editor = renderEditor([eventsExtension]);
+    const { view, add } = editor;
+    const { doc, p } = editor.nodes;
+    const node = p('first');
+
+    eventsExtension.addHandler('click', clickHandler);
+    add(doc(p('first')));
+
+    // JSDOM doesn't pass events through so the only way to simulate is to
+    // directly simulate the `handleClick` prop.
+    view.someProp('handleClickOn', (fn) => fn(view, 2, node, 1, {}, true));
+    expect(clickHandler).toHaveBeenCalled();
+  });
 });

--- a/packages/@remirror/extension-events/src/events-extension.ts
+++ b/packages/@remirror/extension-events/src/events-extension.ts
@@ -1,4 +1,25 @@
-import { CreatePluginReturn, extensionDecorator, Handler, PlainExtension } from '@remirror/core';
+import {
+  CreatePluginReturn,
+  EditorState,
+  EditorStateParameter,
+  EditorViewParameter,
+  entries,
+  ErrorConstant,
+  extensionDecorator,
+  ExtensionPriority,
+  GetHandler,
+  GetMarkRange,
+  getMarkRange,
+  Handler,
+  invariant,
+  isString,
+  MarkType,
+  NodeType,
+  NodeWithPosition,
+  noop,
+  PlainExtension,
+  ResolvedPos,
+} from '@remirror/core';
 
 export interface EventsOptions {
   /**
@@ -6,65 +27,174 @@ export interface EventsOptions {
    *
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
-  blur: Handler<(event: FocusEvent) => boolean | undefined>;
+  blur?: Handler<(event: FocusEvent) => boolean | undefined | void>;
 
   /**
    * Listens for focus events on the editor.
    *
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
-  focus: Handler<(event: FocusEvent) => boolean | undefined>;
+  focus?: Handler<(event: FocusEvent) => boolean | undefined | void>;
 
   /**
    * Listens for mousedown events on the editor.
    *
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
-  mousedown: Handler<(event: MouseEvent) => boolean | undefined>;
+  mousedown?: Handler<(event: MouseEvent) => boolean | undefined | void>;
 
   /**
    * Listens for mouseup events on the editor.
    *
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
-  mouseup: Handler<(event: MouseEvent) => boolean | undefined>;
+  mouseup?: Handler<(event: MouseEvent) => boolean | undefined | void>;
+
+  /**
+   * Listens for click events and provides information which may be useful in
+   * handling them properly.
+   *
+   * This can be used to check if a node was clicked on.
+   *
+   * Please note that this click handler may be called multiple times for one
+   * click. Starting from the node that was clicked directly, it walks up the
+   * node tree until it reaches the `doc` node.
+   *
+   * Return `true` to prevent any other click listeners from being registered.
+   */
+  click?: Handler<ClickHandler>;
+
+  /**
+   * This is similar to the `click` handler, but with better performance when
+   * only capturing clicks for marks.
+   */
+  clickMark?: Handler<ClickMarkHandler>;
 }
 
 /**
  * The events extension which listens to events which occur within the
  * remirror editor.
- *
- * TODO - add more events based on user feedback.
  */
 @extensionDecorator<EventsOptions>({
-  handlerKeys: ['blur', 'focus', 'mousedown', 'mouseup'],
+  handlerKeys: ['blur', 'focus', 'mousedown', 'mouseup', 'click', 'clickMark'],
   handlerKeyOptions: {
     blur: { earlyReturnValue: true },
     focus: { earlyReturnValue: true },
     mousedown: { earlyReturnValue: true },
     mouseup: { earlyReturnValue: true },
+    click: { earlyReturnValue: true },
   },
+  defaultPriority: ExtensionPriority.Low,
 })
 export class EventsExtension extends PlainExtension<EventsOptions> {
   get name() {
     return 'events' as const;
   }
 
+  /**
+   * Add a new lifecycle method which is available to all extensions for adding
+   * a click handler to the node or mark.
+   */
+  onView(): void {
+    for (const extension of this.store.extensions) {
+      if (
+        // managerSettings excluded this from running
+        this.store.managerSettings.exclude?.clickHandler ||
+        // Method doesn't exist
+        !extension.createEventHandlers ||
+        // Extension settings exclude it
+        extension.options.exclude?.clickHandler
+      ) {
+        continue;
+      }
+
+      const eventHandlers = extension.createEventHandlers();
+
+      for (const [key, handler] of entries(eventHandlers)) {
+        // Casting to `any` needed here since I don't know how to teach
+        // `TypeScript` that the object key and the handler are a valid pair.
+        this.addHandler(key as any, handler);
+      }
+    }
+  }
+
+  /**
+   * Create the plugin which manages all of the events being listened to within
+   * the editor.
+   */
   createPlugin(): CreatePluginReturn {
+    // Since event methods can possible be run multiple times for the same event
+    // outer node, it is possible that one event can be run multiple times. To
+    // prevent needless potentially expensive recalculations, this weak map
+    // tracks the references to an event for automatic garbage collection when
+    // the reference to the event is lost.
+    const eventMap: WeakMap<Event, boolean> = new WeakMap();
+
     return {
       props: {
+        handleClickOn: (view, pos, node, nodePos, event, direct) => {
+          const state = this.store.currentState;
+          const { schema, doc } = state;
+          const $pos = doc.resolve(pos);
+
+          // True when the event has already been handled. In these cases we
+          // should **not** run the `clickMark` handler since all that is needed
+          // is the `$pos` property to check if a mark is active.
+          const handled = eventMap.has(event);
+
+          // Generate the base state which is passed to the `clickMark` handler
+          // and used to create the `click` handler state.
+          const baseState = createClickMarkState({ $pos, handled, view, state });
+          let returnValue = false;
+
+          if (!handled) {
+            // The boolean return value for the mark click handler. This is
+            // intentionally separate so that both the `clickMark` handlers and
+            // the `click` handlers are run for each click. It uses the eventMap
+            // to limit the ensure that it is only run once per click since this
+            // method is run with the same event for every single node in the
+            // `doc` tree.
+            returnValue = this.options.clickMark(event, baseState) || returnValue;
+          }
+
+          // Create click state to help API consumers inspect whether the event
+          // is a relevant click type.
+          const clickState: ClickHandlerState = {
+            ...baseState,
+            pos,
+            direct,
+            nodeWithPosition: { node, pos: nodePos },
+
+            getNode: (nodeType) => {
+              const type = isString(nodeType) ? schema.nodes[nodeType] : nodeType;
+
+              invariant(type, {
+                code: ErrorConstant.EXTENSION,
+                message: 'The node being checked does not exist',
+              });
+
+              return type === node.type ? { node, pos: nodePos } : undefined;
+            },
+          };
+
+          // Store this event so that marks aren't re-run for identical events.
+          eventMap.set(event, true);
+
+          return this.options.click(event, clickState) || returnValue;
+        },
+
         handleDOMEvents: {
           focus: (_, event) => {
-            return this.options.focus(event) ?? false;
+            return this.options.focus(event) || false;
           },
           blur: (_, event) => {
-            return this.options.blur(event) ?? false;
+            return this.options.blur(event) || false;
           },
           mousedown: (_, event) => {
-            return this.options.mousedown(event) ?? false;
+            return this.options.mousedown(event) || false;
           },
           mouseup: (_, event) => {
-            return this.options.mouseup(event) ?? false;
+            return this.options.mouseup(event) || false;
           },
         },
       },
@@ -72,8 +202,144 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
   }
 }
 
+interface CreateClickMarkStateParameter extends BaseEventState {
+  /**
+   * True when the event has previously been handled. In this situation we can
+   * return early, since the mark can be checked directly from the current
+   * position.
+   */
+  handled: boolean;
+
+  /**
+   * The resolved position to check for marks.
+   */
+  $pos: ResolvedPos;
+}
+
+/**
+ * Create the click handler state for the mark.
+ */
+function createClickMarkState(parameter: CreateClickMarkStateParameter): ClickMarkHandlerState {
+  const { handled, view, $pos, state } = parameter;
+  const clickState: ClickMarkHandlerState = { getMark: noop, markRanges: [], view, state };
+
+  if (handled) {
+    return clickState;
+  }
+
+  for (const { type } of $pos.marks()) {
+    const range = getMarkRange($pos, type);
+
+    if (range) {
+      clickState.markRanges.push(range);
+    }
+  }
+
+  clickState.getMark = (markType) => {
+    const type = isString(markType) ? state.schema.marks[markType] : markType;
+
+    invariant(type, {
+      code: ErrorConstant.EXTENSION,
+      message: `The mark ${markType} being checked does not exist within the editor schema.`,
+    });
+
+    return clickState.markRanges.find((range) => range.mark.type === type);
+  };
+
+  return clickState;
+}
+
+/**
+ * The click handler for events.
+ */
+export type ClickHandler = (
+  event: MouseEvent,
+  clickState: ClickHandlerState,
+) => boolean | undefined | void;
+
+export interface ClickMarkHandlerState extends BaseEventState {
+  /**
+   * Return the mark range if it exists for the clicked position.
+   */
+  getMark: (markType: string | MarkType) => GetMarkRange | undefined | void;
+
+  /**
+   * The list of mark ranges included. This is only populated when `direct` is
+   * true.
+   */
+  markRanges: GetMarkRange[];
+}
+
+/**
+ * An event solely focused on clicks on marks.
+ */
+export type ClickMarkHandler = (
+  event: MouseEvent,
+  clickState: ClickMarkHandlerState,
+) => boolean | undefined | void;
+
+/**
+ * The helpers passed into the `ClickHandler`.
+ */
+export interface ClickHandlerState extends ClickMarkHandlerState {
+  /**
+   * The position that was clicked.
+   */
+  pos: number;
+
+  /**
+   * Returns undefined when the nodeType doesn't match. Otherwise returns the
+   * node with a position property.
+   */
+  getNode: (nodeType: string | NodeType) => NodeWithPosition | undefined;
+
+  /**
+   * The node that was clicked with the desired position.
+   */
+  nodeWithPosition: NodeWithPosition;
+
+  /**
+   * When this is true it means that the current clicked node is the node that
+   * was directly clicked.
+   */
+  direct: boolean;
+}
+
+/**
+ * The return type for the `createEventHandlers` extension creator method.
+ */
+export type CreateEventHandlers = GetHandler<EventsOptions>;
+
+interface BaseEventState extends EditorViewParameter, EditorStateParameter {
+  /**
+   * The editor state before updates from the event.
+   */
+  state: EditorState;
+}
+
 declare global {
   namespace Remirror {
+    interface ExcludeOptions {
+      /**
+       * Whether to exclude the extension's `clickHandler`.
+       *
+       * @default undefined
+       */
+      clickHandler?: boolean;
+    }
+
+    interface BaseExtension {
+      /**
+       * Create a click handler for this extension. Returns a function which is
+       * used as the click handler. The callback provided is handled via the
+       * `Events` extension and comes with a helpers object
+       * `ClickHandlerHelper`.
+       *
+       * The returned function should return `true` if you want to prevent any
+       * further click handlers from being handled.
+       */
+      createEventHandlers?(): CreateEventHandlers;
+    }
     interface AllExtensions {
       events: EventsExtension;
     }

--- a/packages/@remirror/extension-events/src/index.ts
+++ b/packages/@remirror/extension-events/src/index.ts
@@ -1,2 +1,9 @@
-export type { EventsOptions } from './events-extension';
+export type {
+  EventsOptions,
+  ClickHandler,
+  CreateEventHandlers,
+  ClickHandlerState,
+  ClickMarkHandler,
+  ClickMarkHandlerState,
+} from './events-extension';
 export { EventsExtension } from './events-extension';

--- a/packages/@remirror/extension-link/package.json
+++ b/packages/@remirror/extension-link/package.json
@@ -24,7 +24,8 @@
     "dist"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.12.0"
+    "@babel/runtime": "^7.12.0",
+    "@remirror/extension-events": "1.0.0-next.54"
   },
   "devDependencies": {
     "@remirror/core": "1.0.0-next.54",

--- a/packages/@remirror/extension-link/src/index.ts
+++ b/packages/@remirror/extension-link/src/index.ts
@@ -1,2 +1,2 @@
-export type { LinkOptions } from './link-extension';
+export type { LinkOptions, LinkAttributes, LinkClickData, DefaultProtocol } from './link-extension';
 export { LinkExtension } from './link-extension';

--- a/packages/@remirror/extension-mention-atom/package.json
+++ b/packages/@remirror/extension-mention-atom/package.json
@@ -20,7 +20,8 @@
     "dist"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.12.0"
+    "@babel/runtime": "^7.12.0",
+    "@remirror/extension-events": "1.0.0-next.54"
   },
   "devDependencies": {
     "@remirror/core": "1.0.0-next.54",

--- a/packages/@remirror/extension-mention-atom/src/__tests__/mention-atom-extension.spec.ts
+++ b/packages/@remirror/extension-mention-atom/src/__tests__/mention-atom-extension.spec.ts
@@ -1,10 +1,10 @@
 import { pmBuild } from 'jest-prosemirror';
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import { fromHtml, toHtml } from '@remirror/core';
 import { createCoreManager } from '@remirror/testing';
 
-import { MentionAtomExtension } from '..';
+import { MentionAtomExtension, MentionAtomOptions } from '..';
 
 extensionValidityTest(MentionAtomExtension, { matchers: [] });
 
@@ -41,3 +41,49 @@ describe('schema', () => {
     expect(node).toEqualProsemirrorNode(expected);
   });
 });
+
+describe('onClick', () => {
+  const options = {
+    matchers: [
+      { char: '#', name: 'tag' },
+      { char: '@', name: 'at' },
+      { char: '+', name: 'plus' },
+    ],
+  };
+
+  const { add, doc, p, mentionAtom, view, extension } = create(options);
+
+  it('responds to clicks', () => {
+    const clickHandler = jest.fn(() => true);
+    extension.addHandler('onClick', clickHandler);
+    const atMention = mentionAtom({ id: '@hello', name: 'at', label: '@hello' })();
+    const node = p('first ', atMention);
+    add(doc(node));
+
+    view.someProp('handleClickOn', (fn) => fn(view, 8, atMention, 8, {}, true));
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+    expect(clickHandler).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        pos: 8,
+        node: expect.any(Object),
+      }),
+    );
+
+    view.someProp('handleClick', (fn) => fn(view, 2, node, 1, {}, true));
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * Create the mention extension with an optional `onChange` handler.
+ */
+function create(options: MentionAtomOptions) {
+  const extension = new MentionAtomExtension({ ...options });
+  const editor = renderEditor([extension]);
+  const { add, view, manager, commands } = editor;
+  const { doc, p } = editor.nodes;
+  const { mentionAtom } = editor.attributeNodes;
+
+  return { add, doc, p, mentionAtom, view, manager, commands, editor, extension };
+}

--- a/packages/@remirror/extension-mention/package.json
+++ b/packages/@remirror/extension-mention/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.0",
+    "@remirror/extension-events": "1.0.0-next.54",
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,7 @@ importers:
   packages/@remirror/extension-mention:
     dependencies:
       '@babel/runtime': 7.12.5
+      '@remirror/extension-events': 'link:../extension-events'
       escape-string-regexp: 4.0.0
     devDependencies:
       '@remirror/core': 'link:../core'
@@ -666,6 +667,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.12.0
       '@remirror/core': 1.0.0-next.54
+      '@remirror/extension-events': 1.0.0-next.54
       '@remirror/pm': 1.0.0-next.54
       escape-string-regexp: ^4.0.0
   packages/@remirror/extension-mention-atom:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,12 +673,14 @@ importers:
   packages/@remirror/extension-mention-atom:
     dependencies:
       '@babel/runtime': 7.12.5
+      '@remirror/extension-events': 'link:../extension-events'
     devDependencies:
       '@remirror/core': 'link:../core'
       '@remirror/pm': 'link:../pm'
     specifiers:
       '@babel/runtime': ^7.12.0
       '@remirror/core': 1.0.0-next.54
+      '@remirror/extension-events': 1.0.0-next.54
       '@remirror/pm': 1.0.0-next.54
   packages/@remirror/extension-paragraph:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,12 +649,14 @@ importers:
   packages/@remirror/extension-link:
     dependencies:
       '@babel/runtime': 7.12.5
+      '@remirror/extension-events': 'link:../extension-events'
     devDependencies:
       '@remirror/core': 'link:../core'
       '@remirror/pm': 'link:../pm'
     specifiers:
       '@babel/runtime': ^7.12.0
       '@remirror/core': 1.0.0-next.54
+      '@remirror/extension-events': 1.0.0-next.54
       '@remirror/pm': 1.0.0-next.54
   packages/@remirror/extension-mention:
     dependencies:


### PR DESCRIPTION
### Description

Add `click` and `clickMark` handlers to the `EventsExtension`. These new events are available to hooks created with `useExtension(EventsExtension)` and also exposed via the new `createEventHandlers` extension method. These methods provides utilities for determining whether the position clicked was within a specific node or mark.

- Closes #796

Add `onClick` handler to `LinkExtension` which is called with the `event: MouseEvent` and `data: LinkClickData` which includes the `href` and all the `GetMarkRange` properties.

Export extra types from the `@remirror/extension-link` package.

- `LinkAttributes`
- `LinkClickData`
- `DefaultProtocol`

Add `onClick` handler to `MentionAtomExtension` which is called with the `event: MouseEvent` and `nodeWithPosition: NodeWithPosition`.

Add `onClick` handler to `MentionExtension` which is called with `event: MouseEvent` and `markRange: GetMarkRange`.

Add `GetMarkRange` interface to exports from `@remirror/core-utils`.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
