### PR TITLE
fix: call setState in command in useEmoji

### DIFF
--- a/packages/@remirror/react-hooks/src/use-emoji.ts
+++ b/packages/@remirror/react-hooks/src/use-emoji.ts
@@ -49,8 +49,8 @@ function useEmojiChangeHandler(setState: SetEmojiState) {
           list: emojiMatches,
           index: 0,
           command: (emoji, skinVariation) => {
-            return command(emoji, skinVariation);
             setState(null);
+            return command(emoji, skinVariation);
           },
           range,
         });


### PR DESCRIPTION
 I noticed while using the `useEmoji` hook with the `SocialEmojiComponent`  that when I click an emoji, the `state` persisted and the `SocialEmojiComponent` was left open even after selecting an emoji. As I started to look at the code, I noticed that `command` never sets the state to `null` for the `useEmojiChangeHandler`, and found that `setState` was called after the `return` in the `command`. 

This PR rearranges the `return` and call to `setState` so that the `state` is set to `null`.

### Notes

in the source code, `setState` was being called after `return` in the `useEmojiChangeHandler` `command` handler. 

That meant `setState` was unreachable and was stripped in the distributed files.

Not calling `setState` led to a situation where using the `SocialEmojiComponent` would remain open even after selecting an emoji.


From `use-emoji/dist/react-hooks.esm.js`:

```
  if (changeReason) {
      setState({
        list: emojiMatches,
        index: 0,
        command: (emoji, skinVariation) => {
          return _command(emoji, skinVariation); // no call to `setState`
        },
        range
      });
  }
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.


### Screenshots

**Before**

![Jan-19-2021 22-30-31](https://user-images.githubusercontent.com/1024544/105136418-72addd00-5aa6-11eb-8855-6e993d5c171f.gif)

**After (adding `setState` to `react-hooks.browser.esm.js` bundled file)**

![Jan-19-2021 22-32-40](https://user-images.githubusercontent.com/1024544/105136484-92450580-5aa6-11eb-8ae3-b16598133756.gif)
