### PR TITLE
feat(extension-list): implement list item with checkbox

### DIFF
--- a/.changeset/strange-buses-play.md
+++ b/.changeset/strange-buses-play.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-list': minor
+'@remirror/styles': minor
+'@remirror/theme': minor
+---
+
+Implement list item with checkbox.

--- a/.changeset/strong-emus-rule.md
+++ b/.changeset/strong-emus-rule.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Use `tr.replaceRangeWith` instead of `tr.replaceWith` in inputRule.

--- a/packages/remirror__core-utils/src/prosemirror-rules.ts
+++ b/packages/remirror__core-utils/src/prosemirror-rules.ts
@@ -279,7 +279,7 @@ export function nodeInputRule(props: NodeInputRuleProps): SkippableInputRule {
     const content = nodeType.createAndFill(attributes);
 
     if (content) {
-      tr.replaceWith(nodeType.isBlock ? tr.doc.resolve(start).before() : start, end, content);
+      tr.replaceRangeWith(nodeType.isBlock ? tr.doc.resolve(start).before() : start, end, content);
       beforeDispatch?.({ tr, match: [fullMatch, captureGroup ?? ''], start, end });
     }
 

--- a/packages/remirror__extension-list/__tests__/tsconfig.json
+++ b/packages/remirror__extension-list/__tests__/tsconfig.json
@@ -39,6 +39,9 @@
     },
     {
       "path": "../../remirror__messages/src"
+    },
+    {
+      "path": "../../remirror__theme/src"
     }
   ]
 }

--- a/packages/remirror__extension-list/package.json
+++ b/packages/remirror__extension-list/package.json
@@ -11,7 +11,9 @@
   "repository": "https://github.com/remirror/remirror/tree/HEAD/packages/remirror__extension-list",
   "license": "MIT",
   "contributors": [
-    "Ifiok Jr. <ifiokotung@gmail.com>"
+    "Ifiok Jr. <ifiokotung@gmail.com>",
+    "Will Hawker <w.hawker@hotmail.co.uk>",
+    "Ocavue <ocavue@gmail.com>"
   ],
   "sideEffects": false,
   "exports": {
@@ -39,7 +41,8 @@
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "1.0.0-next.60",
     "@remirror/extension-events": "1.0.0-next.60",
-    "@remirror/messages": "0.0.0"
+    "@remirror/messages": "0.0.0",
+    "@remirror/theme": "1.0.0-next.60"
   },
   "devDependencies": {
     "@remirror/pm": "1.0.0-next.60"

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -1,22 +1,32 @@
 import {
   ApplySchemaAttributes,
+  command,
+  CommandFunction,
   convertCommand,
   cx,
+  DOMOutputSpec,
   extension,
   ExtensionTag,
   findChildren,
+  getMatchString,
+  InputRule,
+  isDomNode,
+  isNodeSelection,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
+  nodeInputRule,
   NodeSpecOverride,
   omitExtraAttributes,
   ProsemirrorAttributes,
   Static,
 } from '@remirror/core';
-import { CreateEventHandlers } from '@remirror/extension-events';
-import { liftListItem, sinkListItem, splitListItem } from '@remirror/pm/schema-list';
+import { ClickHandlerState, CreateEventHandlers } from '@remirror/extension-events';
+import { liftListItem, sinkListItem } from '@remirror/pm/schema-list';
+import { NodeSelection, TextSelection } from '@remirror/pm/state';
+import { ExtensionListTheme } from '@remirror/theme';
 
-import { isList } from './list-commands';
+import { isList, splitListItem } from './list-commands';
 
 /**
  * Creates the node for a list item.
@@ -43,8 +53,10 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        closed: { default: null },
+        closed: { default: false },
         nested: { default: false },
+        hasCheckbox: { default: false },
+        checked: { default: false },
       },
       parseDOM: [{ tag: 'li', getAttrs: extra.parse }, ...(override.parseDOM ?? [])],
       toDOM: (node) => {
@@ -52,48 +64,162 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
           enableToggle &&
           findChildren({ node, predicate: (child) => isList(child.node) }).length > 0;
 
-        const toggleDom = canToggle ? [['button', { class: 'toggler' }]] : [];
+        const toggleDom: DOMOutputSpec[] = canToggle ? [['button', { class: 'toggler' }]] : [];
 
         const { closed } = omitExtraAttributes(node.attrs, extra) as ListItemAttributes;
         const attrs = extra.dom(node);
-        attrs.class = cx(attrs.class, closed && 'closed', canToggle && 'can-toggle');
+        attrs.class = cx(
+          attrs.class,
+          closed && 'closed',
+          canToggle && 'can-toggle',
+          node.attrs.hasCheckbox && ExtensionListTheme.CHECKBOX_LIST_ITEM,
+        );
 
-        return ['li', extra.dom(node), ...toggleDom, ['span', 0]] as any;
+        let childrenDom: DOMOutputSpec[] = [['span', 0]];
+
+        if (node.attrs.hasCheckbox) {
+          attrs['data-checkbox'] = '';
+          childrenDom = [
+            [
+              'p', // Since the first child node of a listItem node is a paragraph, use a <p> as the checkbox container is the easiest way to align the checkbox.
+              {
+                contentEditable: 'false',
+                class: ExtensionListTheme.LIST_ITEM_CHECKBOX_CONTAINER,
+              },
+              [
+                'input',
+                {
+                  type: 'checkbox',
+                  checked: node.attrs.checked ? '' : undefined,
+                  class: ExtensionListTheme.LIST_ITEM_CHECKBOX,
+                },
+              ],
+            ],
+            ['div', { style: 'flex: 1;' }, 0],
+          ];
+        }
+
+        return ['li', attrs, ...toggleDom, ...childrenDom] as any;
       },
     };
   }
 
+  /**
+   * Track click events passed through to the editor.
+   */
   createEventHandlers(): CreateEventHandlers {
     return {
       click: (event, clickState) => {
-        const nodeWithPos = clickState.getNode(this.type);
-
-        if (!nodeWithPos || !event) {
-          return false;
-        }
-
-        const { pos, node } = nodeWithPos;
-
-        if (event.target instanceof HTMLButtonElement) {
-          this.store.commands.updateNodeAttributes(pos, {
-            ...node.attrs,
-            closed: !node.attrs.closed,
-          });
-
-          return true;
-        }
-
-        return false;
+        return (
+          this.handleListItemToggleClick(event, clickState) ||
+          this.handleListItemCheckboxClick(event, clickState)
+        );
       },
     };
+  }
+
+  private handleListItemToggleClick(event: MouseEvent, clickState: ClickHandlerState): boolean {
+    const nodeWithPos = clickState.getNode(this.type);
+
+    if (!nodeWithPos || !event) {
+      return false;
+    }
+
+    const { pos, node } = nodeWithPos;
+
+    if (event.target instanceof HTMLButtonElement) {
+      this.store.commands.updateNodeAttributes(pos, {
+        ...node.attrs,
+        closed: !node.attrs.closed,
+      });
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private handleListItemCheckboxClick(event: MouseEvent, clickState: ClickHandlerState): boolean {
+    if (!clickState.direct) {
+      return false;
+    }
+
+    const target = event.target;
+
+    if (!isDomNode(target)) {
+      return false;
+    }
+
+    if (
+      target.nodeName === 'INPUT' &&
+      (target as HTMLInputElement).getAttribute('type') === 'checkbox'
+    ) {
+      const nodeAtPosition = clickState.getNode(this.type);
+
+      if (!nodeAtPosition) {
+        return false;
+      }
+
+      const {
+        state: { tr },
+        view,
+        pos,
+      } = clickState;
+      view.dispatch?.(tr.setSelection(NodeSelection.create(tr.doc, pos)));
+
+      this.store.commands.toggleCheckboxChecked();
+      return true;
+    }
+
+    return false;
   }
 
   createKeymap(): KeyBindings {
     return {
-      Enter: convertCommand(splitListItem(this.type)),
+      Enter: splitListItem(this.type), // TODO: if the previous checkbox list item is checked, the next list item should not be checked.
       Tab: convertCommand(sinkListItem(this.type)),
       'Shift-Tab': convertCommand(liftListItem(this.type)),
     };
+  }
+
+  /**
+   * Toggles the current checkbox state
+   */
+  @command()
+  toggleCheckboxChecked(): CommandFunction {
+    return ({ state: { tr, selection }, dispatch }) => {
+      // Make sure  the `checkbox` that is selected. Otherwise do nothing.
+      if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
+        return false;
+      }
+
+      const { node, from } = selection;
+      dispatch?.(
+        tr.setNodeMarkup(from, undefined, { ...node.attrs, checked: !node.attrs.checked }),
+      );
+
+      return true;
+    };
+  }
+
+  createInputRules(): InputRule[] {
+    return [
+      nodeInputRule({
+        regexp: /^\s*(\[( ?|x|X)]\s)$/,
+        type: this.type,
+        getAttributes: (match) => ({
+          checked: ['x', 'X'].includes(getMatchString(match, 2)),
+          hasCheckbox: true,
+        }),
+        beforeDispatch: ({ tr, start }) => {
+          const $listItemPos = tr.doc.resolve(start + 1);
+
+          if ($listItemPos.node()?.type.name === this.type.name) {
+            tr.setSelection(new TextSelection($listItemPos));
+          }
+        },
+      }),
+    ];
   }
 }
 
@@ -111,6 +237,18 @@ export type ListItemAttributes = ProsemirrorAttributes<{
    * @default false
    */
   closed: boolean;
+  /**
+   * @default false
+   */
+  nested: boolean;
+  /**
+   * @default false
+   */
+  hasCheckbox: boolean;
+  /**
+   * @default false
+   */
+  checked: boolean;
 }>;
 
 declare global {

--- a/packages/remirror__extension-list/src/tsconfig.json
+++ b/packages/remirror__extension-list/src/tsconfig.json
@@ -24,6 +24,9 @@
     },
     {
       "path": "../../remirror__messages/src"
+    },
+    {
+      "path": "../../remirror__theme/src"
     }
   ]
 }

--- a/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
+++ b/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
@@ -1,3 +1,5 @@
+import '@remirror/styles/all.css';
+
 import { css } from '@emotion/css';
 import { createContextState } from 'create-context-state';
 import jsx from 'refractor/lang/jsx';

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -3531,6 +3531,22 @@ button:active .remirror-menu-pane-shortcut,
 .remirror-editor {
 }
 
+.remirror-list-item-checkbox-container {
+  position: absolute;
+  left: -24px;
+}
+
+.remirror-list-item-checkbox {
+  /* change the checkbox color from blue (default on Chrome) to purple. */
+  -webkit-filter: hue-rotate(60deg);
+  filter: hue-rotate(60deg);
+}
+
+.remirror-checkbox-list-item {
+  display: flex;
+  flex-direction: row;
+}
+
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-mention-atom-theme.ts
  */

--- a/packages/remirror__styles/extension-list.css
+++ b/packages/remirror__styles/extension-list.css
@@ -3,3 +3,19 @@
  */
 .remirror-editor {
 }
+
+.remirror-list-item-checkbox-container {
+  position: absolute;
+  left: -24px;
+}
+
+.remirror-list-item-checkbox {
+  /* change the checkbox color from blue (default on Chrome) to purple. */
+  -webkit-filter: hue-rotate(60deg);
+  filter: hue-rotate(60deg);
+}
+
+.remirror-checkbox-list-item {
+  display: flex;
+  flex-direction: row;
+}

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -3555,6 +3555,22 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
  */
   .remirror-editor {
   }
+
+  .remirror-list-item-checkbox-container {
+    position: absolute;
+    left: -24px;
+  }
+
+  .remirror-list-item-checkbox {
+    /* change the checkbox color from blue (default on Chrome) to purple. */
+    -webkit-filter: hue-rotate(60deg);
+    filter: hue-rotate(60deg);
+  }
+
+  .remirror-checkbox-list-item {
+    display: flex;
+    flex-direction: row;
+  }
 `;
 
 export const extensionMentionAtomStyledCss: ReturnType<typeof css> = css`

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -3586,6 +3586,22 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
  */
   .remirror-editor {
   }
+
+  .remirror-list-item-checkbox-container {
+    position: absolute;
+    left: -24px;
+  }
+
+  .remirror-list-item-checkbox {
+    /* change the checkbox color from blue (default on Chrome) to purple. */
+    -webkit-filter: hue-rotate(60deg);
+    filter: hue-rotate(60deg);
+  }
+
+  .remirror-checkbox-list-item {
+    display: flex;
+    flex-direction: row;
+  }
 `;
 
 export const ExtensionListStyledComponent: ReturnType<typeof styled.div> = styled.div`

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -3585,6 +3585,22 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
  */
   .remirror-editor {
   }
+
+  .remirror-list-item-checkbox-container {
+    position: absolute;
+    left: -24px;
+  }
+
+  .remirror-list-item-checkbox {
+    /* change the checkbox color from blue (default on Chrome) to purple. */
+    -webkit-filter: hue-rotate(60deg);
+    filter: hue-rotate(60deg);
+  }
+
+  .remirror-checkbox-list-item {
+    display: flex;
+    flex-direction: row;
+  }
 `;
 
 export const ExtensionListStyledComponent: ReturnType<typeof styled.div> = styled.div`

--- a/packages/remirror__theme/src/extension-list-theme.ts
+++ b/packages/remirror__theme/src/extension-list-theme.ts
@@ -1,3 +1,18 @@
 import { css } from '@linaria/core';
 
 export const EDITOR = css``;
+
+export const LIST_ITEM_CHECKBOX_CONTAINER = css`
+  position: absolute;
+  left: -24px;
+` as 'remirror-list-item-checkbox-container';
+
+export const LIST_ITEM_CHECKBOX = css`
+  /* change the checkbox color from blue (default on Chrome) to purple. */
+  filter: hue-rotate(60deg);
+` as 'remirror-list-item-checkbox';
+
+export const CHECKBOX_LIST_ITEM = css`
+  display: flex;
+  flex-direction: row;
+` as 'remirror-checkbox-list-item';

--- a/packages/remirror__theme/src/index.ts
+++ b/packages/remirror__theme/src/index.ts
@@ -6,6 +6,7 @@ export * as ExtensionCodeBlockTheme from './extension-code-block-theme';
 export * as ExtensionEmojiTheme from './extension-emoji-theme';
 export * as ExtensionGapCursorTheme from './extension-gap-cursor-theme';
 export * as ExtensionImageTheme from './extension-image-theme';
+export * as ExtensionListTheme from './extension-list-theme';
 export * as ExtensionMentionAtomTheme from './extension-mention-atom-theme';
 export * as ExtensionPlaceholderTheme from './extension-placeholder-theme';
 export * as ExtensionPositionerTheme from './extension-positioner-theme';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1318,6 +1318,7 @@ importers:
       '@remirror/core': link:../remirror__core
       '@remirror/extension-events': link:../remirror__extension-events
       '@remirror/messages': link:../remirror__messages
+      '@remirror/theme': link:../remirror__theme
     devDependencies:
       '@remirror/pm': link:../remirror__pm
     specifiers:
@@ -1326,6 +1327,7 @@ importers:
       '@remirror/extension-events': 1.0.0-next.60
       '@remirror/messages': 0.0.0
       '@remirror/pm': 1.0.0-next.60
+      '@remirror/theme': 1.0.0-next.60
   packages/remirror__extension-markdown:
     dependencies:
       '@babel/runtime': 7.13.10

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -389,7 +389,8 @@
       "@remirror/pm",
       "@remirror/core",
       "@remirror/extension-events",
-      "@remirror/messages"
+      "@remirror/messages",
+      "@remirror/theme"
     ],
     "running": false,
     "gzip": true


### PR DESCRIPTION
### Description

This PR updates the origin `ListItemExtension` with two new attributes: `hasCheckbox` and `checked`. If a list item node has `hasChekcbox: true`, then it will render a checkbox at the beginning. This should be the simplest way to implement a togglable list since we don't need to add any new extensions. 

This PR also re-implements some commands from `prosemirror-schema-list` for better support to the checkbox.

A list item with a checkbox can be created by following input rules:

- Input `[ ] ` to create an unchecked list item.
- Input `- [ ] ` to create a normal list item firstly and then transform it to an unchecked list item. This matches the markdown style of writing.

In the above input rules, you can also use add `x` inside `[ ]` to directly create a checked list item.

The code is based on the origin implementation from #890. Big thanks to @whawker for letting me use some code from him and @ifiokjr for his customized commands help.

I would like to keep each PR smaller. Although I think this PR is ready for review and follow-up merging, we still have some things to follow up in the feature:

1. Markdown support
2. Menu support
3. When one list item is checked and the user press Enter, the next list item should not be checked too. I believe that it's a ProseMirror issue (https://github.com/ProseMirror/prosemirror/issues/1155).






<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
![image](https://user-images.githubusercontent.com/24715727/114779825-26262500-9da9-11eb-8c45-bd63ad430e49.png)
![2021-04-15 06 07 22](https://user-images.githubusercontent.com/24715727/114786597-f67b1b00-9db0-11eb-9f77-e02cb43dde06.gif)
