### PR TITLE
chore: add `cross-env` into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "case-anything": "^1.1.1",
     "core-js": "^3.6.5",
     "cpy-cli": "^3.1.1",
+    "cross-env": "^7.0.2",
     "eslint": "^7.12.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-formatter-github": "^1.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
       case-anything: 1.1.2
       core-js: 3.7.0
       cpy-cli: 3.1.1
+      cross-env: 7.0.2
       eslint: 7.13.0
       eslint-config-prettier: 6.15.0_eslint@7.13.0
       eslint-formatter-github: 1.0.11_eslint@7.13.0
@@ -129,6 +130,7 @@ importers:
       case-anything: ^1.1.1
       core-js: ^3.6.5
       cpy-cli: ^3.1.1
+      cross-env: ^7.0.2
       eslint: ^7.12.0
       eslint-config-prettier: ^6.15.0
       eslint-formatter-github: ^1.0.11
@@ -11009,6 +11011,17 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
       integrity: sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==
+  /cross-env/7.0.2:
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: false
+    engines:
+      node: '>=10.14'
+      npm: '>=6'
+      yarn: '>=1'
+    hasBin: true
+    resolution:
+      integrity: sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
   /cross-fetch/3.0.5:
     dependencies:
       node-fetch: 2.6.0


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR include `cross-env` into dependencies to fix `cross-env-shell: command not found` issue. I found this issue when I developed the previous PR. 

```
$ git checkout next
Switched to branch 'next'
Your branch is up to date with 'origin/next'.
husky > post-checkout (node v15.2.1)
sh: cross-env-shell: command not found
sh: cross-env-shell: command not found
```



### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 