### PR TITLE
fix(extension-image): fix regexp for image filetype

### DIFF
--- a/.changeset/late-days-tease.md
+++ b/.changeset/late-days-tease.md
@@ -1,0 +1,5 @@
+---
+"@remirror/extension-image": patch
+---
+
+Fix regexp for image filetype check

--- a/.changeset/late-days-tease.md
+++ b/.changeset/late-days-tease.md
@@ -1,5 +1,5 @@
 ---
-"@remirror/extension-image": patch
+'@remirror/extension-image': patch
 ---
 
 Fix regexp for image filetype check

--- a/packages/@remirror/extension-image/src/image-extension.ts
+++ b/packages/@remirror/extension-image/src/image-extension.ts
@@ -93,7 +93,7 @@ export class ImageExtension extends NodeExtension {
               return false;
             }
 
-            const images = [...event.dataTransfer.files].filter((file) => /image/i.test(file.type));
+            const images = [...event.dataTransfer.files].filter((file) => /^image\//i.test(file.type));
 
             if (images.length === 0) {
               return false;

--- a/packages/@remirror/extension-image/src/image-extension.ts
+++ b/packages/@remirror/extension-image/src/image-extension.ts
@@ -93,7 +93,9 @@ export class ImageExtension extends NodeExtension {
               return false;
             }
 
-            const images = [...event.dataTransfer.files].filter((file) => /^image\//i.test(file.type));
+            const images = [...event.dataTransfer.files].filter((file) =>
+              /^image\//i.test(file.type),
+            );
 
             if (images.length === 0) {
               return false;


### PR DESCRIPTION
### Description

Without the anchoring, the regexp would unintentionally match things like `application/vnd.fastcopy-disk-image` and `application/vnd.oasis.opendocument.image`.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
