### PR TITLE
fix(core): initialize `previousState` for `store`

### DIFF
--- a/.changeset/tiny-buttons-repair.md
+++ b/.changeset/tiny-buttons-repair.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Initialize the `Extension#store` property with a `previousState` of `undefined` to prevent a crash in certain conditions. This closes [#863](https://github.com/remirror/remirror/pull/863).

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "checks": "run-s lint typecheck:quick test",
     "checks:disable": "rimraf ./.config.json",
     "checks:enable": "cpy support/.config.sample.json ./ --rename=\".config.json\"",
-    "checks:fix": "run-s -c fix typecheck test",
+    "checks:fix": "run-s -c fix typecheck test build build:dev",
     "checks:release": "run-s checks build e2e",
     "clean": "pnpm if-clean git clean -- -fdx --exclude=.config.json --exclude=node_modules --exclude=**/node_modules",
     "clean:all": "git clean -fdX --exclude='.config.json'",

--- a/packages/remirror__core/__tests__/__snapshots__/remirror-manager.spec.tsx.snap
+++ b/packages/remirror__core/__tests__/__snapshots__/remirror-manager.spec.tsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Manager #properties should initialize the \`extensionStore\` with the correct values 1`] = `
+Array [
+  "extensions",
+  "phase",
+  "view",
+  "managerSettings",
+  "getState",
+  "updateState",
+  "isMounted",
+  "getExtension",
+  "manager",
+  "document",
+  "stringHandlers",
+  "currentState",
+  "previousState",
+  "getStoreKey",
+  "setStoreKey",
+  "setExtensionStore",
+  "setStringHandler",
+  "nodeNames",
+  "markNames",
+  "plainNames",
+  "tags",
+  "plainTags",
+  "markTags",
+  "nodeTags",
+  "schema",
+  "updatePlugins",
+  "dispatchPluginUpdate",
+  "updateExtensionPlugins",
+  "getPluginState",
+  "updateAttributes",
+  "rebuildInputRules",
+  "addSuggester",
+  "removeSuggester",
+  "attrs",
+  "active",
+  "helpers",
+  "rebuildKeymap",
+  "createPlaceholderCommand",
+]
+`;
+
+exports[`Manager #properties should initialize the \`extensionStore\` with the correct values 2`] = `
+"This occurs when accessing a method or property before it is available.
+
+\`getState\` can only be called after the \`Framework\` or the \`EditorView\` has been added to the manager\`. Check your plugins to make sure that the decorations callback uses the state argument.
+
+For more information visit https://remirror.io/docs/errors#rmr0008"
+`;

--- a/packages/remirror__core/__tests__/remirror-manager.spec.tsx
+++ b/packages/remirror__core/__tests__/remirror-manager.spec.tsx
@@ -132,6 +132,17 @@ describe('Manager', () => {
     it('should provide access to `attributes`', () => {
       expect(manager.store.attributes.class).toInclude('custom');
     });
+
+    hideConsoleError(true);
+
+    it('should initialize the `extensionStore` with the correct values', () => {
+      const manager = createCoreManager([]);
+
+      expect(Object.keys(manager.extensionStore)).toMatchSnapshot();
+      expect(manager.extensionStore.previousState).toBeUndefined();
+      expect(() => manager.extensionStore.currentState).toThrowErrorMatchingSnapshot();
+      expect(manager.extensionStore.getState).toEqual(expect.any(Function));
+    });
   });
 
   it('isManager', () => {
@@ -271,15 +282,15 @@ describe('createEmptyDoc', () => {
     const manager = RemirrorManager.create([...corePreset()]);
 
     expect(manager.createEmptyDoc().toJSON()).toMatchInlineSnapshot(`
-    Object {
-      "content": Array [
-        Object {
-          "type": "paragraph",
-        },
-      ],
-      "type": "doc",
-    }
-  `);
+          Object {
+            "content": Array [
+              Object {
+                "type": "paragraph",
+              },
+            ],
+            "type": "doc",
+          }
+      `);
   });
 
   it('creates an empty doc with alternative content', () => {

--- a/packages/remirror__core/src/manager/remirror-manager.ts
+++ b/packages/remirror__core/src/manager/remirror-manager.ts
@@ -482,6 +482,7 @@ export class RemirrorManager<Extension extends AnyExtension> {
     // Allow current state to default to `getState` for first access.
     // This fixed an issue with #814
     let currentState: EditorState | undefined;
+    let previousState: EditorState | undefined;
 
     Object.defineProperties(store, {
       extensions: { get: () => this.#extensions, enumerable },
@@ -499,6 +500,13 @@ export class RemirrorManager<Extension extends AnyExtension> {
         get: () => (currentState ??= this.getState()),
         set: (state: EditorState) => {
           currentState = state;
+        },
+        enumerable,
+      },
+      previousState: {
+        get: () => previousState,
+        set: (state: EditorState) => {
+          previousState = state;
         },
         enumerable,
       },

--- a/packages/testing/src/tsconfig.json
+++ b/packages/testing/src/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../remirror__core/src"
     },
     {
+      "path": "../../remirror__pm/src"
+    },
+    {
       "path": "../../remirror__preset-core/src"
     },
     {


### PR DESCRIPTION
### Description

Initialize the `Extension#store` property with a `previousState` of `undefined` to prevent a crash in certain conditions. 

Closes #863 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
