### PR TITLE
fix(react-renderer): export heading, link, and iframe

### DIFF
--- a/.changeset/funny-schools-swim.md
+++ b/.changeset/funny-schools-swim.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-renderer': patch
+---
+
+Expose renderer for heading, link, and iframe

--- a/packages/remirror__react-renderer/__tests__/heading.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/heading.spec.tsx
@@ -1,7 +1,7 @@
 import { strictRender } from 'testing/react';
 import { RemirrorJSON } from '@remirror/core';
 
-import { Heading } from '../src/handlers/heading';
+import { Heading } from '../';
 
 describe('Heading', () => {
   it('renders different heading levels to HTML', () => {

--- a/packages/remirror__react-renderer/__tests__/iframe.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/iframe.spec.tsx
@@ -1,6 +1,6 @@
 import { strictRender } from 'testing/react';
 
-import { createIFrameHandler } from '../src/handlers/iframe';
+import { createIFrameHandler } from '../';
 
 const JSON = {
   type: 'iframe',

--- a/packages/remirror__react-renderer/__tests__/link.spec.tsx
+++ b/packages/remirror__react-renderer/__tests__/link.spec.tsx
@@ -1,6 +1,6 @@
 import { strictRender } from 'testing/react';
 
-import { createLinkHandler } from '../src/handlers/link';
+import { createLinkHandler } from '../';
 
 const LINK = {
   href: 'https://www.example.com',

--- a/packages/remirror__react-renderer/src/handlers/index.ts
+++ b/packages/remirror__react-renderer/src/handlers/index.ts
@@ -1,2 +1,5 @@
 export { CodeBlock } from './code-block';
+export { Heading } from './heading';
+export { createIFrameHandler } from './iframe';
+export { createLinkHandler } from './link';
 export { TextHandler } from './text';


### PR DESCRIPTION
### Description

This was missed in PR https://github.com/remirror/remirror/pull/882.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
