### PR TITLE
fix(core-types): update `DOMOutputSpec`

### DIFF
--- a/.changeset/three-toes-wait.md
+++ b/.changeset/three-toes-wait.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-types': patch
+---
+
+Update `DOMOutputSpec`.

--- a/packages/remirror__core-types/__tests__/core-types.spec.ts
+++ b/packages/remirror__core-types/__tests__/core-types.spec.ts
@@ -1,0 +1,58 @@
+/* eslint-disable jest/expect-expect */
+
+import { DOMOutputSpec } from '../src/core-types';
+
+describe('DOMOutputSpec', () => {
+  let spec: DOMOutputSpec;
+
+  it('can be a string', () => {
+    spec = 'div';
+    spec = 'p';
+  });
+
+  it('can be an array', () => {
+    spec = ['div', { style: 'display: flex;' }, 0];
+    spec = ['li', { style: 'display: flex;' }, ['input'], ['div'], ['div'], ['div', 0]];
+    spec = [
+      'div',
+      ['div', { attr: '    ' }, ['div'], ['div'], ['div'], ['div'], ['div']],
+      ['div', { attr: '    ' }, ['div'], ['div'], ['div'], ['div'], ['div']],
+      ['div', { attr: '    ' }, ['div'], ['div'], ['div'], ['div'], ['div']],
+      ['div', { attr: '    ' }, ['div'], ['div'], ['div'], ['div'], ['div']],
+      ['div', { attr: '    ' }, ['div'], ['div'], ['div'], ['div'], ['div']],
+      ['div', { attr: '    ' }, ['div'], ['div'], ['div'], ['div'], ['div']],
+      ['div', ['div'], ['div'], ['div'], ['div', { attr: '    ' }, ['div']]],
+      ['div', ['div'], ['div'], ['div'], ['div', { attr: '    ' }, ['div']]],
+      ['div', ['div'], ['div'], ['div'], ['div', { attr: '    ' }, ['div']]],
+      ['div', ['div'], ['div'], ['div'], ['div', { attr: '    ' }, ['div']]],
+      ['div', ['div'], ['div'], ['div'], ['div', { attr: '    ' }, ['div']]],
+      ['div', ['div'], ['div'], ['div'], ['div', { attr: '    ' }, ['div']]],
+      ['div', 0],
+    ];
+  });
+
+  it('can not be other types', () => {
+    // @ts-expect-error
+    spec = 123;
+    // @ts-expect-error
+    spec = { hello: '' };
+    // @ts-expect-error
+    spec = true;
+  });
+
+  it('should only has one child element if the number zero is its child element', () => {
+    spec = ['div', 0];
+    spec = ['div', { style: 'color:red' }, 0];
+    spec = ['div', ['div', 0]];
+    spec = ['div', ['div', { style: 'color:red' }], ['div', 0]];
+
+    // @ts-expect-error
+    spec = ['div', 'div', 0];
+    // @ts-expect-error
+    spec = ['div', { style: 'color:red' }, 'div', 0];
+    // @ts-expect-error
+    spec = ['div', ['div', 'div', 0]];
+    // @ts-expect-error
+    spec = ['div', ['div', { style: 'color:red' }], ['div', ['div', { style: 'color:green' }], 0]];
+  });
+});

--- a/packages/remirror__core-types/src/core-types.ts
+++ b/packages/remirror__core-types/src/core-types.ts
@@ -167,14 +167,6 @@ export interface DOMCompatibleAttributes {
   [attribute: string]: string | number | undefined;
 }
 
-type DOMOutputSpecPos1 = DOMOutputSpecPosX | DOMCompatibleAttributes;
-type DOMOutputSpecPosX =
-  | string
-  | 0
-  | [string, 0]
-  | [string, DOMCompatibleAttributes]
-  | [string, DOMCompatibleAttributes, 0];
-
 /**
  * Defines the return type of the toDOM methods for both nodes and marks
  *
@@ -185,24 +177,31 @@ type DOMOutputSpecPosX =
  *
  * Additionally we don't want to support domNodes in the toDOM spec since this
  * will create problems once SSR is fully supported
+ *
+ * DOMOutputSpec is a description of a DOM structure. Can be either a string,
+ * which is interpreted as a text node, a DOM node (not supported by remirror),
+ * which is interpreted as itself, a {dom: Node, contentDOM: ?Node} object (not
+ * supported by remirror), or an array (DOMOutputSpecArray).
+ *
+ * An array (DOMOutputSpecArray) describes a DOM element. The first value in the
+ * array should be a string—the name of the DOM element, optionally prefixed by
+ * a namespace URL and a space. If the second element is plain object (DOMCompatibleAttributes),
+ * it is interpreted as a set of attributes for the element. Any elements
+ * after that (including the 2nd if it's not an attribute object) are
+ * interpreted as children of the DOM elements, and must either be valid
+ * DOMOutputSpec values, or the number zero.
+ *
+ * The number zero (pronounced “hole”) is used to indicate the place where a
+ * node's child nodes should be inserted. If it occurs in an output spec, it
+ * should be the only child element in its parent node.
  */
-export type DOMOutputSpec =
-  | string
-  | [string, 0?]
-  | [string, DOMCompatibleAttributes, 0?]
-  | [
-      string,
-      DOMOutputSpecPos1?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-      DOMOutputSpecPosX?,
-    ];
+export type DOMOutputSpec = string | DOMOutputSpecArray;
+
+type DOMOutputSpecArray =
+  | [string, ...DOMOutputSpec[]]
+  | [string, DOMCompatibleAttributes, ...DOMOutputSpec[]]
+  | [string, 0]
+  | [string, DOMCompatibleAttributes, 0];
 
 /**
  * The schema spec definition for a node extension


### PR DESCRIPTION
### Description

This PR updates the type definition of DOMOutputSpec, thanks to the power from the new version TypeScript.

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 