### PR TITLE
fix(extension-link): improve rendered html

### DIFF
--- a/.changeset/hip-hairs-mix.md
+++ b/.changeset/hip-hairs-mix.md
@@ -1,0 +1,27 @@
+---
+'@remirror/extension-link': patch
+---
+
+Fix rendered HTML when selecting or applying marks to part of a link.
+
+Behaviour before fix.
+
+```html
+<p>
+  <a href="/">My partially</a>
+  <a href="/"><span class="selection">selected</span></a>
+  <a href="/">link</a>
+</p>
+```
+
+Behaviour after fix.
+
+```html
+<p>
+  <a href="/">
+    My partially
+    <span class="selection">selected</span>
+    link
+  </a>
+</p>
+```

--- a/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
+++ b/packages/@remirror/extension-link/src/__tests__/link-extension.spec.ts
@@ -693,3 +693,33 @@ describe('onClick', () => {
     expect(view.state.selection.empty).toBeFalse();
   });
 });
+
+describe('spanning', () => {
+  it('should allow selection of part of link without splitting it', () => {
+    const {
+      add,
+      attributeMarks: { link },
+      nodes: { doc, p },
+      view,
+    } = renderEditor([new LinkExtension()]);
+
+    const linkMark = link({ href: '//test.com' })('a <start>long<end> link');
+    add(doc(p('Paragraph with ', linkMark, ' and text')));
+
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        Paragraph with
+        <a href="//test.com"
+           rel="noopener noreferrer nofollow"
+        >
+          a
+          <span class="selection">
+            long
+          </span>
+          link
+        </a>
+        and text
+      </p>
+    `);
+  });
+});

--- a/packages/@remirror/extension-link/src/link-extension.ts
+++ b/packages/@remirror/extension-link/src/link-extension.ts
@@ -147,7 +147,6 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
         auto: { default: false },
       },
       inclusive: false,
-      spanning: false,
       parseDOM: [
         {
           tag: 'a[href]',


### PR DESCRIPTION
# Description

Fix rendered HTML when selecting or applying marks to part of a link.

Given the use case of

![Screenshot 2020-11-25 at 10 41 35](https://user-images.githubusercontent.com/2003804/100217012-e00c1a00-2f0a-11eb-8b86-f08230cafffd.png)

Behaviour before fix.

```html
<p>
  <a href="/">My partially</a>
  <a href="/"><span class="selection">selected</span></a>
  <a href="/">link</a>
</p>
```

Behaviour after fix.

```html
<p>
  <a href="/">
    My partially
    <span class="selection">selected</span>
    link
  </a>
</p>
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

