### PR TITLE
feat(core): add `insertHtml` command

### DIFF
--- a/.changeset/afraid-flowers-taste.md
+++ b/.changeset/afraid-flowers-taste.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Add `insertHtml` command for inserting html into an active editor.

--- a/packages/remirror__core/__tests__/commands-extension.spec.ts
+++ b/packages/remirror__core/__tests__/commands-extension.spec.ts
@@ -1,5 +1,5 @@
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
-import { BoldExtension, ItalicExtension } from 'remirror/extensions';
+import { BoldExtension, HeadingExtension, ItalicExtension } from 'remirror/extensions';
 import { AllSelection } from '@remirror/pm/state';
 
 import { CommandsExtension } from '../';
@@ -209,5 +209,33 @@ describe('setContent', () => {
     expect(editor.state.doc).toEqualProsemirrorNode(doc(p()));
     editor.commands.undo();
     expect(editor.state.doc).toEqualProsemirrorNode(doc(p('my content')));
+  });
+});
+
+describe('commands.insertHtml', () => {
+  it('can insert html', () => {
+    const editor = renderEditor([
+      new HeadingExtension(),
+      new BoldExtension(),
+      new ItalicExtension(),
+    ]);
+    const { doc, p } = editor.nodes;
+    const { bold, italic } = editor.marks;
+    const { heading } = editor.attributeNodes;
+    const h1 = heading({ level: 1 });
+
+    editor.add(doc(p('Content<cursor>')));
+
+    editor.chain.insertHtml('<h1>This is a heading</h1>').selectText('end').run();
+    expect(editor.state.doc).toEqualProsemirrorNode(doc(p('Content'), h1('This is a heading')));
+
+    editor.commands.insertHtml('<p>A paragraph <em>with</em> <strong>formatting</strong></p>');
+    expect(editor.state.doc).toEqualProsemirrorNode(
+      doc(
+        p('Content'),
+        h1('This is a heading'),
+        p('A paragraph ', italic('with'), ' ', bold('formatting')),
+      ),
+    );
   });
 });

--- a/packages/remirror__core/src/builtins/commands-extension.ts
+++ b/packages/remirror__core/src/builtins/commands-extension.ts
@@ -686,6 +686,20 @@ export class CommandsExtension extends PlainExtension<CommandOptions> {
   }
 
   /**
+   * Insert a html string as a ProseMirror Node,
+   *
+   * @category Builtin Command
+   */
+  @command()
+  insertHtml(html: string, options?: InsertNodeOptions): CommandFunction {
+    return (props) => {
+      const { state } = props;
+      const node = this.store.stringHandlers.html({ content: html, schema: state.schema });
+      return this.insertNode(node, options)(props);
+    };
+  }
+
+  /**
    * Set the focus for the editor.
    *
    * If using this with chaining this should only be placed at the end of


### PR DESCRIPTION
### Description

Add `insertHtml` command for inserting html into an active editor.
