### PR TITLE
feat(extension-image): support resizable images

### DIFF
--- a/.changeset/blue-toys-act.md
+++ b/.changeset/blue-toys-act.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-image': minor
+---
+
+Support resizable image.

--- a/.changeset/six-peas-burn.md
+++ b/.changeset/six-peas-burn.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-resizable-view': minor
+---
+
+New `prosemirror-resizable-view` package.

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "prosemirror-resizable-view",
+  "version": "0.0.0",
+  "private": false,
+  "description": "A ProseMirror node view that make your node resizable",
+  "keywords": [
+    "prosemirror",
+    "resizable"
+  ],
+  "homepage": "https://github.com/remirror/remirror/tree/HEAD/packages/prosemirror-resizable-view",
+  "repository": "https://github.com/remirror/remirror/tree/HEAD/packages/prosemirror-resizable-view",
+  "license": "MIT",
+  "contributors": [
+    "Ocavue <ocavue@gmail.com>"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/prosemirror-resizable-view.esm.js",
+      "require": "./dist/prosemirror-resizable-view.cjs.js",
+      "browser": "./dist/prosemirror-resizable-view.browser.esm.js",
+      "types": "./dist/prosemirror-resizable-view.cjs.d.ts",
+      "default": "./dist/prosemirror-resizable-view.esm.js"
+    },
+    "./package.json": "./package.json",
+    "./types/*": "./dist/declarations/src/*.d.ts"
+  },
+  "main": "dist/prosemirror-resizable-view.cjs.js",
+  "module": "dist/prosemirror-resizable-view.esm.js",
+  "browser": {
+    "./dist/prosemirror-resizable-view.cjs.js": "./dist/prosemirror-resizable-view.browser.cjs.js",
+    "./dist/prosemirror-resizable-view.esm.js": "./dist/prosemirror-resizable-view.browser.esm.js"
+  },
+  "types": "dist/prosemirror-resizable-view.cjs.d.ts",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@types/prosemirror-model": "^1.13.0",
+    "@types/prosemirror-view": "^1.17.1",
+    "@types/throttle-debounce": "^2.1.0",
+    "prosemirror-model": "^1.14.0",
+    "prosemirror-view": "^1.18.3",
+    "@remirror/core-helpers": "^1.0.0-next.60",
+    "throttle-debounce": "^3.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "@remirror": {
+    "sizeLimit": "5 KB"
+  }
+}

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -36,6 +36,7 @@
     "dist"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.13.10",
     "@types/prosemirror-model": "^1.13.0",
     "@types/prosemirror-view": "^1.17.1",
     "@types/throttle-debounce": "^2.1.0",

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -37,9 +37,9 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@remirror/core-helpers": "^1.0.0-next.60",
     "prosemirror-model": "^1.14.0",
-    "prosemirror-view": "^1.18.3",
-    "@remirror/core-helpers": "^1.0.0-next.60"
+    "prosemirror-view": "^1.18.3"
   },
   "publishConfig": {
     "@types/prosemirror-model": "^1.13.0",

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -41,9 +41,11 @@
     "prosemirror-model": "^1.14.0",
     "prosemirror-view": "^1.18.3"
   },
-  "publishConfig": {
+  "devDependencies": {
     "@types/prosemirror-model": "^1.13.0",
-    "@types/prosemirror-view": "^1.17.1",
+    "@types/prosemirror-view": "^1.17.1"
+  },
+  "publishConfig": {
     "access": "public"
   },
   "@remirror": {

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -37,15 +37,13 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@types/prosemirror-model": "^1.13.0",
-    "@types/prosemirror-view": "^1.17.1",
-    "@types/throttle-debounce": "^2.1.0",
     "prosemirror-model": "^1.14.0",
     "prosemirror-view": "^1.18.3",
-    "@remirror/core-helpers": "^1.0.0-next.60",
-    "throttle-debounce": "^3.0.1"
+    "@remirror/core-helpers": "^1.0.0-next.60"
   },
   "publishConfig": {
+    "@types/prosemirror-model": "^1.13.0",
+    "@types/prosemirror-view": "^1.17.1",
     "access": "public"
   },
   "@remirror": {

--- a/packages/prosemirror-resizable-view/readme.md
+++ b/packages/prosemirror-resizable-view/readme.md
@@ -1,0 +1,53 @@
+# prosemirror-resizable-view
+
+> A ProseMirror node view that make your node resizable
+
+[![Version][version]][npm] [![Weekly Downloads][downloads-badge]][npm] [![Bundled size][size-badge]][size] [![Typed Codebase][typescript]](#) [![MIT License][license]](#)
+
+[version]: https://flat.badgen.net/npm/v/prosemirror-resizable-view
+[npm]: https://npmjs.com/package/prosemirror-resizable-view
+[license]: https://flat.badgen.net/badge/license/MIT/purple
+[size]: https://bundlephobia.com/result?p=prosemirror-resizable-view
+[size-badge]: https://flat.badgen.net/bundlephobia/minzip/prosemirror-resizable-view
+[typescript]: https://flat.badgen.net/badge/icon/TypeScript?icon=typescript&label
+[downloads-badge]: https://badgen.net/npm/dw/prosemirror-resizable-view/red?icon=npm
+
+## Installation
+
+```bash
+# yarn
+yarn add prosemirror-resizable-view
+
+# pnpm
+pnpm add prosemirror-resizable-view
+
+# npm
+npm install prosemirror-resizable-view
+```
+
+## Usage
+
+The following code creates an resizable image node view.
+
+```ts
+import { ResizableNodeView } from 'prosemirror-resizable-view';
+
+const createInnerImage = ({ node }: { node: ProsemirrorNode }) => {
+  const inner = document.createElement('img');
+  inner.setAttribute('src', node.attrs.src);
+  inner.style.width = '100%';
+  inner.style.minWidth = '50px';
+  inner.style.objectFit = 'contain'; // maintain image's aspect ratio
+  return inner;
+};
+
+/**
+ * ResizableImageView is a NodeView for image. You can resize the image by
+ * dragging the handle over the image.
+ */
+export class ResizableImageView extends ResizableNodeView implements NodeView {
+  constructor(node: ProsemirrorNode, view: EditorView, getPos: () => number) {
+    super({ node, view, getPos, createElement: createInnerImage });
+  }
+}
+```

--- a/packages/prosemirror-resizable-view/src/index.ts
+++ b/packages/prosemirror-resizable-view/src/index.ts
@@ -1,0 +1,1 @@
+export * from './prosemirror-resizable-view';

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -1,0 +1,204 @@
+import { Node as ProsemirrorNode } from 'prosemirror-model';
+import { EditorView, NodeView } from 'prosemirror-view';
+import { throttle } from 'throttle-debounce';
+import { isNumber, isString } from '@remirror/core-helpers';
+
+type CreateElement = (props: {
+  node: ProsemirrorNode;
+  view: EditorView;
+  getPos: () => number;
+}) => HTMLElement;
+
+/**
+ * ResizableNodeView is a base NodeView for resizable element. You can resize the
+ * DOM element by dragging the handle over the image.
+ *
+ * @param node - the node which uses this nodeView. Must have `width` and `height` in the attrs.
+ * @param view - the editor view used by this nodeView.
+ * @param getPos - a utility method to get the absolute cursor position of the node
+ * @param createElement - a function to get the inner DOM element for this prosemirror node
+ */
+export class ResizableNodeView implements NodeView {
+  dom: HTMLElement;
+  readonly inner: HTMLElement;
+  node: ProsemirrorNode;
+
+  // cache the current element's size so that we can compare with new node's
+  // size when `update` method is called.
+  width = '';
+
+  constructor({
+    node,
+    view,
+    getPos,
+    createElement,
+  }: {
+    node: ProsemirrorNode;
+    view: EditorView;
+    getPos: () => number;
+    createElement: CreateElement;
+  }) {
+    const outer = document.createElement('div');
+    outer.style.position = 'relative';
+    outer.style.width = node.attrs.width;
+    outer.style.maxWidth = '100%';
+    outer.style.minWidth = '50px';
+    outer.style.display = 'inline-block';
+    outer.style.lineHeight = '0'; // necessary so the bottom right handle is aligned nicely
+    outer.style.transition = 'width 0.15s ease-out, height 0.15s ease-out'; // make sure transition time is larger then mousemove event's throttle time
+
+    const inner = createElement({ node, view, getPos });
+
+    const handle = document.createElement('div');
+    handle.style.position = 'absolute';
+    handle.style.bottom = '0px';
+    handle.style.right = '0px';
+    handle.style.width = '16px';
+    handle.style.height = '16px';
+    handle.style.borderBottom = handle.style.borderRight = '4px solid #000';
+    handle.style.display = 'none';
+    handle.style.zIndex = '100';
+    handle.style.cursor = 'nwse-resize';
+
+    const setHandleDisplay = (visible?: true | string) => {
+      visible = visible || handle.dataset.mouseover || handle.dataset.dragging;
+      handle.style.display = visible ? '' : 'none';
+    };
+
+    outer.addEventListener('mouseover', () => {
+      handle.dataset.mouseover = 'true';
+      setHandleDisplay(true);
+    });
+
+    outer.addEventListener('mouseout', () => {
+      handle.dataset.mouseover = '';
+      setHandleDisplay();
+    });
+
+    handle.addEventListener('mousedown', (e: MouseEvent) => {
+      e.preventDefault();
+
+      handle.dataset.dragging = 'true';
+
+      const startX = e.pageX;
+
+      const startWidth = getWidthFromNode(this.node) || getSizeFromDom(inner)[0];
+
+      const onMouseMove = throttle(100, false, (e: MouseEvent) => {
+        const currentX = e.pageX;
+
+        const diffX = currentX - startX;
+        outer.style.width = `${startWidth + diffX}px`;
+      });
+
+      const onMouseUp = (e: MouseEvent) => {
+        e.preventDefault();
+
+        handle.dataset.dragging = '';
+        setHandleDisplay();
+
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+
+        const transaction = view.state.tr.setNodeMarkup(getPos(), undefined, {
+          src: node.attrs.src,
+          width: outer.style.width,
+        });
+
+        this.width = outer.style.width;
+
+        view.dispatch(transaction);
+      };
+
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    });
+
+    outer.append(handle);
+    outer.append(inner);
+
+    this.dom = outer;
+    this.inner = inner;
+    this.node = node;
+  }
+
+  update(node: ProsemirrorNode): boolean {
+    if (node.type !== this.node.type) {
+      return false;
+    }
+
+    if (node.attrs.width && node.attrs.width !== this.width) {
+      return false;
+    }
+
+    if (!isEqualWithoutAttrs(this.node, node, ['width'])) {
+      return false;
+    }
+
+    node.attrs.width = this.node = node;
+    this.width = node.attrs.width;
+
+    this.inner.style.width = node.attrs.width;
+    return true;
+  }
+}
+
+function getWidthFromNode(node: ProsemirrorNode): number {
+  const width = node.attrs.width;
+
+  if (isNumber(width)) {
+    return width;
+  }
+
+  if (isString(width)) {
+    const w = width.match(/(\d+)px/)?.[0];
+
+    if (w) {
+      return Number.parseFloat(w);
+    }
+  }
+
+  return 0;
+}
+
+function getSizeFromDom(element: HTMLElement | null): [number, number] {
+  if (!element) {
+    return [0, 0];
+  }
+
+  const rect = element.getBoundingClientRect();
+  return [rect.width, rect.height];
+}
+
+// Check if two nodes are equal by ignore some attributes
+function isEqualWithoutAttrs(
+  node1: ProsemirrorNode,
+  node2: ProsemirrorNode,
+  ignoreAttrs: string[],
+): boolean {
+  return (
+    node1 === node2 || (sameMarkup(node1, node2, ignoreAttrs) && node1.content.eq(node2.content))
+  );
+}
+
+// Compare the markup (type, attributes, and marks) of one node to those of
+// another. Returns `true` if both have the same markup except some attributes.
+function sameMarkup(node1: ProsemirrorNode, node2: ProsemirrorNode, ignoreAttrs: string[]) {
+  const node1Attrs = node1.attrs;
+  const node2Attrs = node2.attrs;
+  const deltaAttrs: Record<string, null> = {};
+
+  for (const attr of ignoreAttrs) {
+    deltaAttrs[attr] = null;
+  }
+
+  node1.attrs = { ...node1Attrs, ...deltaAttrs };
+  node2.attrs = { ...node2Attrs, ...deltaAttrs };
+
+  const same = node1.sameMarkup(node2);
+
+  node1.attrs = node1Attrs;
+  node2.attrs = node2Attrs;
+
+  return same;
+}

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -1,7 +1,6 @@
 import { Node as ProsemirrorNode } from 'prosemirror-model';
 import { EditorView, NodeView } from 'prosemirror-view';
-import { throttle } from 'throttle-debounce';
-import { isNumber, isString } from '@remirror/core-helpers';
+import { isNumber, isString, throttle } from '@remirror/core-helpers';
 
 type CreateElement = (props: {
   node: ProsemirrorNode;

--- a/packages/prosemirror-resizable-view/src/tsconfig.json
+++ b/packages/prosemirror-resizable-view/src/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > 'src'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [],
+    "declaration": true,
+    "noEmit": false,
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "outDir": "../dist-types"
+  },
+  "include": ["./"],
+  "references": []
+}

--- a/packages/prosemirror-resizable-view/src/tsconfig.json
+++ b/packages/prosemirror-resizable-view/src/tsconfig.json
@@ -15,5 +15,9 @@
     "outDir": "../dist-types"
   },
   "include": ["./"],
-  "references": []
+  "references": [
+    {
+      "path": "../../remirror__core-helpers/src"
+    }
+  ]
 }

--- a/packages/remirror__extension-image/__stories__/image.stories.tsx
+++ b/packages/remirror__extension-image/__stories__/image.stories.tsx
@@ -1,0 +1,42 @@
+import 'remirror/styles/all.css';
+
+import React from 'react';
+import { ImageExtension } from 'remirror/extensions';
+import { htmlToProsemirrorNode } from '@remirror/core';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+export default { title: 'Image' };
+
+const basicExtensions = () => [new ImageExtension()];
+
+export const Basic: React.FC = () => {
+  const { manager, state, onChange } = useRemirror({
+    extensions: basicExtensions,
+    content:
+      '<p>You can see a green image below.</p><img src="https://dummyimage.com/200x80/479e0c/fafafa">',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end' />
+    </ThemeProvider>
+  );
+};
+
+const resizableExtensions = () => [new ImageExtension({ enableResizing: true })];
+
+export const Resizable: React.FC = () => {
+  const { manager, state, onChange } = useRemirror({
+    extensions: resizableExtensions,
+    content:
+      '<p>You can see a resizable image below. Move you mouse over the image and drag the resizing handler to resize it.</p><img src="https://dummyimage.com/200x80/479e0c/fafafa">',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end' />
+    </ThemeProvider>
+  );
+};

--- a/packages/remirror__extension-image/__stories__/tsconfig.json
+++ b/packages/remirror__extension-image/__stories__/tsconfig.json
@@ -1,0 +1,56 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > '__stories__'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [],
+    "declaration": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove",
+    "paths": {
+      "react": [
+        "../../../node_modules/.pnpm/@types/react@17.0.3/node_modules/@types/react/index.d.ts"
+      ],
+      "react/jsx-dev-runtime": [
+        "../../../node_modules/.pnpm/@types/react@17.0.3/node_modules/@types/react/jsx-dev-runtime.d.ts"
+      ],
+      "react/jsx-runtime": [
+        "../../../node_modules/.pnpm/@types/react@17.0.3/node_modules/@types/react/jsx-runtime.d.ts"
+      ],
+      "react-dom": [
+        "../../../node_modules/.pnpm/@types/react-dom@17.0.3/node_modules/@types/react-dom/index.d.ts"
+      ],
+      "reakit": [
+        "../../../node_modules/.pnpm/reakit@1.3.7_react-dom@17.0.2+react@17.0.2/node_modules/reakit/ts/index.d.ts"
+      ],
+      "@remirror/react": ["../../remirror__react/src/index.ts"],
+      "@storybook/react": [
+        "../../../node_modules/.pnpm/@storybook/react@6.2.8_fab8b5747c4374c1ef861a7534eabef4/node_modules/@storybook/react/types-6-0.d.ts"
+      ],
+      "@remirror/dev": ["../../remirror__dev/src/index.ts"]
+    }
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../../testing/src"
+    },
+    {
+      "path": "../../remirror/src"
+    },
+    {
+      "path": "../../remirror__core/src"
+    },
+    {
+      "path": "../../remirror__messages/src"
+    },
+    {
+      "path": "../../remirror__theme/src"
+    }
+  ]
+}

--- a/packages/remirror__extension-image/__stories__/tsconfig.json
+++ b/packages/remirror__extension-image/__stories__/tsconfig.json
@@ -44,6 +44,9 @@
       "path": "../../remirror/src"
     },
     {
+      "path": "../../prosemirror-resizable-view/src"
+    },
+    {
       "path": "../../remirror__core/src"
     },
     {

--- a/packages/remirror__extension-image/__stories__/tsconfig.json
+++ b/packages/remirror__extension-image/__stories__/tsconfig.json
@@ -44,9 +44,6 @@
       "path": "../../remirror/src"
     },
     {
-      "path": "../../prosemirror-resizable-view/src"
-    },
-    {
       "path": "../../remirror__core/src"
     },
     {
@@ -54,6 +51,9 @@
     },
     {
       "path": "../../remirror__theme/src"
+    },
+    {
+      "path": "../../prosemirror-resizable-view/src"
     }
   ]
 }

--- a/packages/remirror__extension-image/__tests__/tsconfig.json
+++ b/packages/remirror__extension-image/__tests__/tsconfig.json
@@ -32,9 +32,6 @@
       "path": "../../remirror/src"
     },
     {
-      "path": "../../prosemirror-resizable-view/src"
-    },
-    {
       "path": "../../remirror__core/src"
     },
     {
@@ -42,6 +39,9 @@
     },
     {
       "path": "../../remirror__theme/src"
+    },
+    {
+      "path": "../../prosemirror-resizable-view/src"
     }
   ]
 }

--- a/packages/remirror__extension-image/__tests__/tsconfig.json
+++ b/packages/remirror__extension-image/__tests__/tsconfig.json
@@ -32,6 +32,9 @@
       "path": "../../remirror/src"
     },
     {
+      "path": "../../prosemirror-resizable-view/src"
+    },
+    {
       "path": "../../remirror__core/src"
     },
     {

--- a/packages/remirror__extension-image/package.json
+++ b/packages/remirror__extension-image/package.json
@@ -39,6 +39,7 @@
     "dist"
   ],
   "dependencies": {
+    "prosemirror-resizable-view": "^0.0.0",
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "1.0.0-next.60",
     "@remirror/messages": "0.0.0",

--- a/packages/remirror__extension-image/package.json
+++ b/packages/remirror__extension-image/package.json
@@ -39,11 +39,11 @@
     "dist"
   ],
   "dependencies": {
-    "prosemirror-resizable-view": "^0.0.0",
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "1.0.0-next.60",
     "@remirror/messages": "0.0.0",
-    "@remirror/theme": "1.0.0-next.60"
+    "@remirror/theme": "1.0.0-next.60",
+    "prosemirror-resizable-view": "^0.0.0"
   },
   "devDependencies": {
     "@remirror/pm": "1.0.0-next.60"

--- a/packages/remirror__extension-image/package.json
+++ b/packages/remirror__extension-image/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "@remirror": {
-    "sizeLimit": "5 KB"
+    "sizeLimit": "20 KB"
   },
   "rn:dev": "src/index.ts"
 }

--- a/packages/remirror__extension-image/src/index.ts
+++ b/packages/remirror__extension-image/src/index.ts
@@ -1,2 +1,3 @@
 export type { ImageAttributes, ImageExtensionAttributes, ImageOptions } from './image-extension';
 export { ImageExtension, isImageFileType } from './image-extension';
+export { ResizableImageView } from './resizable-image-view';

--- a/packages/remirror__extension-image/src/resizable-image-view.ts
+++ b/packages/remirror__extension-image/src/resizable-image-view.ts
@@ -1,0 +1,21 @@
+import { ResizableNodeView } from 'prosemirror-resizable-view';
+import { EditorView, NodeView, ProsemirrorNode } from '@remirror/pm';
+
+const createInnerImage = ({ node }: { node: ProsemirrorNode }) => {
+  const inner = document.createElement('img');
+  inner.setAttribute('src', node.attrs.src);
+  inner.style.width = '100%';
+  inner.style.minWidth = '50px';
+  inner.style.objectFit = 'contain'; // maintain image's aspect ratio
+  return inner;
+};
+
+/**
+ * ResizableImageView is a NodeView for image. You can resize the image by
+ * dragging the handle over the image.
+ */
+export class ResizableImageView extends ResizableNodeView implements NodeView {
+  constructor(node: ProsemirrorNode, view: EditorView, getPos: () => number) {
+    super({ node, view, getPos, createElement: createInnerImage });
+  }
+}

--- a/packages/remirror__extension-image/src/tsconfig.json
+++ b/packages/remirror__extension-image/src/tsconfig.json
@@ -17,9 +17,6 @@
   "include": ["./"],
   "references": [
     {
-      "path": "../../prosemirror-resizable-view/src"
-    },
-    {
       "path": "../../remirror__core/src"
     },
     {
@@ -27,6 +24,9 @@
     },
     {
       "path": "../../remirror__theme/src"
+    },
+    {
+      "path": "../../prosemirror-resizable-view/src"
     }
   ]
 }

--- a/packages/remirror__extension-image/src/tsconfig.json
+++ b/packages/remirror__extension-image/src/tsconfig.json
@@ -17,6 +17,9 @@
   "include": ["./"],
   "references": [
     {
+      "path": "../../prosemirror-resizable-view/src"
+    },
+    {
       "path": "../../remirror__core/src"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,21 +505,13 @@ importers:
     dependencies:
       '@babel/runtime': 7.13.10
       '@remirror/core-helpers': link:../remirror__core-helpers
-      '@types/prosemirror-model': 1.13.0
-      '@types/prosemirror-view': 1.17.1
-      '@types/throttle-debounce': 2.1.0
       prosemirror-model: 1.14.0
       prosemirror-view: 1.18.3
-      throttle-debounce: 3.0.1
     specifiers:
       '@babel/runtime': ^7.13.10
       '@remirror/core-helpers': ^1.0.0-next.60
-      '@types/prosemirror-model': ^1.13.0
-      '@types/prosemirror-view': ^1.17.1
-      '@types/throttle-debounce': ^2.1.0
       prosemirror-model: ^1.14.0
       prosemirror-view: ^1.18.3
-      throttle-debounce: ^3.0.1
   packages/prosemirror-suggest:
     dependencies:
       '@babel/runtime': 7.13.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,9 +507,14 @@ importers:
       '@remirror/core-helpers': link:../remirror__core-helpers
       prosemirror-model: 1.14.0
       prosemirror-view: 1.18.3
+    devDependencies:
+      '@types/prosemirror-model': 1.13.0
+      '@types/prosemirror-view': 1.17.1
     specifiers:
       '@babel/runtime': ^7.13.10
       '@remirror/core-helpers': ^1.0.0-next.60
+      '@types/prosemirror-model': ^1.13.0
+      '@types/prosemirror-view': ^1.17.1
       prosemirror-model: ^1.14.0
       prosemirror-view: ^1.18.3
   packages/prosemirror-suggest:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,7 @@ importers:
       prosemirror-view: ^1.18.3
   packages/prosemirror-resizable-view:
     dependencies:
+      '@babel/runtime': 7.13.10
       '@remirror/core-helpers': link:../remirror__core-helpers
       '@types/prosemirror-model': 1.13.0
       '@types/prosemirror-view': 1.17.1
@@ -511,6 +512,7 @@ importers:
       prosemirror-view: 1.18.3
       throttle-debounce: 3.0.1
     specifiers:
+      '@babel/runtime': ^7.13.10
       '@remirror/core-helpers': ^1.0.0-next.60
       '@types/prosemirror-model': ^1.13.0
       '@types/prosemirror-view': ^1.17.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,23 @@ importers:
       prosemirror-model: ^1.14.0
       prosemirror-state: ^1.3.4
       prosemirror-view: ^1.18.3
+  packages/prosemirror-resizable-view:
+    dependencies:
+      '@remirror/core-helpers': link:../remirror__core-helpers
+      '@types/prosemirror-model': 1.13.0
+      '@types/prosemirror-view': 1.17.1
+      '@types/throttle-debounce': 2.1.0
+      prosemirror-model: 1.14.0
+      prosemirror-view: 1.18.3
+      throttle-debounce: 3.0.1
+    specifiers:
+      '@remirror/core-helpers': ^1.0.0-next.60
+      '@types/prosemirror-model': ^1.13.0
+      '@types/prosemirror-view': ^1.17.1
+      '@types/throttle-debounce': ^2.1.0
+      prosemirror-model: ^1.14.0
+      prosemirror-view: ^1.18.3
+      throttle-debounce: ^3.0.1
   packages/prosemirror-suggest:
     dependencies:
       '@babel/runtime': 7.13.10
@@ -1278,6 +1295,7 @@ importers:
       '@remirror/core': link:../remirror__core
       '@remirror/messages': link:../remirror__messages
       '@remirror/theme': link:../remirror__theme
+      prosemirror-resizable-view: link:../prosemirror-resizable-view
     devDependencies:
       '@remirror/pm': link:../remirror__pm
     specifiers:
@@ -1286,6 +1304,7 @@ importers:
       '@remirror/messages': 0.0.0
       '@remirror/pm': 1.0.0-next.60
       '@remirror/theme': 1.0.0-next.60
+      prosemirror-resizable-view: ^0.0.0
   packages/remirror__extension-italic:
     dependencies:
       '@babel/runtime': 7.13.10

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -41,6 +41,14 @@
     "gzip": true
   },
   {
+    "name": "prosemirror-resizable-view",
+    "limit": "5 KB",
+    "path": "packages/prosemirror-resizable-view/dist/prosemirror-resizable-view.browser.esm.js",
+    "ignore": [],
+    "running": false,
+    "gzip": true
+  },
+  {
     "name": "prosemirror-suggest",
     "limit": "10 KB",
     "path": "packages/prosemirror-suggest/dist/prosemirror-suggest.browser.esm.js",

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -362,7 +362,7 @@
   },
   {
     "name": "@remirror/extension-image",
-    "limit": "5 KB",
+    "limit": "20 KB",
     "path": "packages/remirror__extension-image/dist/remirror-extension-image.browser.esm.js",
     "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -44,7 +44,7 @@
     "name": "prosemirror-resizable-view",
     "limit": "5 KB",
     "path": "packages/prosemirror-resizable-view/dist/prosemirror-resizable-view.browser.esm.js",
-    "ignore": [],
+    "ignore": ["@remirror/core-helpers"],
     "running": false,
     "gzip": true
   },

--- a/support/root/tsconfig.json
+++ b/support/root/tsconfig.json
@@ -48,6 +48,9 @@
       "path": "packages/prosemirror-paste-rules/src"
     },
     {
+      "path": "packages/prosemirror-resizable-view/src"
+    },
+    {
       "path": "packages/prosemirror-suggest/__tests__"
     },
     {
@@ -259,6 +262,9 @@
     },
     {
       "path": "packages/remirror__extension-horizontal-rule/src"
+    },
+    {
+      "path": "packages/remirror__extension-image/__stories__"
     },
     {
       "path": "packages/remirror__extension-image/__tests__"

--- a/support/root/typedoc.json
+++ b/support/root/typedoc.json
@@ -6,6 +6,7 @@
     "packages/jest-remirror/src/index.ts",
     "packages/multishift/src/index.ts",
     "packages/prosemirror-paste-rules/src/index.ts",
+    "packages/prosemirror-resizable-view/src/index.ts",
     "packages/prosemirror-suggest/src/index.ts",
     "packages/prosemirror-trailing-node/src/index.ts",
     "packages/remirror/src/index.ts",


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Support resizable images. Pass `enableResizable: true` to `ImageExtension` to enable this feature. When the mouse is over a resizable image, a resize handler will show at the left-bottom corner. 

TODO: 

- [x] use `throttle` and CSS animation to improve the performance.
- [ ] update the handle style.
- [x] the handle will only show when *reduce* the image.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->


https://user-images.githubusercontent.com/24715727/115728787-61cb7b00-a3b7-11eb-95ba-0d2b236f2e30.mov

