### PR TITLE
fix: pasting links ignores everything after "www."

### DIFF
--- a/.changeset/angry-crews-shave.md
+++ b/.changeset/angry-crews-shave.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-link': patch
+---
+
+Fix: pasting links ignores everything after "www."

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -163,7 +163,7 @@ export type LinkAttributes = ProsemirrorAttributes<{
     defaultProtocol: '',
     selectTextOnClick: false,
     openLinkOnClick: false,
-    autoLinkRegex: /(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+([.-][\da-z]+)*\.[a-z]{2,8}(:\d{1,5})?(\/\S*)?/,
+    autoLinkRegex: /((?:http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,8}(?::\d{1,5})?(\/\S*)?)/,
     defaultTarget: null,
   },
   staticKeys: ['autoLinkRegex'],
@@ -332,7 +332,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     return [
       {
         type: 'mark',
-        regexp: /https?:\/\/(www\.)?[\w#%+.:=@~-]{2,256}\.[a-z]{2,8}\b([\w#%&+./:=?@~-]*)/gi,
+        regexp: this.options.autoLinkRegex,
         markType: this.type,
         getAttributes: (url, isReplacement) => ({
           href: getMatchString(url),

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -163,7 +163,7 @@ export type LinkAttributes = ProsemirrorAttributes<{
     defaultProtocol: '',
     selectTextOnClick: false,
     openLinkOnClick: false,
-    autoLinkRegex: /((?:http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,8}(?::\d{1,5})?(\/\S*)?)/,
+    autoLinkRegex: /(?:https?:\/\/)?[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,8}(?::\d{1,5})?(?:\/\S*)?/gi,
     defaultTarget: null,
   },
   staticKeys: ['autoLinkRegex'],

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -116,7 +116,7 @@ export interface LinkOptions {
    * value.
    *
    * @default
-   * /((http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/.*)?)/gi
+   * /((?:http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,8}(?::\d{1,5})?(\/\S*)?)/
    */
   autoLinkRegex?: Static<RegExp>;
 

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -116,7 +116,7 @@ export interface LinkOptions {
    * value.
    *
    * @default
-   * /((?:http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,8}(?::\d{1,5})?(\/\S*)?)/
+   * /(?:https?:\/\/)?[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,8}(?::\d{1,5})?(?:\/\S*)?/gi
    */
   autoLinkRegex?: Static<RegExp>;
 


### PR DESCRIPTION
### Description

This happened because the RegEx used optional capturing groups.

The commit adds two improvements to capture the link text:
- All existing capturing RegEx groups are changed to be non-capturing. An additional capturing group covers now the complete URL.
- @whawker had pointed out that the RegEx to capture the link text wasn't linked to the RegEx to capture the link href (which can be changed by the user). This is solved by using the same, user-controlled, RegEx to capture the link href and text.

Fixes https://github.com/remirror/remirror/issues/933

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
