### PR TITLE
fix: `getMarkRange` usage with mixed marks

### DIFF
--- a/.changeset/two-tables-end.md
+++ b/.changeset/two-tables-end.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core-utils': patch
+---
+
+Fix `getMarkRange` not returning the entire mark length, instead stopping at the first change in mark. This fix also resolves the infinite loop described in #823.
+
+

--- a/.changeset/two-tables-end.md
+++ b/.changeset/two-tables-end.md
@@ -3,5 +3,3 @@
 ---
 
 Fix `getMarkRange` not returning the entire mark length, instead stopping at the first change in mark. This fix also resolves the infinite loop described in #823.
-
-

--- a/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
@@ -8,6 +8,7 @@ import {
   p,
   pm,
   schema as testSchema,
+  strong,
   tableRow,
 } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
@@ -236,6 +237,16 @@ describe('getMarkRange', () => {
 
     expect(range?.mark).toBeInstanceOf(Mark);
     expect(range?.text).toBe(expected);
+  });
+
+  it('returns the entire range when marks are mixed', () => {
+    const { state, schema } = createEditor(
+      doc(p('Something <cursor>', strong(em('italic')), strong(' but still strong'))),
+    );
+    const range = getMarkRange(state.selection.$from, schema.marks.strong);
+
+    expect(range?.mark).toBeInstanceOf(Mark);
+    expect(range?.text).toBe('italic but still strong');
   });
 });
 

--- a/packages/@remirror/core-utils/src/core-utils.ts
+++ b/packages/@remirror/core-utils/src/core-utils.ts
@@ -333,16 +333,22 @@ export function getMarkRange($pos: ResolvedPos, type: MarkType): GetMarkRange | 
 
   let startIndex = $pos.index();
   let startPos = $pos.start() + start.offset;
+  let endIndex = startIndex + 1;
+  let endPos = startPos + start.node.nodeSize;
 
   while (startIndex > 0 && mark.isInSet($pos.parent.child(startIndex - 1).marks)) {
     startIndex -= 1;
     startPos -= $pos.parent.child(startIndex).nodeSize;
   }
 
-  const [from, to] = [startPos, startPos + start.node.nodeSize];
-  const text = $pos.doc.textBetween(from, to, LEAF_NODE_REPLACING_CHARACTER, '\n\n');
+  while (endIndex < $pos.parent.childCount && mark.isInSet($pos.parent.child(endIndex).marks)) {
+    endPos += $pos.parent.child(endIndex).nodeSize;
+    endIndex += 1;
+  }
 
-  return { from, to, text, mark };
+  const text = $pos.doc.textBetween(startPos, endPos, LEAF_NODE_REPLACING_CHARACTER, '\n\n');
+
+  return { from: startPos, to: endPos, text, mark };
 }
 
 /**


### PR DESCRIPTION
### Description

If marks are mixed then `getMarkRange` does not return the entire mark length, instead stopping at the first change in mark (see included test). Fixing this should resolve the infinite loop I described seeing here https://github.com/remirror/remirror/issues/823

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
