### PR TITLE
fix(extension-react-tables): fix insert button and cell menu

### DIFF
--- a/.changeset/early-laws-report.md
+++ b/.changeset/early-laws-report.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-react-tables': patch
+---
+
+Fix the problem that the insert button fails when there are other nodes below the table.
+
+Fix the problem that the table menu is always displayed.

--- a/packages/remirror__extension-react-tables/src/components/table-cell-menu.tsx
+++ b/packages/remirror__extension-react-tables/src/components/table-cell-menu.tsx
@@ -45,7 +45,10 @@ const DefaultTableCellMenuButton: React.FC<TableCellMenuComponentProps> = ({ set
   );
 };
 
-const DefaultTableCellMenuPopup: React.FC<TableCellMenuComponentProps> = ({ setPopupOpen }) => {
+const DefaultTableCellMenuPopup: React.FC<TableCellMenuComponentProps> = ({
+  setPopupOpen,
+  popupOpen,
+}) => {
   const ctx = useRemirrorContext();
 
   // close the popup after clicking
@@ -71,7 +74,7 @@ const DefaultTableCellMenuPopup: React.FC<TableCellMenuComponentProps> = ({ setP
         backgroundColor: 'white',
         border: '1px solid red',
         width: '200px',
-        display: 'flex',
+        display: popupOpen ? 'flex' : 'none',
         flexDirection: 'column',
       }}
     >

--- a/packages/remirror__extension-react-tables/src/components/table-insert-button.ts
+++ b/packages/remirror__extension-react-tables/src/components/table-insert-button.ts
@@ -114,7 +114,7 @@ function TableInsertButton({
     view.dispatch(removeInsertButton(tr));
   };
 
-  button.addEventListener('click', () => {
+  button.addEventListener('mousedown', () => {
     insertRolOrColumn();
   });
 


### PR DESCRIPTION
### Description

- Fix the problem that the insert button fails when there are other nodes below the table.
- Fix the problem that the table menu is always displayed.

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->

Before this fix:


https://user-images.githubusercontent.com/24715727/114903646-96848300-9e49-11eb-8d34-0cf9f26fe7c1.mov

After this ifx:

https://user-images.githubusercontent.com/24715727/114903746-ae5c0700-9e49-11eb-8c8c-9b05cbdde856.mov


