### PR TITLE
chore(deps): add missing dependency cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "case-anything": "^1.1.2",
     "core-js": "^3.8.2",
     "cpy-cli": "^3.1.1",
+    "cross-env": "^7.0.3",
     "delay": "^5.0.0",
     "detox": "^18.2.2",
     "downlevel-dts": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,7 @@ importers:
       case-anything: 1.1.2
       core-js: 3.8.3
       cpy-cli: 3.1.1
+      cross-env: 7.0.3
       delay: 5.0.0
       detox: 18.2.2_jest-circus@26.6.3
       downlevel-dts: 0.7.0
@@ -166,6 +167,7 @@ importers:
       case-anything: ^1.1.2
       core-js: ^3.8.2
       cpy-cli: ^3.1.1
+      cross-env: ^7.0.3
       delay: ^5.0.0
       detox: ^18.2.2
       downlevel-dts: ^0.7.0
@@ -3168,6 +3170,9 @@ packages:
     bundledDependencies:
       - jsonschema
       - semver
+    dependencies:
+      jsonschema: 1.4.0
+      semver: 7.3.4
     dev: false
     engines:
       node: '>= 10.13.0 <13 || >=13.7.0'
@@ -3191,6 +3196,7 @@ packages:
       - semver
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 1.88.0
+      semver: 7.3.4
     dev: false
     engines:
       node: '>= 10.13.0 <13 || >=13.7.0'
@@ -3205,6 +3211,8 @@ packages:
   /@aws-cdk/yaml-cfn/1.88.0:
     bundledDependencies:
       - yaml
+    dependencies:
+      yaml: 1.10.0
     dev: false
     engines:
       node: '>= 10.13.0 <13 || >=13.7.0'
@@ -13158,6 +13166,17 @@ packages:
     dev: false
     resolution:
       integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+  /cross-env/7.0.3:
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: false
+    engines:
+      node: '>=10.14'
+      npm: '>=6'
+      yarn: '>=1'
+    hasBin: true
+    resolution:
+      integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
   /cross-fetch/3.0.6:
     dependencies:
       node-fetch: 2.6.1
@@ -20193,6 +20212,10 @@ packages:
   /jsonify/0.0.0:
     resolution:
       integrity: sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+  /jsonschema/1.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
   /jsonwebtoken/8.5.1:
     dependencies:
       jws: 3.2.2


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

I found that in Github Codespace, the git hooks don't work well because of `cross-env-shell: not found`. 

```bash 
node ➜ ~/workspace/remirror (beta) $ git checkout -b fix_deps
Switched to a new branch 'fix_deps'
husky > post-checkout (node v14.15.4)
sh: 1: sh: 1: cross-env-shell: not foundcross-env-shell: not found

husky > post-checkout hook failed (cannot be bypassed with --no-verify due to Git specs)
```

*BTW, when I wrote this PR, I just found out that `cross-env` was in [maintenance mode](https://github.com/kentcdodds/cross-env/issues/257). `cross-env` will continue to support the latest Node.js version as we as to fix security/critical bugs, so it should be ok to continue to use it. I just post this as a small piece of news.*

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
 