### PR TITLE
fix(extension-callout): prevent empty block containers

### DIFF
--- a/.changeset/giant-ligers-exist.md
+++ b/.changeset/giant-ligers-exist.md
@@ -1,0 +1,11 @@
+---
+'@remirror/extension-blockquote': patch
+'@remirror/extension-callout': patch
+'@remirror/messages': patch
+---
+
+Prevents callouts and blockquotes containing zero blocks
+
+Prevent callouts of invalid types being created via parseDOM
+
+Fixes messages for the callouts commands

--- a/packages/remirror__extension-blockquote/src/blockquote-extension.ts
+++ b/packages/remirror__extension-blockquote/src/blockquote-extension.ts
@@ -29,7 +29,7 @@ export class BlockquoteExtension extends NodeExtension {
 
   createNodeSpec(extra: ApplySchemaAttributes, override: NodeSpecOverride): NodeExtensionSpec {
     return {
-      content: 'block*',
+      content: 'block+',
       defining: true,
       draggable: false,
       ...override,

--- a/packages/remirror__extension-callout/src/callout-extension.ts
+++ b/packages/remirror__extension-callout/src/callout-extension.ts
@@ -114,7 +114,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
    * }
    * ```
    */
-  @command()
+  @command(toggleCalloutOptions)
   toggleCallout(attributes: CalloutAttributes = {}): CommandFunction {
     return toggleWrap(this.type, attributes);
   }

--- a/packages/remirror__extension-callout/src/callout-extension.ts
+++ b/packages/remirror__extension-callout/src/callout-extension.ts
@@ -109,7 +109,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
    * lifted out of the callout node.
    *
    * ```ts
-   * if (commands.toggleCallout.isEnabled()) {
+   * if (commands.toggleCallout.enabled()) {
    *   commands.toggleCallout({ type: 'success' });
    * }
    * ```
@@ -124,7 +124,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
    * to change the type.
    *
    * ```ts
-   * if (commands.updateCallout.isEnabled()) {
+   * if (commands.updateCallout.enabled()) {
    *   commands.updateCallout({ type: 'error' });
    * }
    * ```

--- a/packages/remirror__extension-callout/src/callout-extension.ts
+++ b/packages/remirror__extension-callout/src/callout-extension.ts
@@ -47,7 +47,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
 
   createNodeSpec(extra: ApplySchemaAttributes, override: NodeSpecOverride): NodeExtensionSpec {
     return {
-      content: 'block*',
+      content: 'block+',
       defining: true,
       draggable: false,
       ...override,
@@ -80,8 +80,9 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
   }
 
   /**
-   * Create an input rule that listens converts the code fence into a code block
-   * when typing triple back tick followed by a space.
+   * Create an input rule that listens for input of 3 colons followed
+   * by a valid callout type, to create a callout node
+   * If the callout type is invalid, the defaultType callout is created
    */
   createInputRules(): InputRule[] {
     return [

--- a/packages/remirror__extension-callout/src/callout-extension.ts
+++ b/packages/remirror__extension-callout/src/callout-extension.ts
@@ -46,6 +46,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
   readonly tags = [ExtensionTag.Block];
 
   createNodeSpec(extra: ApplySchemaAttributes, override: NodeSpecOverride): NodeExtensionSpec {
+    const { defaultType, validTypes } = this.options;
     return {
       content: 'block+',
       defining: true,
@@ -53,7 +54,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        type: { default: this.options.defaultType },
+        type: { default: defaultType },
       },
       parseDOM: [
         {
@@ -63,7 +64,8 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
               return false;
             }
 
-            const type = node.getAttribute(dataAttributeType);
+            const rawType = node.getAttribute(dataAttributeType);
+            const type = getCalloutType(rawType, validTypes, defaultType);
             const content = node.textContent;
             return { ...extra.parse(node), type, content };
           },

--- a/packages/remirror__messages/src/extension-callout-messages.ts
+++ b/packages/remirror__messages/src/extension-callout-messages.ts
@@ -4,7 +4,7 @@ import { defineMessage } from '@lingui/macro';
 export const LABEL = defineMessage({
   id: 'extension.command.toggle-callout.label',
   comment: 'Label for callout command with support for callout types.',
-  message: `{level, select, info {Information Callout}
+  message: `{type, select, info {Information Callout}
                             warning {Warning Callout}
                             error {Error Callout}
                             success {Success Callout}
@@ -14,7 +14,7 @@ export const LABEL = defineMessage({
 export const DESCRIPTION = defineMessage({
   id: 'extension.command.toggle-callout.description',
   comment: 'Description of the callout command with support for callout types.',
-  message: `{level, select, info {Create an information callout block}
+  message: `{type, select, info {Create an information callout block}
                             warning {Create a warning callout block}
                             error {Create an error callout block}
                             success {Create a success callout block}


### PR DESCRIPTION
### Description

Fixes the input rule for callouts (and prevent similar issue on blockquotes)

Fixes messages for the callout commands (copy and paste error from headings extension)

Prevents callout `parseDOM` creating callouts of invalid type

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

#### Before
https://user-images.githubusercontent.com/2003804/115887933-4e1d2480-a44a-11eb-9a06-1020daf183ff.mov

#### After
https://user-images.githubusercontent.com/2003804/115887979-59705000-a44a-11eb-9313-eecf36fa1efa.mov

