### PR TITLE
fix(extension-positioner): display positioners immediately

### DIFF
--- a/.changeset/thick-mails-jump.md
+++ b/.changeset/thick-mails-jump.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-positioner': patch
+---
+
+Fix positioners so they can be displayed as soon as they are added.

--- a/packages/@remirror/extension-positioner/src/__tests__/positioner-extension.spec.ts
+++ b/packages/@remirror/extension-positioner/src/__tests__/positioner-extension.spec.ts
@@ -1,5 +1,7 @@
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
+import { isAllSelection } from '@remirror/core';
+
 import {
   centeredSelectionPositioner,
   cursorPopupPositioner,
@@ -80,6 +82,47 @@ test('`centeredSelectionPositioner` can position itself', () => {
     });
 });
 
+test('`floatingSelectionPositioner` can position itself', () => {
+  const positionerExtension = new PositionerExtension();
+  const {
+    add,
+    nodes: { p, doc },
+  } = renderEditor([positionerExtension]);
+
+  const floatingElement = document.createElement('div');
+  document.body.append(floatingElement);
+  const floatingMock = {
+    onUpdate: jest.fn((items) => items?.[0]?.setElement(floatingElement)),
+    onDone: jest.fn(),
+  };
+
+  add(doc(p('<cursor>')))
+    .callback(() => {
+      positionerExtension.addCustomHandler('positioner', floatingSelectionPositioner);
+      floatingSelectionPositioner.addListener('update', floatingMock.onUpdate);
+      floatingSelectionPositioner.addListener('done', floatingMock.onDone);
+    })
+    .insertText('a')
+    .selectText({ from: 1, to: 2 })
+    .replace('')
+    .callback(() => {
+      expect(floatingMock.onUpdate).toHaveBeenCalledWith([
+        { setElement: expect.any(Function), id: '0' },
+      ]);
+      expect(floatingMock.onDone).toHaveBeenCalledWith([
+        { position: expect.any(Object), element: floatingElement, id: '0' },
+      ]);
+    })
+    .insertText('hello')
+    .callback(() => {
+      expect(floatingMock.onUpdate).toHaveBeenCalledWith([]);
+    })
+    .selectText({ from: 1, to: 5 })
+    .callback(() => {
+      expect(floatingMock.onUpdate).toHaveBeenCalledWith([]);
+    });
+});
+
 test("a custom positioner can define it's own hasChanged behaviour", () => {
   const positionerExtension = new PositionerExtension();
   const {
@@ -106,6 +149,61 @@ test("a custom positioner can define it's own hasChanged behaviour", () => {
       customSelectionPositioner.addListener('done', customMock.onDone);
       positionerExtension.addCustomHandler('positioner', customSelectionPositioner);
     })
+    .callback(() => {
+      expect(customMock.onUpdate).toHaveBeenCalledWith([
+        { setElement: expect.any(Function), id: '0' },
+      ]);
+      expect(customMock.onDone).toHaveBeenCalledWith([
+        { position: expect.any(Object), element: customElement, id: '0' },
+      ]);
+    });
+});
+
+test("a custom positioner can determine it's own active state", () => {
+  const positionerExtension = new PositionerExtension();
+  const {
+    add,
+    nodes: { p, doc },
+  } = renderEditor([positionerExtension]);
+
+  const customElement = document.createElement('div');
+  document.body.append(customElement);
+  const customMock = {
+    onUpdate: jest.fn((items) => items?.[0]?.setElement(customElement)),
+    onDone: jest.fn(),
+  };
+
+  const customSelectionPositioner = Positioner.fromPositioner(centeredSelectionPositioner, {
+    getActive(parameter) {
+      const { state, view } = parameter;
+
+      if (isAllSelection(state.selection) === false) {
+        return [];
+      }
+
+      const { from, to } = state.selection;
+      const start = view.coordsAtPos(from);
+      const end = view.coordsAtPos(to);
+
+      return [{ start, end }];
+    },
+  });
+
+  add(doc(p('<cursor>')))
+    .callback(() => {
+      positionerExtension.addCustomHandler('positioner', customSelectionPositioner);
+      customSelectionPositioner.addListener('update', customMock.onUpdate);
+      customSelectionPositioner.addListener('done', customMock.onDone);
+    })
+    .insertText('hello')
+    .callback(() => {
+      expect(customMock.onUpdate).toHaveBeenCalledWith([]);
+    })
+    .selectText({ from: 1, to: 5 })
+    .callback(() => {
+      expect(customMock.onUpdate).toHaveBeenCalledWith([]);
+    })
+    .selectText('all')
     .callback(() => {
       expect(customMock.onUpdate).toHaveBeenCalledWith([
         { setElement: expect.any(Function), id: '0' },

--- a/packages/@remirror/extension-positioner/src/positioner-extension.ts
+++ b/packages/@remirror/extension-positioner/src/positioner-extension.ts
@@ -67,6 +67,8 @@ export class PositionerExtension extends PlainExtension<PositionerOptions> {
     }
 
     this.#positioners = [...this.#positioners, positioner];
+    // Ensure onStateUpdate is trigger when positioner is added
+    this.store.commands.forceUpdate();
     return () => {
       this.#positioners = this.#positioners.filter((handler) => handler !== positioner);
     };


### PR DESCRIPTION
### Description

Positioners previously required a state change to take place, before they were displayed. This PR adds a force update so that positioners can be displayed immediately (if applicable)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
