### PR TITLE
fix: update exports and `YjsExtension` style

### DIFF
--- a/.changeset/hip-bears-whisper.md
+++ b/.changeset/hip-bears-whisper.md
@@ -1,0 +1,6 @@
+---
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Remove the `margin-top` style for first chilld.

--- a/.changeset/modern-snails-camp.md
+++ b/.changeset/modern-snails-camp.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-hooks': minor
+---
+
+Export `useHover`.

--- a/.changeset/sweet-pets-visit.md
+++ b/.changeset/sweet-pets-visit.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-image': minor
+---
+
+Export `ImageAttributes`.

--- a/packages/remirror__extension-image/src/image-extension.ts
+++ b/packages/remirror__extension-image/src/image-extension.ts
@@ -214,7 +214,7 @@ export class ImageExtension extends NodeExtension<ImageOptions> {
   }
 }
 
-type ImageAttributes = ProsemirrorAttributes<ImageExtensionAttributes>;
+export type ImageAttributes = ProsemirrorAttributes<ImageExtensionAttributes>;
 
 export interface ImageExtensionAttributes {
   align?: 'center' | 'end' | 'justify' | 'left' | 'match-parent' | 'right' | 'start';

--- a/packages/remirror__extension-image/src/index.ts
+++ b/packages/remirror__extension-image/src/index.ts
@@ -1,2 +1,2 @@
-export type { ImageExtensionAttributes, ImageOptions } from './image-extension';
+export type { ImageAttributes, ImageExtensionAttributes, ImageOptions } from './image-extension';
 export { ImageExtension, isImageFileType } from './image-extension';

--- a/packages/remirror__react-hooks/src/index.ts
+++ b/packages/remirror__react-hooks/src/index.ts
@@ -3,6 +3,7 @@ export * from './use-editor-focus';
 export * from './use-emoji';
 export * from './use-event';
 export * from './use-history';
+export * from './use-hover';
 export * from './use-keymap';
 export * from './use-keymaps';
 export * from './use-mention';

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -3950,15 +3950,6 @@ button:active .remirror-menu-pane-shortcut,
 .remirror-editor.ProseMirror > .ProseMirror-yjs-cursor:first-child {
   margin-top: 16px;
 }
-.remirror-editor.ProseMirror p:first-child,
-.remirror-editor.ProseMirror h1:first-child,
-.remirror-editor.ProseMirror h2:first-child,
-.remirror-editor.ProseMirror h3:first-child,
-.remirror-editor.ProseMirror h4:first-child,
-.remirror-editor.ProseMirror h5:first-child,
-.remirror-editor.ProseMirror h6:first-child {
-  margin-top: 16px;
-}
 .remirror-editor #y-functions {
   position: absolute;
   top: 20px;

--- a/packages/remirror__styles/extension-yjs.css
+++ b/packages/remirror__styles/extension-yjs.css
@@ -32,15 +32,6 @@
 .remirror-editor.ProseMirror > .ProseMirror-yjs-cursor:first-child {
   margin-top: 16px;
 }
-.remirror-editor.ProseMirror p:first-child,
-.remirror-editor.ProseMirror h1:first-child,
-.remirror-editor.ProseMirror h2:first-child,
-.remirror-editor.ProseMirror h3:first-child,
-.remirror-editor.ProseMirror h4:first-child,
-.remirror-editor.ProseMirror h5:first-child,
-.remirror-editor.ProseMirror h6:first-child {
-  margin-top: 16px;
-}
 .remirror-editor #y-functions {
   position: absolute;
   top: 20px;

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -3985,15 +3985,6 @@ export const extensionYjsStyledCss: ReturnType<typeof css> = css`
   .remirror-editor.ProseMirror > .ProseMirror-yjs-cursor:first-child {
     margin-top: 16px;
   }
-  .remirror-editor.ProseMirror p:first-child,
-  .remirror-editor.ProseMirror h1:first-child,
-  .remirror-editor.ProseMirror h2:first-child,
-  .remirror-editor.ProseMirror h3:first-child,
-  .remirror-editor.ProseMirror h4:first-child,
-  .remirror-editor.ProseMirror h5:first-child,
-  .remirror-editor.ProseMirror h6:first-child {
-    margin-top: 16px;
-  }
   .remirror-editor #y-functions {
     position: absolute;
     top: 20px;

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -4036,15 +4036,6 @@ export const extensionYjsStyledCss: ReturnType<typeof css> = css`
   .remirror-editor.ProseMirror > .ProseMirror-yjs-cursor:first-child {
     margin-top: 16px;
   }
-  .remirror-editor.ProseMirror p:first-child,
-  .remirror-editor.ProseMirror h1:first-child,
-  .remirror-editor.ProseMirror h2:first-child,
-  .remirror-editor.ProseMirror h3:first-child,
-  .remirror-editor.ProseMirror h4:first-child,
-  .remirror-editor.ProseMirror h5:first-child,
-  .remirror-editor.ProseMirror h6:first-child {
-    margin-top: 16px;
-  }
   .remirror-editor #y-functions {
     position: absolute;
     top: 20px;

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -4035,15 +4035,6 @@ export const extensionYjsStyledCss: ReturnType<typeof css> = css`
   .remirror-editor.ProseMirror > .ProseMirror-yjs-cursor:first-child {
     margin-top: 16px;
   }
-  .remirror-editor.ProseMirror p:first-child,
-  .remirror-editor.ProseMirror h1:first-child,
-  .remirror-editor.ProseMirror h2:first-child,
-  .remirror-editor.ProseMirror h3:first-child,
-  .remirror-editor.ProseMirror h4:first-child,
-  .remirror-editor.ProseMirror h5:first-child,
-  .remirror-editor.ProseMirror h6:first-child {
-    margin-top: 16px;
-  }
   .remirror-editor #y-functions {
     position: absolute;
     top: 20px;

--- a/packages/remirror__theme/src/extension-yjs-theme.ts
+++ b/packages/remirror__theme/src/extension-yjs-theme.ts
@@ -36,16 +36,6 @@ export const EDITOR = css`
     > .ProseMirror-yjs-cursor:first-child {
       margin-top: 16px;
     }
-
-    p:first-child,
-    h1:first-child,
-    h2:first-child,
-    h3:first-child,
-    h4:first-child,
-    h5:first-child,
-    h6:first-child {
-      margin-top: 16px;
-    }
   }
 
   #y-functions {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR removes the `margin-top: 16px` style from the yjs extension, which will affect the style when using `all.css` event the users don't want to use the yjs extension.

This PR also exports some values.
 
### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 