### PR TITLE
fix(react-node-view): `update` method signature

### DIFF
--- a/@remirror/react-node-view/src/react-node-view.tsx
+++ b/@remirror/react-node-view/src/react-node-view.tsx
@@ -198,13 +198,8 @@ export class ReactNodeView<
     );
   }
 
-  public update(
-    node: ProsemirrorNode,
-    _: Decoration[],
-    validUpdate: (currentNode: ProsemirrorNode, newNode: ProsemirrorNode) => boolean = () => true,
-  ) {
-    // see https://github.com/ProseMirror/prosemirror/issues/648
-    const isValidUpdate = this.node.type === node.type && validUpdate(this.node, node);
+  public update(node: ProsemirrorNode) {
+    const isValidUpdate = this.node.type === node.type;
 
     if (!isValidUpdate) {
       return false;


### PR DESCRIPTION
According to the prosemirror-view code, there is no third arg for this function.
And recently prosemirror updated the update function signature  to 3 args, but the 3rd arg is innerNode, not this validate function, which lead to error for apps use remirror 0.x
see https://github.com/ProseMirror/prosemirror-view/commit/e2c6315191cdd6f331737eac8482458ff5925a6c#diff-5b144bea3a5aaf7a0121242551abe1890b112bb3cbd9fbf3d5cd2022ed44bc4bR868

### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
