### PR TITLE
fix(core-utils): use createAndFill instead of create in inputRule

### DIFF
--- a/.changeset/witty-impalas-deny.md
+++ b/.changeset/witty-impalas-deny.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Use `createAndFill` when creating nodes in a inputRule.


### PR DESCRIPTION
### Description

When creating a node in a inputRule, use `createAndFill` instead of `create`.
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 