### PR TITLE
feat(react-renderer): support static heading, iframe & link

### DIFF
--- a/.changeset/twelve-berries-greet.md
+++ b/.changeset/twelve-berries-greet.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-renderer': minor
+---
+
+Support static rendering of heading, iframe, linkAdded support for some common node types and marks. The iframe and link handler can be parameterized to change the visualization vs the node attributes in RemirrorJSON. For example, it allows to open links in a new tab or set the iframe to a specific width/height (independently of how this was entered in the editor).

--- a/.changeset/twelve-berries-greet.md
+++ b/.changeset/twelve-berries-greet.md
@@ -2,4 +2,4 @@
 '@remirror/react-renderer': minor
 ---
 
-Support static rendering of heading, iframe, linkAdded support for some common node types and marks. The iframe and link handler can be parameterized to change the visualization vs the node attributes in RemirrorJSON. For example, it allows to open links in a new tab or set the iframe to a specific width/height (independently of how this was entered in the editor).
+Support static rendering of heading, iframe, link. Added support for some common node types and marks. The iframe and link handler can be parameterized to change the visualization vs the node attributes in RemirrorJSON. For example, it allows to open links in a new tab or set the iframe to a specific width/height (independently of how this was entered in the editor).

--- a/packages/remirror__react-renderer/__tests__/heading.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/heading.spec.tsx
@@ -1,0 +1,33 @@
+import { strictRender } from 'testing/react';
+import { RemirrorJSON } from '@remirror/core';
+
+import { Heading } from '../src/handlers/heading';
+
+describe('Heading', () => {
+  it('renders different heading levels to HTML', () => {
+    const createJson = (level: number): RemirrorJSON => ({
+      type: 'heading',
+      attrs: {
+        level,
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'Heading',
+        },
+      ],
+    });
+
+    for (let level = 1; level <= 6; level++) {
+      const json = createJson(level);
+      const { container } = strictRender(<Heading node={json} markMap={{}} />);
+
+      const expected = `
+        <h${level}>
+          Heading
+        </h${level}>
+      `;
+      expect(container.innerHTML).toMatchInlineSnapshot(expected);
+    }
+  });
+});

--- a/packages/remirror__react-renderer/__tests__/iframe.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/iframe.spec.tsx
@@ -1,0 +1,44 @@
+import { strictRender } from 'testing/react';
+
+import { createIFrameHandler } from '../src/handlers/iframe';
+
+const JSON = {
+  type: 'iframe',
+  attrs: {
+    src: 'https://www.youtube-nocookie.com/embed/ew-mIOGJls0?',
+    allowFullScreen: 'true',
+    frameBorder: 0,
+    type: 'youtube',
+    width: null,
+    height: null,
+  },
+};
+
+describe('createIFrameHandler', () => {
+  it('renders iFrame to HTML', () => {
+    const IFrame = createIFrameHandler();
+    const { container } = strictRender(<IFrame node={JSON} markMap={{}} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <iframe src="https://www.youtube-nocookie.com/embed/ew-mIOGJls0?"
+              frameborder="0"
+              allowfullscreen
+      >
+      </iframe>
+    `);
+  });
+
+  it('allows to overwrite attributes', () => {
+    const IFrame = createIFrameHandler({ width: '100%' });
+    const { container } = strictRender(<IFrame node={JSON} markMap={{}} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <iframe src="https://www.youtube-nocookie.com/embed/ew-mIOGJls0?"
+              frameborder="0"
+              width="100%"
+              allowfullscreen
+      >
+      </iframe>
+    `);
+  });
+});

--- a/packages/remirror__react-renderer/__tests__/link.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/link.spec.tsx
@@ -1,0 +1,36 @@
+import { strictRender } from 'testing/react';
+
+import { createLinkHandler } from '../src/handlers/link';
+
+const LINK = {
+  href: 'https://www.example.com',
+  target: null,
+  auto: false,
+  children: <>example.com</>,
+};
+
+describe('createLinkHandler', () => {
+  it('renders link to HTML', () => {
+    const Link = createLinkHandler();
+    const { container } = strictRender(<Link {...LINK} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <a href="https://www.example.com">
+        example.com
+      </a>
+    `);
+  });
+
+  it('allows to overwrite attributes', () => {
+    const Link = createLinkHandler({ target: '_blank' });
+    const { container } = strictRender(<Link {...LINK} />);
+
+    expect(container.innerHTML).toMatchInlineSnapshot(`
+      <a href="https://www.example.com"
+         target="_blank"
+      >
+        example.com
+      </a>
+    `);
+  });
+});

--- a/packages/remirror__react-renderer/src/handlers/heading.tsx
+++ b/packages/remirror__react-renderer/src/handlers/heading.tsx
@@ -1,0 +1,24 @@
+import { createElement, FC } from 'react';
+import { RemirrorJSON } from '@remirror/core';
+
+import { MarkMap } from '../types';
+import { TextHandler } from './text';
+
+export const Heading: FC<{
+  node: RemirrorJSON;
+  markMap: MarkMap;
+}> = (props) => {
+  const content = props.node.content;
+
+  if (!content) {
+    return null;
+  }
+
+  const children = content.map((node, ii) => {
+    return <TextHandler key={ii} {...{ ...props, node }} />;
+  });
+
+  const level = (props.node.attrs?.level as number) ?? 1;
+
+  return createElement(`h${level}`, null, children);
+};

--- a/packages/remirror__react-renderer/src/handlers/iframe.tsx
+++ b/packages/remirror__react-renderer/src/handlers/iframe.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+import { Literal, RemirrorJSON } from '@remirror/core';
+
+import { MarkMap } from '../types';
+
+export const createIFrameHandler = (overwriteProps?: Record<string, Literal>) => {
+  const iframeHandler: FC<{
+    node: RemirrorJSON;
+    markMap: MarkMap;
+  }> = (props) => {
+    // Remove remirror-internal attributes
+    const { allowFullScreen, type, ...attrs } = props.node.attrs ?? {};
+    const normalizedAttrs = {
+      ...attrs,
+      // Prevent React error that allowFullScreen must be boolean (but is string in remirror)
+      allowFullScreen: allowFullScreen !== 'false',
+      ...overwriteProps,
+    };
+    return <iframe {...normalizedAttrs} />;
+  };
+  return iframeHandler;
+};

--- a/packages/remirror__react-renderer/src/handlers/iframe.tsx
+++ b/packages/remirror__react-renderer/src/handlers/iframe.tsx
@@ -3,7 +3,7 @@ import { Literal, RemirrorJSON } from '@remirror/core';
 
 import { MarkMap } from '../types';
 
-export const createIFrameHandler = (overwriteProps?: Record<string, Literal>) => {
+export const createIFrameHandler = (overwriteAttrs?: Record<string, Literal>) => {
   const iframeHandler: FC<{
     node: RemirrorJSON;
     markMap: MarkMap;
@@ -14,7 +14,7 @@ export const createIFrameHandler = (overwriteProps?: Record<string, Literal>) =>
       ...attrs,
       // Prevent React error that allowFullScreen must be boolean (but is string in remirror)
       allowFullScreen: allowFullScreen !== 'false',
-      ...overwriteProps,
+      ...overwriteAttrs,
     };
     return <iframe {...normalizedAttrs} />;
   };

--- a/packages/remirror__react-renderer/src/handlers/link.tsx
+++ b/packages/remirror__react-renderer/src/handlers/link.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { Literal } from '@remirror/core';
+
+export const createLinkHandler = (overwriteProps?: Record<string, Literal>) => {
+  const linkHandler: FC<{
+    href: string;
+    target?: string | null;
+    children: React.ReactElement<HTMLElement>;
+  }> = ({ href, target, children }) => {
+    const normalizedAttrs = {
+      href,
+      target: target ?? undefined,
+      ...overwriteProps,
+    };
+    return <a {...normalizedAttrs}>{children}</a>;
+  };
+  return linkHandler;
+};

--- a/packages/remirror__react-renderer/src/handlers/link.tsx
+++ b/packages/remirror__react-renderer/src/handlers/link.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { Literal } from '@remirror/core';
 
-export const createLinkHandler = (overwriteProps?: Record<string, Literal>) => {
+export const createLinkHandler = (overwriteAttrs?: Record<string, Literal>) => {
   const linkHandler: FC<{
     href: string;
     target?: string | null;
@@ -10,7 +10,7 @@ export const createLinkHandler = (overwriteProps?: Record<string, Literal>) => {
     const normalizedAttrs = {
       href,
       target: target ?? undefined,
-      ...overwriteProps,
+      ...overwriteAttrs,
     };
     return <a {...normalizedAttrs}>{children}</a>;
   };

--- a/packages/remirror__react-renderer/src/renderer.tsx
+++ b/packages/remirror__react-renderer/src/renderer.tsx
@@ -2,6 +2,9 @@ import { FC, Fragment } from 'react';
 import { isEmptyArray, isString, object, RemirrorJSON } from '@remirror/core';
 
 import { CodeBlock, TextHandler } from './handlers';
+import { Heading } from './handlers/heading';
+import { createIFrameHandler } from './handlers/iframe';
+import { createLinkHandler } from './handlers/link';
 import { MarkMap } from './types';
 
 export const Doc: FC<SubRenderTreeProps> = ({ node, ...props }) => {
@@ -22,7 +25,9 @@ const defaultTypeMap: MarkMap = {
   blockquote: 'blockquote',
   bulletList: 'ul',
   doc: Doc,
+  heading: Heading,
   paragraph: 'p',
+  iframe: createIFrameHandler(),
   image: 'img',
   hardBreak: 'br',
   codeBlock: CodeBlock,
@@ -34,7 +39,7 @@ const defaultMarkMap: MarkMap = {
   italic: 'em',
   bold: 'strong',
   code: 'code',
-  link: 'a',
+  link: createLinkHandler(),
   underline: 'u',
 };
 


### PR DESCRIPTION
### Description

Added support for some common node types and marks.

The iframe and link handler can be parameterized to change the visualization vs the node attributes in RemirrorJSON. For example, it allows to open links in a new tab or set the iframe to a specific width/height (independently of how this was entered in the editor).

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
