### PR TITLE
chore: visualize internal state in annotation storybook

### DIFF
--- a/support/storybook/stories/annotation.stories.tsx
+++ b/support/storybook/stories/annotation.stories.tsx
@@ -35,6 +35,7 @@ const Popup: FC = () => {
         position: 'absolute',
         border: '1px solid black',
         whiteSpace: 'pre-line',
+        background: 'white',
       }}
       ref={positioner.ref}
     >
@@ -44,7 +45,9 @@ const Popup: FC = () => {
 };
 
 const SmallEditor: FC = () => {
-  const { getRootProps, setContent, commands } = useRemirror();
+  const { getRootProps, setContent, commands, helpers } = useRemirror({
+    autoUpdate: true,
+  });
 
   useEffect(() => {
     setContent({
@@ -84,6 +87,8 @@ const SmallEditor: FC = () => {
     <div>
       <div {...getRootProps()} />
       <Popup />
+      <div>Annotations:</div>
+      <pre>{JSON.stringify(helpers.getAnnotations(), null, '  ')}</pre>
     </div>
   );
 };


### PR DESCRIPTION
### Description

Annotations are stored in a separate data structure from the editor content. It's helpful to see them not only visualized in the editor but see also the expected JSON. Showing the internal state transports a clearer idea how annotations work and eases testing/debugging of annotation corner cases.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/9339055/102685654-897cbd80-41e2-11eb-903e-8d0035d017f3.png)
