### PR TITLE
fix(extension-events): fix undefined nodes

### DIFF
--- a/.changeset/heavy-ants-heal.md
+++ b/.changeset/heavy-ants-heal.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': patch
+---
+
+Fix `createMouseEventHandler` to not return undefined nodes.

--- a/packages/remirror__extension-events/src/events-extension.ts
+++ b/packages/remirror__extension-events/src/events-extension.ts
@@ -440,32 +440,34 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
       // The marks wrapping the captured position.
       const marks: GetMarkRange[] = [];
 
-      const { pos, inside } = eventPosition;
+      const { inside } = eventPosition;
+
+      // This handle the case when the context menu click has no corresponding
+      // nodes or marks because it's outside of any editor content.
+      if (inside === -1) {
+        return false;
+      }
 
       // Retrieve the resolved position from the current state.
-      const $pos = view.state.doc.resolve(pos);
+      const $pos = view.state.doc.resolve(inside);
 
       // The depth of the current node (which is a direct match)
       const currentNodeDepth = $pos.depth + 1;
 
-      // This handle the case when the context menu click has no corresponding
-      // nodes or marks because it's outside of any editor content.
-      if (inside > -1) {
-        // Populate the nodes.
-        for (const index of range(currentNodeDepth, 1)) {
-          nodes.push({
-            node: index > $pos.depth && $pos.nodeAfter ? $pos.nodeAfter : $pos.node(index),
-            pos: $pos.before(index),
-          });
-        }
+      // Populate the nodes.
+      for (const index of range(currentNodeDepth, 1)) {
+        nodes.push({
+          node: index > $pos.depth && $pos.nodeAfter ? $pos.nodeAfter : $pos.node(index),
+          pos: $pos.before(index),
+        });
+      }
 
-        // Populate the marks.
-        for (const { type } of $pos.marks()) {
-          const range = getMarkRange($pos, type);
+      // Populate the marks.
+      for (const { type } of $pos.marks()) {
+        const range = getMarkRange($pos, type);
 
-          if (range) {
-            marks.push(range);
-          }
+        if (range) {
+          marks.push(range);
         }
       }
 

--- a/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
+++ b/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { createContextState } from 'create-context-state';
-import React from 'react';
 import jsx from 'refractor/lang/jsx';
 import md from 'refractor/lang/markdown';
 import typescript from 'refractor/lang/typescript';
@@ -28,27 +27,11 @@ import {
   ThemeProvider,
   Toolbar,
   ToolbarItemUnion,
-  useHover,
   useRemirror,
-  useRemirrorContext,
   UseRemirrorReturn,
 } from '@remirror/react';
 
 export default { title: 'Markdown Editor' };
-
-function useDebug() {
-  useHover(
-    React.useCallback((p) => {
-      console.log('props:', p.hovering, p.nodes);
-
-      for (const node of p.nodes) {
-        if (!node.node) {
-          console.error('error:', p.nodes);
-        }
-      }
-    }, []),
-  );
-}
 
 /**
  * The editor which is used to create the annotation. Supports formatting.
@@ -63,14 +46,7 @@ export const Basic = () => {
   return (
     <>
       <ThemeProvider>
-        <Remirror
-          manager={manager}
-          autoFocus
-          onChange={onChange}
-          state={state}
-          autoRender='end'
-          hooks={[useDebug]}
-        >
+        <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end'>
           <Toolbar items={toolbarItems} refocusEditor label='Top Toolbar' />
         </Remirror>
         <pre>

--- a/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
+++ b/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { createContextState } from 'create-context-state';
+import React from 'react';
 import jsx from 'refractor/lang/jsx';
 import md from 'refractor/lang/markdown';
 import typescript from 'refractor/lang/typescript';
@@ -27,11 +28,27 @@ import {
   ThemeProvider,
   Toolbar,
   ToolbarItemUnion,
+  useHover,
   useRemirror,
+  useRemirrorContext,
   UseRemirrorReturn,
 } from '@remirror/react';
 
 export default { title: 'Markdown Editor' };
+
+function useDebug() {
+  useHover(
+    React.useCallback((p) => {
+      console.log('props:', p.hovering, p.nodes);
+
+      for (const node of p.nodes) {
+        if (!node.node) {
+          console.error('error:', p.nodes);
+        }
+      }
+    }, []),
+  );
+}
 
 /**
  * The editor which is used to create the annotation. Supports formatting.
@@ -46,7 +63,14 @@ export const Basic = () => {
   return (
     <>
       <ThemeProvider>
-        <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end'>
+        <Remirror
+          manager={manager}
+          autoFocus
+          onChange={onChange}
+          state={state}
+          autoRender='end'
+          hooks={[useDebug]}
+        >
           <Toolbar items={toolbarItems} refocusEditor label='Top Toolbar' />
         </Remirror>
         <pre>


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

The `useHover` hooks sometimes returns `undefined` as a node. This PR fixes this issue.


I found this bug when developing the draggable header bug I didn't pay much attraction to it back then. Vojtech Rinik @vojto from the project Reflect also found this bug as well as provided a solution. 
 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Using the following code as a simple test case:

```ts
function useDebug() {
  useHover(
    React.useCallback((p) => {
      console.log('props:', p.hovering, p.nodes);

      for (const node of p.nodes) {
        if (!node.node) {
          console.error('error:', p.nodes);
        }
      }
    }, []),
  );
}
```



Before this fix:

https://user-images.githubusercontent.com/24715727/115096193-ae95f880-9f56-11eb-8f53-bca9b7a2c766.mov



After this fix:


https://user-images.githubusercontent.com/24715727/115096183-a8078100-9f56-11eb-92b1-f448bc0f7f93.mov



<!-- Delete this section if not applicable -->
