### PR TITLE
fix(extension-annotation): delete text and annotations

### DIFF
--- a/.changeset/kind-houses-protect.md
+++ b/.changeset/kind-houses-protect.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+Deleting text deletes also enclosed annotations

--- a/packages/remirror__extension-annotation/src/annotation-plugin.ts
+++ b/packages/remirror__extension-annotation/src/annotation-plugin.ts
@@ -38,7 +38,7 @@ export class AnnotationState<Type extends Annotation = Annotation> {
       // if new text was added before the decoration
       .map((annotation) => ({
         ...annotation,
-        from: tr.mapping.map(annotation.from),
+        from: tr.mapping.map(annotation.from, -1),
         // -1 indicates that the annotation isn't extended when the user types
         // at the end of the annotation
         to: tr.mapping.map(annotation.to, -1),


### PR DESCRIPTION
Fixes https://github.com/remirror/remirror/issues/874

### Description

Deleting text kept enclosed annotations with a negative length (`to=0`). This PR deletes the annotations for good. 

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
