### PR TITLE
feat(react-renderer): make composable

### DIFF
--- a/.changeset/clean-rings-flash.md
+++ b/.changeset/clean-rings-flash.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-renderer': minor
+---
+
+Make react-renderer composableBefore, it was hard to add further node renderer to RemirrorRenderer. Users couldn't use the existing node renderer like TextHandler and CodeBlock because they weren't exported. This commit simplifies composing a static renderer for the user's needs by exporting the renderers and the interface required to write custom node renderers. As part of the commit, the complex renderer file is split into smaller - easier to understand&test - units.

--- a/.changeset/clean-rings-flash.md
+++ b/.changeset/clean-rings-flash.md
@@ -2,4 +2,4 @@
 '@remirror/react-renderer': minor
 ---
 
-Make react-renderer composableBefore, it was hard to add further node renderer to RemirrorRenderer. Users couldn't use the existing node renderer like TextHandler and CodeBlock because they weren't exported. This commit simplifies composing a static renderer for the user's needs by exporting the renderers and the interface required to write custom node renderers. As part of the commit, the complex renderer file is split into smaller - easier to understand&test - units.
+Make react-renderer composable. Before, it was hard to add further node renderer to RemirrorRenderer. Users couldn't use the existing node renderer like `TextHandler` and `CodeBlock` because they weren't exported. This commit simplifies composing a static renderer for the user's needs by exporting the renderers and the interface required to write custom node renderers. As part of the commit, the complex renderer file is split into smaller - easier to understand and test - units.

--- a/packages/remirror__react-renderer/__tests__/code-block.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/code-block.spec.tsx
@@ -1,0 +1,30 @@
+import { strictRender } from 'testing/react';
+import { RemirrorJSON } from '@remirror/core';
+
+import { CodeBlock } from '../';
+
+describe('CodeBlock', () => {
+  it('renders codeblock to HTML', () => {
+    const json: RemirrorJSON = {
+      type: 'codeBlock',
+      attrs: {
+        language: 'js',
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Code',
+        },
+      ],
+    };
+    const { container } = strictRender(<CodeBlock node={json} markMap={{}} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <pre>
+        <code>
+          Code
+        </code>
+      </pre>
+    `);
+  });
+});

--- a/packages/remirror__react-renderer/__tests__/renderer.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/renderer.spec.tsx
@@ -1,0 +1,90 @@
+import { strictRender } from 'testing/react';
+import { RemirrorJSON } from '@remirror/core';
+
+import { Doc, RemirrorRenderer, TextHandler } from '../';
+
+const JSON: RemirrorJSON = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'This is a',
+        },
+        {
+          type: 'text',
+          marks: [
+            {
+              type: 'bold',
+            },
+          ],
+          text: 'sample',
+        },
+        {
+          type: 'text',
+          text: 'text.',
+        },
+      ],
+    },
+  ],
+};
+
+describe('RemirrorRenderer', () => {
+  it('renders RemirrorJSON to HTML', () => {
+    const { container } = strictRender(<RemirrorRenderer json={JSON} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <p>
+          This is a
+          <strong>
+            sample
+          </strong>
+          text.
+        </p>
+      </div>
+    `);
+  });
+
+  it('supports custom typeMap', () => {
+    const typeMap = {
+      doc: Doc,
+      paragraph: 'div',
+      text: TextHandler,
+    };
+    const { container } = strictRender(<RemirrorRenderer json={JSON} typeMap={typeMap} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <div>
+          This is a
+          <strong>
+            sample
+          </strong>
+          text.
+        </div>
+      </div>
+    `);
+  });
+
+  it('supports custom markMap', () => {
+    const markMap = {
+      bold: 'b',
+    };
+    const { container } = strictRender(<RemirrorRenderer json={JSON} markMap={markMap} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <p>
+          This is a
+          <b>
+            sample
+          </b>
+          text.
+        </p>
+      </div>
+    `);
+  });
+});

--- a/packages/remirror__react-renderer/__tests__/text.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/text.spec.tsx
@@ -1,0 +1,38 @@
+import { strictRender } from 'testing/react';
+import { RemirrorJSON } from '@remirror/core';
+
+import { TextHandler } from '../';
+
+describe('TextHandler', () => {
+  it('renders text to HTML', () => {
+    const json: RemirrorJSON = {
+      type: 'text',
+      text: 'Some text',
+    };
+    const { container } = strictRender(<TextHandler node={json} markMap={{}} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot('"Some text"');
+  });
+
+  it('renders marks', () => {
+    const json: RemirrorJSON = {
+      type: 'text',
+      text: 'bold text',
+      marks: [
+        {
+          type: 'bold',
+        },
+      ],
+    };
+    const markMap = {
+      bold: 'strong',
+    };
+    const { container } = strictRender(<TextHandler node={json} markMap={markMap} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <strong>
+        bold text
+      </strong>
+    `);
+  });
+});

--- a/packages/remirror__react-renderer/__tests__/tsconfig.json
+++ b/packages/remirror__react-renderer/__tests__/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > '__tests__'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "jest",
+      "jest-extended",
+      "jest-axe",
+      "@testing-library/jest-dom",
+      "snapshot-diff",
+      "node"
+    ],
+    "declaration": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove"
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../testing/src"
+    },
+    {
+      "path": "../../remirror/src"
+    },
+    {
+      "path": "../../remirror__core/src"
+    }
+  ]
+}

--- a/packages/remirror__react-renderer/src/handlers/code-block.tsx
+++ b/packages/remirror__react-renderer/src/handlers/code-block.tsx
@@ -1,0 +1,26 @@
+import { FC } from 'react';
+import { RemirrorJSON } from '@remirror/core';
+
+import { MarkMap } from '../types';
+import { TextHandler } from './text';
+
+export const CodeBlock: FC<{
+  node: RemirrorJSON;
+  markMap: MarkMap;
+}> = (props) => {
+  const content = props.node.content;
+
+  if (!content) {
+    return null;
+  }
+
+  const children = content.map((node, ii) => {
+    return <TextHandler key={ii} {...{ ...props, node }} />;
+  });
+
+  return (
+    <pre>
+      <code>{children}</code>
+    </pre>
+  );
+};

--- a/packages/remirror__react-renderer/src/handlers/index.ts
+++ b/packages/remirror__react-renderer/src/handlers/index.ts
@@ -1,0 +1,2 @@
+export { CodeBlock } from './code-block';
+export { TextHandler } from './text';

--- a/packages/remirror__react-renderer/src/handlers/text.tsx
+++ b/packages/remirror__react-renderer/src/handlers/text.tsx
@@ -1,0 +1,42 @@
+import { FC, Fragment } from 'react';
+import { isString, ObjectMark, RemirrorJSON } from '@remirror/core';
+
+import { MarkMap } from '../types';
+
+interface TextHandlerProps {
+  node: RemirrorJSON;
+  markMap: MarkMap;
+  skipUnknownMarks?: boolean;
+}
+
+const normalizeMark = (mark: ObjectMark | string) =>
+  isString(mark) ? { type: mark, attrs: {} } : { attrs: {}, ...mark };
+
+export const TextHandler: FC<TextHandlerProps> = ({ node, ...props }) => {
+  if (!node.text) {
+    return null;
+  }
+
+  let textElement = <Fragment>{node.text}</Fragment>;
+
+  if (!node.marks) {
+    return textElement;
+  }
+
+  for (const mark of node.marks) {
+    const normalized = normalizeMark(mark);
+    const MarkHandler = props.markMap[normalized.type];
+
+    if (!MarkHandler) {
+      if (!props.skipUnknownMarks) {
+        throw new Error(`No handler for mark type \`${normalized.type}\` registered`);
+      }
+
+      continue;
+    }
+
+    textElement = <MarkHandler {...normalized.attrs}>{textElement}</MarkHandler>;
+  }
+
+  return textElement;
+};

--- a/packages/remirror__react-renderer/src/index.ts
+++ b/packages/remirror__react-renderer/src/index.ts
@@ -1,1 +1,3 @@
-export { RemirrorRenderer } from './renderer';
+export * from './handlers';
+export { Doc, RemirrorRenderer } from './renderer';
+export type { MarkMap } from './types';

--- a/packages/remirror__react-renderer/src/renderer.tsx
+++ b/packages/remirror__react-renderer/src/renderer.tsx
@@ -1,67 +1,10 @@
-import { ComponentType, FC, Fragment } from 'react';
-import { isEmptyArray, isString, object, ObjectMark, RemirrorJSON } from '@remirror/core';
+import { FC, Fragment } from 'react';
+import { isEmptyArray, isString, object, RemirrorJSON } from '@remirror/core';
 
-type MarkMap = Partial<Record<string, string | ComponentType<any>>>;
-interface TextHandlerProps {
-  node: RemirrorJSON;
-  markMap: MarkMap;
-  skipUnknownMarks?: boolean;
-}
+import { CodeBlock, TextHandler } from './handlers';
+import { MarkMap } from './types';
 
-const normalizeMark = (mark: ObjectMark | string) =>
-  isString(mark) ? { type: mark, attrs: {} } : { attrs: {}, ...mark };
-
-const TextHandler: FC<TextHandlerProps> = ({ node, ...props }) => {
-  if (!node.text) {
-    return null;
-  }
-
-  let textElement = <Fragment>{node.text}</Fragment>;
-
-  if (!node.marks) {
-    return textElement;
-  }
-
-  for (const mark of node.marks) {
-    const normalized = normalizeMark(mark);
-    const MarkHandler = props.markMap[normalized.type];
-
-    if (!MarkHandler) {
-      if (!props.skipUnknownMarks) {
-        throw new Error(`No handler for mark type \`${normalized.type}\` registered`);
-      }
-
-      continue;
-    }
-
-    textElement = <MarkHandler {...normalized.attrs}>{textElement}</MarkHandler>;
-  }
-
-  return textElement;
-};
-
-const CodeBlock: FC<{
-  node: RemirrorJSON;
-  markMap: MarkMap;
-}> = (props) => {
-  const content = props.node.content;
-
-  if (!content) {
-    return null;
-  }
-
-  content.map((node, ii) => {
-    return <TextHandler key={ii} {...{ ...props, node }} />;
-  });
-
-  return (
-    <pre>
-      <code>{content}</code>
-    </pre>
-  );
-};
-
-const Doc: FC<SubRenderTreeProps> = ({ node, ...props }) => {
+export const Doc: FC<SubRenderTreeProps> = ({ node, ...props }) => {
   const content = node.content;
 
   if (!content || isEmptyArray(content)) {

--- a/packages/remirror__react-renderer/src/renderer.tsx
+++ b/packages/remirror__react-renderer/src/renderer.tsx
@@ -19,11 +19,14 @@ export const Doc: FC<SubRenderTreeProps> = ({ node, ...props }) => {
 };
 
 const defaultTypeMap: MarkMap = {
+  blockquote: 'blockquote',
+  bulletList: 'ul',
   doc: Doc,
   paragraph: 'p',
   image: 'img',
   hardBreak: 'br',
   codeBlock: CodeBlock,
+  orderedList: 'ol',
   text: TextHandler,
 };
 

--- a/packages/remirror__react-renderer/src/types.ts
+++ b/packages/remirror__react-renderer/src/types.ts
@@ -1,0 +1,3 @@
+import { ComponentType } from 'react';
+
+export type MarkMap = Partial<Record<string, string | ComponentType<any>>>;

--- a/support/root/tsconfig.json
+++ b/support/root/tsconfig.json
@@ -492,6 +492,9 @@
       "path": "packages/remirror__react-native/src"
     },
     {
+      "path": "packages/remirror__react-renderer/__tests__"
+    },
+    {
       "path": "packages/remirror__react-renderer/src"
     },
     {


### PR DESCRIPTION
### Description

Before, it was hard to add further node renderer to RemirrorRenderer. Users couldn't use the existing node renderer like TextHandler and CodeBlock because they weren't exported.
This PR simplifies composing a static renderer for the user's needs by exporting the renderers and the interface required to write custom node renderers.

I tried to preserve the different steps as separate commits. They are intended to be squashed before merge. 

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
