### PR TITLE
fix(prosemirror-paste-rules): maximum call stack

### DIFF
--- a/.changeset/selfish-laws-tease.md
+++ b/.changeset/selfish-laws-tease.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Fix paste rules which caused an Maximum call stack size error when active.

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -75,7 +75,7 @@ describe('pasteRules', () => {
         });
     });
 
-    it.skip('should transform complex content', () => {
+    it('should transform complex content', () => {
       const plugin = pasteRules([
         { regexp: /(@[a-z]+)/, markType: schema.marks.strong, type: 'mark' },
       ]);

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -341,7 +341,7 @@ function createPasteRuleHandler<Rule extends RegexPasteRule>(
 
       // When the current node is not a text node, recursively dive into it's child nodes.
       if (!child.isText) {
-        nodes.push(child.copy(handler({ fragment: child.content, rule, nodes })));
+        nodes.push(child.copy(handler({ fragment: child.content, rule, nodes: [] })));
         return;
       }
 


### PR DESCRIPTION
### Description

- Fix #897
- Fix #900
- Fix #883

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

[**Watch Video**](https://www.loom.com/share/dba6f631cb7a4160ba8a542e7d65fe94)


https://user-images.githubusercontent.com/1160934/112470878-1c3d7300-8d63-11eb-935f-e9589c80c5f3.mp4

