### PR TITLE
fix(core): allow `currentState` before first update

### DIFF
--- a/.changeset/brave-nails-switch.md
+++ b/.changeset/brave-nails-switch.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Allow access to `extension.store.currentState` before the first state update. This fixes [#814](https://github.com/remirror/remirror/issues/814).

--- a/packages/@remirror/core/src/manager/remirror-manager.ts
+++ b/packages/@remirror/core/src/manager/remirror-manager.ts
@@ -510,43 +510,28 @@ export class RemirrorManager<Combined extends AnyCombinedUnion> {
    */
   private createExtensionStore(): Remirror.ExtensionStore {
     const store: Remirror.ExtensionStore = object();
+    const enumerable = true;
+
+    // Allow current state to default to `getState` for first access.
+    // This fixed an issue with #814
+    let currentState: EditorState | undefined;
 
     Object.defineProperties(store, {
-      extensions: {
-        get: () => this.#extensions,
-        enumerable: true,
-      },
-      phase: {
-        get: () => this.#phase,
-        enumerable: true,
-      },
-      view: {
-        get: () => this.view,
-        enumerable: true,
-      },
-      managerSettings: {
-        get: () => freeze(this.#settings),
-        enumerable: true,
-      },
-      getState: {
-        value: this.getState,
-        enumerable: true,
-      },
-      updateState: {
-        value: this.updateState,
-        enumerable: true,
-      },
-      isMounted: {
-        value: () => this.mounted,
-        enumerable: true,
-      },
-      getExtension: {
-        value: this.getExtension.bind(this),
-        enumerable: true,
-      },
-      getPreset: {
-        value: this.getPreset.bind(this),
-        enumerable: true,
+      extensions: { get: () => this.#extensions, enumerable },
+      phase: { get: () => this.#phase, enumerable },
+      view: { get: () => this.view, enumerable },
+      managerSettings: { get: () => freeze(this.#settings), enumerable },
+      getState: { value: this.getState, enumerable },
+      updateState: { value: this.updateState, enumerable },
+      isMounted: { value: () => this.mounted, enumerable },
+      getExtension: { value: this.getExtension.bind(this), enumerable },
+      getPreset: { value: this.getPreset.bind(this), enumerable },
+      currentState: {
+        get: () => (currentState ??= this.getState()),
+        set: (state: EditorState) => {
+          currentState = state;
+        },
+        enumerable,
       },
     });
 

--- a/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
+++ b/packages/@remirror/extension-events/src/__tests__/events-extension.spec.ts
@@ -74,4 +74,16 @@ describe('events', () => {
     view.someProp('handleClickOn', (fn) => fn(view, 2, node, 1, {}, true));
     expect(clickHandler).toHaveBeenCalled();
   });
+
+  it('should not throw when clicked on before first state called', () => {
+    const eventsExtension = new EventsExtension();
+    const editor = renderEditor([eventsExtension]);
+    const { view } = editor;
+    const { p } = editor.nodes;
+    const node = p('first');
+
+    expect(() =>
+      editor.view.someProp('handleClickOn', (fn) => fn(view, 2, node, 1, {}, true)),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
### Description

Allow access to `extension.store.currentState` before the first state update.

Closes #814

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
