### PR TITLE
feat(react-renderer): add default `horizontalRule`

### DIFF
--- a/.changeset/brown-otters-juggle.md
+++ b/.changeset/brown-otters-juggle.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-renderer': minor
+---
+
+Render horizontalRule by default

--- a/packages/remirror__react-renderer/src/renderer.tsx
+++ b/packages/remirror__react-renderer/src/renderer.tsx
@@ -27,6 +27,7 @@ const defaultTypeMap: MarkMap = {
   doc: Doc,
   heading: Heading,
   paragraph: 'p',
+  horizontalRule: 'hr',
   iframe: createIFrameHandler(),
   image: 'img',
   hardBreak: 'br',


### PR DESCRIPTION
### Description

Renders horizontalRule when setting up an out-of-the-box react-renderer.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
