### PR TITLE
fix(node-formatting): fix `nodeLineHeight` accessing wrong attrs

### DIFF
--- a/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
@@ -270,7 +270,7 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
         return element.getAttribute(NODE_LINE_HEIGHT_ATTRIBUTE) ?? element.style.lineHeight;
       },
       toDOM: (attrs) => {
-        const lineHeight = attrs.nodeTextAlignment;
+        const lineHeight = attrs.nodeLineHeight;
 
         if (!lineHeight) {
           return;


### PR DESCRIPTION
### Description

This PR fixes the bug where in the extension `node-formatting`, the `nodeLineHeight` schema attribute is trying to access `attrs.nodeTextAlignment` instead of `attrs.nodeLineHeight` causing to commands `setTextAlignment` and all its shortcut to apply `line-height: right` instead of `text-align: right` in the styles

I did not add a test for this fix as of now, because there doesn't seem to be any existing tests. Should I be responsible for adding tests for this extension?

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
