### PR TITLE
fix: preserve attributes for `toggleBlockItem` and `setBlockType`

### DIFF
--- a/.changeset/few-olives-walk.md
+++ b/.changeset/few-olives-walk.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Add `getActiveNode` function which returns the information for an active node of the provided type.

--- a/.changeset/good-queens-tan.md
+++ b/.changeset/good-queens-tan.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-constants': major
+---
+
+Rename deprecated error constant from `COMMANDS_CALLED_IN_OUTER_SCOPE` to `SCHEMA`.

--- a/.changeset/smart-pots-thank.md
+++ b/.changeset/smart-pots-thank.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': minor
+---
+
+Add `getMarkRanges` which supports retrieving all the mark ranges from within the provided selection.

--- a/.changeset/tame-items-turn.md
+++ b/.changeset/tame-items-turn.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Preserve attributes when toggling a block node. This allows for better support when using `extraAttributes` and fixes [#819](https://github.com/remirror/remirror/issues/819).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -87,9 +87,9 @@ Invalid value passed into `Manager constructor`. Only `Presets` and `Extensions`
 
 ### RMR0012
 
-> Commands Called In Outer Scope
+> Schema
 
-The `commands` or `dispatch` method which is passed into the `create*` method should only be called within returned method since it relies on an active view (not present in the outer scope).
+There is a problem with the schema or you are trying to access a node / mark that doesn't exists.
 
 ### RMR0013
 

--- a/packages/@remirror/core-constants/src/error-constants.ts
+++ b/packages/@remirror/core-constants/src/error-constants.ts
@@ -64,11 +64,10 @@ export enum ErrorConstant {
   INVALID_MANAGER_ARGUMENTS = 'RMR0011',
 
   /**
-   * The `commands` or `dispatch` method which is passed into the `create*`
-   * method should only be called within returned method since it relies on an
-   * active view (not present in the outer scope).
+   * There is a problem with the schema or you are trying to access a node /
+   * mark that doesn't exists.
    */
-  COMMANDS_CALLED_IN_OUTER_SCOPE = 'RMR0012',
+  SCHEMA = 'RMR0012',
 
   /**
    * The `helpers` method which is passed into the ``create*` method should only

--- a/packages/@remirror/core-helpers/src/core-errors.ts
+++ b/packages/@remirror/core-helpers/src/core-errors.ts
@@ -35,8 +35,8 @@ if (process.env.NODE_ENV !== 'production') {
       'You requested an invalid extension from the preset. Please check the `createExtensions` return method is returning an extension with the requested constructor.',
     [ErrorConstant.INVALID_MANAGER_ARGUMENTS]:
       'Invalid value(s) passed into `Manager` constructor. Only `Presets` and `Extensions` are supported.',
-    [ErrorConstant.COMMANDS_CALLED_IN_OUTER_SCOPE]:
-      'The `commands` or `dispatch` method which is passed into the `create*` method should only be called within returned method since it relies on an active view (not present in the outer scope).',
+    [ErrorConstant.SCHEMA]:
+      "There is a problem with the schema or you are trying to access a node / mark that doesn't exists.",
     [ErrorConstant.HELPERS_CALLED_IN_OUTER_SCOPE]:
       'The `helpers` method which is passed into the ``create*` method should only be called within returned method since it relies on an active view (not present in the outer scope).',
     [ErrorConstant.INVALID_MANAGER_EXTENSION]:

--- a/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
+++ b/packages/@remirror/core-utils/src/__tests__/core-utils.spec.ts
@@ -38,6 +38,7 @@ import {
   getInvalidContent,
   getMarkAttributes,
   getMarkRange,
+  getMarkRanges,
   getNearestNonTextElement,
   getRemirrorJSON,
   getSelectedWord,
@@ -247,6 +248,40 @@ describe('getMarkRange', () => {
 
     expect(range?.mark).toBeInstanceOf(Mark);
     expect(range?.text).toBe('italic but still strong');
+  });
+
+  it('returns first matched range when provided with $end', () => {
+    const { state, schema } = createEditor(
+      doc(p('Something <start>', em('italic'), strong(' <end>but still strong'))),
+    );
+    const { $from, $to } = state.selection;
+    const range = getMarkRange($from, schema.marks.strong, $to);
+
+    expect(range?.mark).toBeInstanceOf(Mark);
+    expect(range?.text).toBe(' but still strong');
+  });
+});
+
+describe('getMarkRanges', () => {
+  it('returns all the marks within provided range', () => {
+    const { state } = createEditor(
+      doc(
+        p(
+          'Something <start>',
+          strong('hi'),
+          em(' my '),
+          strong('friend. '),
+          em('Bye'),
+          strong(' for<en> now... 😼'),
+        ),
+      ),
+    );
+    const ranges = getMarkRanges(state.selection, 'strong');
+
+    expect(ranges).toHaveLength(3);
+    expect(ranges[0]?.text).toBe('hi');
+    expect(ranges[1]?.text).toBe('friend. ');
+    expect(ranges[2]?.text).toBe(' for now... 😼');
   });
 });
 

--- a/packages/@remirror/core-utils/src/index.ts
+++ b/packages/@remirror/core-utils/src/index.ts
@@ -37,6 +37,7 @@ export {
   getInvalidContent,
   getMarkAttributes,
   getMarkRange,
+  getMarkRanges,
   getMatchString,
   getNearestNonTextElement,
   getRemirrorJSON,
@@ -137,4 +138,5 @@ export {
   removeNodeBefore,
   replaceNodeAtPosition,
   schemaToJSON,
+  getActiveNode,
 } from './prosemirror-utils';


### PR DESCRIPTION
### Description

Add `getActiveNode` function which returns the information for an active node of the provided type.

Rename deprecated error constant from `COMMANDS_CALLED_IN_OUTER_SCOPE` to `SCHEMA`.

Add `getMarkRanges` which supports retrieving all the mark ranges from within the provided selection.

Preserve attributes when toggling a block node. This allows for better support when using `extraAttributes` and fixes [#819](https://github.com/remirror/remirror/issues/819).


Fixes #819 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
