### PR TITLE
fix(extension-events): use posAtDOM to get mouse event position

### DIFF
--- a/.changeset/quiet-kings-dream.md
+++ b/.changeset/quiet-kings-dream.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': patch
+---
+
+Use `posAtDOM` instead of `posAtCoords` to get mouse event position.

--- a/packages/remirror__extension-events/src/events-utils.ts
+++ b/packages/remirror__extension-events/src/events-utils.ts
@@ -1,12 +1,39 @@
 import { EditorView } from '@remirror/core';
 
 /**
+ * A port of `view.posAtDOM` without throwing error when the dom node is not
+ * inside the editor.
+ */
+function posAtDOM(view: EditorView, node: Node, offset: number, bias?: number): number | null {
+  return (view as any).docView.posFromDOM(node, offset, bias);
+}
+
+/**
  * Extract the position from a provided event.
  */
 export function getPositionFromEvent(
   view: EditorView,
   event: MouseEvent,
 ): PositionFromCoords | undefined {
+  const target = event.target;
+
+  if (target) {
+    const pos = posAtDOM(view, target as Node, 0);
+
+    if (pos !== null) {
+      const $pos = view.state.doc.resolve(pos);
+      const border = $pos.node().isLeaf ? 0 : 1;
+      // https://github.com/ProseMirror/prosemirror-view/blob/9af8ceac1ee60a30ced3611913db7f187bbb51ed/src/domcoords.js#L283
+      const inside = $pos.start() - border;
+      return { pos, inside };
+    }
+  }
+
+  // If the coordinates are just at the boundary of two elements, `view.posAtCoords`
+  // can't distinguish which one should be returned. This is not a big deal for
+  // `click` event but it's a huge problem for `mouseover` and `mouseout` events.
+  // That's why we try to use `posAtDOM` firstly and only use `posAtCoords` if
+  // `posAtDOM` doesn't work.
   return view.posAtCoords({ left: event.clientX, top: event.clientY }) ?? undefined;
 }
 


### PR DESCRIPTION
### Description

Fixes #929
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
- [x] I have updated the documentation where necessary.

### Screenshots

<!-- Delete this section if not applicable -->
