### PR TITLE
ci: limit releases to owner, members and contributors

### DIFF
--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   publish_comment:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/publish') && github.event.comment.author_association == 'COLLABORATOR'
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/publish' && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR') }}
     steps:
       - name: get pr information
         uses: actions/github-script@v3
@@ -25,6 +25,9 @@ jobs:
             try {
               const result = await github.pulls.get(request)
               core.info(`Got PR: ${JSON.stringify(result.data)}`)
+              if (result.data.head.repo.full_name !== 'remirror/remirror') {
+                throw new Error(`this workflow is only allowed on the "remirror" repository`)
+              }
               return result.data
             } catch (err) {
               core.setFailed(`Request failed with error ${err}`)


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR includes three updates for the PR-based release workflow:

1. allow not only COLLABORATOR but also OWNER and MEMBER to release a PR-based version.
2. only allow users to submit exact "/publish" in the comment to avoid [this situation](https://github.com/remirror/remirror/pull/885#issuecomment-792465373).
3. Return an error when running this workflow on a forked repository.

---

In my view, one of the biggest challenges to write a CI workflow for an open-source project is preventing attacks. For this workflow as an example, an attacker may be able to override the `pnpm publish` command and upload the `NPM_TOKEN` to their own server.

We now have three layers to prevent this kind of attacks:

1. we limit the people who can trigger this workflow.
2. we don't allow people to run this workflow when the source branch is from a forked repository.
3. when using `actions/checkout`, we only provide `ref` but didn't provide `repository`, which means that we won't clone the code from a forked repository.

I think we should keep the existing protections for future iterations.

--- 

BYW, when I test this PR, I found that GitHub Action doesn't allow newline in the `if`. I just post it as a tip.

This is OK:

```yaml
jobs:
  publish_comment:
    runs-on: ubuntu-latest
    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/publish' && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR') }}
```


This is not OK:

```yaml
jobs:
  publish_comment:
    runs-on: ubuntu-latest
    if: |
      ${{ 
        github.event.issue.pull_request 
        && github.event.comment.body == '/publish' 
        && (
          github.event.comment.author_association == 'OWNER' 
          || github.event.comment.author_association == 'MEMBER' 
          || github.event.comment.author_association == 'COLLABORATOR'
        ) 
      }}
```


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
