### PR TITLE
feat(extension-list): support collapsible list item

### DIFF
--- a/packages/remirror__extension-list/src/bullet-list-extension.ts
+++ b/packages/remirror__extension-list/src/bullet-list-extension.ts
@@ -12,9 +12,14 @@ import {
   NodeExtension,
   NodeExtensionSpec,
   NodeSpecOverride,
+  NodeViewMethod,
+  ProsemirrorNode,
+  Static,
 } from '@remirror/core';
 import { ExtensionListMessages as Messages } from '@remirror/messages';
 import { InputRule, wrappingInputRule } from '@remirror/pm/inputrules';
+import { NodeSelection } from '@remirror/pm/state';
+import { ExtensionListTheme } from '@remirror/theme';
 
 import { toggleList } from './list-commands';
 import { ListItemExtension } from './list-item-extension';
@@ -22,8 +27,11 @@ import { ListItemExtension } from './list-item-extension';
 /**
  * Create the node for a bullet list.
  */
-@extension({})
-export class BulletListExtension extends NodeExtension {
+@extension<BulletListOptions>({
+  defaultOptions: { enableSpine: false },
+  staticKeys: ['enableSpine'],
+})
+export class BulletListExtension extends NodeExtension<BulletListOptions> {
   get name() {
     return 'bulletList' as const;
   }
@@ -39,6 +47,52 @@ export class BulletListExtension extends NodeExtension {
       attrs: extra.defaults(),
       parseDOM: [{ tag: 'ul', getAttrs: extra.parse }, ...(override.parseDOM ?? [])],
       toDOM: (node) => ['ul', extra.dom(node), 0],
+    };
+  }
+
+  createNodeViews(): NodeViewMethod | Record<string, never> {
+    if (!this.options.enableSpine) {
+      return {};
+    }
+
+    return (_, view, getPos) => {
+      const dom = document.createElement('ul');
+      dom.style.position = 'relative';
+
+      const pos = (getPos as () => number)();
+      const $pos = view.state.doc.resolve(pos + 1);
+
+      const parentListItemNode: ProsemirrorNode | undefined = $pos.node($pos.depth - 1);
+
+      const isFirstLevel = parentListItemNode?.type?.name !== 'listItem';
+
+      if (!isFirstLevel) {
+        const parentListItemPos: number = $pos.start($pos.depth - 1);
+
+        const spine = document.createElement('div');
+        spine.contentEditable = 'false';
+        spine.classList.add(ExtensionListTheme.LIST_SPINE);
+
+        spine.addEventListener('click', (event) => {
+          view.dispatch?.(
+            view.state.tr.setSelection(NodeSelection.create(view.state.doc, parentListItemPos - 1)),
+          );
+          this.store.commands.toggleListItemClosed();
+
+          event.preventDefault();
+          event.stopPropagation();
+        });
+        dom.append(spine);
+      }
+
+      const contentDOM = document.createElement('div');
+      contentDOM.classList.add(ExtensionListTheme.UL_LIST_CONTENT);
+      dom.append(contentDOM);
+
+      return {
+        dom,
+        contentDOM,
+      };
     };
   }
 
@@ -62,6 +116,13 @@ export class BulletListExtension extends NodeExtension {
   createInputRules(): InputRule[] {
     return [wrappingInputRule(/^\s*([*+-])\s$/, this.type)];
   }
+}
+
+export interface BulletListOptions {
+  /**
+   * Set this to true to add a spine.
+   */
+  enableSpine?: Static<boolean>;
 }
 
 declare global {

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -20,7 +20,6 @@ import {
 } from '@remirror/core';
 import { liftListItem, sinkListItem } from '@remirror/pm/schema-list';
 import { NodeSelection, TextSelection } from '@remirror/pm/state';
-import { ProsemirrorNode } from '@remirror/pm/suggest';
 import { ExtensionListTheme } from '@remirror/theme';
 
 import { splitListItem } from './list-commands';

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -4,36 +4,32 @@ import {
   CommandFunction,
   convertCommand,
   cx,
-  DOMOutputSpec,
   extension,
   ExtensionTag,
-  findChildren,
   getMatchString,
   InputRule,
-  isDomNode,
   isNodeSelection,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,
   nodeInputRule,
   NodeSpecOverride,
-  omitExtraAttributes,
+  NodeViewMethod,
   ProsemirrorAttributes,
   Static,
 } from '@remirror/core';
-import { ClickHandlerState, CreateEventHandlers } from '@remirror/extension-events';
 import { liftListItem, sinkListItem } from '@remirror/pm/schema-list';
 import { NodeSelection, TextSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
-import { isList, splitListItem } from './list-commands';
+import { splitListItem } from './list-commands';
 
 /**
  * Creates the node for a list item.
  */
 @extension<ListItemOptions>({
-  defaultOptions: { enableToggle: false },
-  staticKeys: ['enableToggle'],
+  defaultOptions: { enableCollapsible: false, enableCheckbox: false },
+  staticKeys: ['enableCollapsible', 'enableCheckbox'],
 })
 export class ListItemExtension extends NodeExtension<ListItemOptions> {
   get name() {
@@ -45,7 +41,6 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
   }
 
   createNodeSpec(extra: ApplySchemaAttributes, override: NodeSpecOverride): NodeExtensionSpec {
-    const { enableToggle } = this.options;
     return {
       content: 'paragraph block*',
       defining: true,
@@ -60,118 +55,69 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       },
       parseDOM: [{ tag: 'li', getAttrs: extra.parse }, ...(override.parseDOM ?? [])],
       toDOM: (node) => {
-        const canToggle =
-          enableToggle &&
-          findChildren({ node, predicate: (child) => isList(child.node) }).length > 0;
-
-        const toggleDom: DOMOutputSpec[] = canToggle ? [['button', { class: 'toggler' }]] : [];
-
-        const { closed } = omitExtraAttributes(node.attrs, extra) as ListItemAttributes;
         const attrs = extra.dom(node);
-        attrs.class = cx(
-          attrs.class,
-          closed && 'closed',
-          canToggle && 'can-toggle',
-          node.attrs.hasCheckbox && ExtensionListTheme.CHECKBOX_LIST_ITEM,
-        );
-
-        let childrenDom: DOMOutputSpec[] = [['span', 0]];
-
-        if (node.attrs.hasCheckbox) {
-          attrs['data-checkbox'] = '';
-          childrenDom = [
-            [
-              'p', // Since the first child node of a listItem node is a paragraph, use a <p> as the checkbox container is the easiest way to align the checkbox.
-              {
-                contentEditable: 'false',
-                class: ExtensionListTheme.LIST_ITEM_CHECKBOX_CONTAINER,
-              },
-              [
-                'input',
-                {
-                  type: 'checkbox',
-                  checked: node.attrs.checked ? '' : undefined,
-                  class: ExtensionListTheme.LIST_ITEM_CHECKBOX,
-                },
-              ],
-            ],
-            ['div', { style: 'flex: 1;' }, 0],
-          ];
-        }
-
-        return ['li', attrs, ...toggleDom, ...childrenDom] as any;
+        attrs.class = cx(attrs.class);
+        return ['li', attrs, 0];
       },
     };
   }
 
-  /**
-   * Track click events passed through to the editor.
-   */
-  createEventHandlers(): CreateEventHandlers {
-    return {
-      click: (event, clickState) => {
-        return (
-          this.handleListItemToggleClick(event, clickState) ||
-          this.handleListItemCheckboxClick(event, clickState)
-        );
-      },
-    };
-  }
-
-  private handleListItemToggleClick(event: MouseEvent, clickState: ClickHandlerState): boolean {
-    const nodeWithPos = clickState.getNode(this.type);
-
-    if (!nodeWithPos || !event) {
-      return false;
+  createNodeViews(): NodeViewMethod | Record<string, never> {
+    if (!this.options.enableCheckbox && !this.options.enableCollapsible) {
+      return {};
     }
 
-    const { pos, node } = nodeWithPos;
+    return (node, view, getPos) => {
+      const dom = document.createElement('li');
+      dom.classList.add(ExtensionListTheme.LIST_ITEM_WITH_CUSTOM_MARKER);
 
-    if (event.target instanceof HTMLButtonElement) {
-      this.store.commands.updateNodeAttributes(pos, {
-        ...node.attrs,
-        closed: !node.attrs.closed,
-      });
-
-      return true;
-    }
-
-    return false;
-  }
-
-  private handleListItemCheckboxClick(event: MouseEvent, clickState: ClickHandlerState): boolean {
-    if (!clickState.direct) {
-      return false;
-    }
-
-    const target = event.target;
-
-    if (!isDomNode(target)) {
-      return false;
-    }
-
-    if (
-      target.nodeName === 'INPUT' &&
-      (target as HTMLInputElement).getAttribute('type') === 'checkbox'
-    ) {
-      const nodeAtPosition = clickState.getNode(this.type);
-
-      if (!nodeAtPosition) {
-        return false;
+      if (node.attrs.closed) {
+        dom.classList.add(ExtensionListTheme.COLLAPSIBLE_LIST_ITEM_CLOSED);
       }
 
-      const {
-        state: { tr },
-        view,
-        pos,
-      } = clickState;
-      view.dispatch?.(tr.setSelection(NodeSelection.create(tr.doc, pos)));
+      const markContainer = document.createElement('span');
+      markContainer.contentEditable = 'false';
+      markContainer.classList.add(ExtensionListTheme.LIST_ITEM_MARKER_CONTAINER);
 
-      this.store.commands.toggleCheckboxChecked();
-      return true;
-    }
+      let mark: HTMLElement;
 
-    return false;
+      const contentDOM = document.createElement('span');
+
+      if (node.attrs.hasCheckbox) {
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = !!node.attrs.checked;
+        checkbox.classList.add(ExtensionListTheme.LIST_ITEM_CHECKBOX);
+        checkbox.addEventListener('click', () => {
+          const pos = (getPos as () => number)();
+          view.dispatch?.(view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)));
+          this.store.commands.toggleCheckboxChecked();
+          return true;
+        });
+        mark = checkbox;
+      } else {
+        mark = document.createElement('div');
+        mark.classList.add(ExtensionListTheme.COLLAPSIBLE_LIST_ITEM_BUTTON);
+
+        if (node.childCount <= 1) {
+          mark.classList.add('disabled');
+        } else {
+          mark.addEventListener('click', () => {
+            const pos = (getPos as () => number)();
+            view.dispatch?.(view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)));
+            this.store.commands.toggleListItemClosed();
+            return true;
+          });
+        }
+      }
+
+      mark.contentEditable = 'false';
+      markContainer.append(mark);
+      dom.append(markContainer);
+      dom.append(contentDOM);
+
+      return { dom, contentDOM };
+    };
   }
 
   createKeymap(): KeyBindings {
@@ -188,7 +134,7 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
   @command()
   toggleCheckboxChecked(): CommandFunction {
     return ({ state: { tr, selection }, dispatch }) => {
-      // Make sure  the `checkbox` that is selected. Otherwise do nothing.
+      // Make sure the list item is selected. Otherwise do nothing.
       if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
         return false;
       }
@@ -196,6 +142,30 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       const { node, from } = selection;
       dispatch?.(
         tr.setNodeMarkup(from, undefined, { ...node.attrs, checked: !node.attrs.checked }),
+      );
+
+      return true;
+    };
+  }
+
+  /**
+   * Toggles the current list item
+   */
+  @command()
+  toggleListItemClosed(closed?: true | false | undefined): CommandFunction {
+    // TODO: rename
+    return ({ state: { tr, selection }, dispatch }) => {
+      // Make sure the list item is selected. Otherwise do nothing.
+      if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
+        return false;
+      }
+
+      const { node, from } = selection;
+      dispatch?.(
+        tr.setNodeMarkup(from, undefined, {
+          ...node.attrs,
+          closed: closed === undefined ? !node.attrs.closed : closed,
+        }),
       );
 
       return true;
@@ -226,10 +196,13 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
 export interface ListItemOptions {
   /**
    * Set this to true to support toggling.
-   *
-   * Since the list item is used for both bullet lists
    */
-  enableToggle?: Static<boolean>;
+  enableCollapsible?: Static<boolean>;
+
+  /**
+   * Set this to true to support checkbox.
+   */
+  enableCheckbox?: Static<boolean>;
 }
 
 export type ListItemAttributes = ProsemirrorAttributes<{

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -20,6 +20,7 @@ import {
 } from '@remirror/core';
 import { liftListItem, sinkListItem } from '@remirror/pm/schema-list';
 import { NodeSelection, TextSelection } from '@remirror/pm/state';
+import { ProsemirrorNode } from '@remirror/pm/suggest';
 import { ExtensionListTheme } from '@remirror/theme';
 
 import { splitListItem } from './list-commands';
@@ -116,7 +117,14 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       dom.append(markContainer);
       dom.append(contentDOM);
 
-      return { dom, contentDOM };
+      // When a list item node's `content` updates, it's necessary to re-run the
+      // nodeView function so that the list item node's `disabled` class can be
+      // updated.
+      const update = (): boolean => {
+        return false;
+      };
+
+      return { dom, contentDOM, update };
     };
   }
 

--- a/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
+++ b/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
@@ -5,7 +5,7 @@ import { createContextState } from 'create-context-state';
 import jsx from 'refractor/lang/jsx';
 import md from 'refractor/lang/markdown';
 import typescript from 'refractor/lang/typescript';
-import { getTheme } from 'remirror';
+import { ExtensionPriority, getTheme } from 'remirror';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -16,6 +16,7 @@ import {
   HeadingExtension,
   ItalicExtension,
   LinkExtension,
+  ListItemExtension,
   MarkdownExtension,
   OrderedListExtension,
   StrikeExtension,
@@ -201,8 +202,9 @@ const extensions = () => [
   new HeadingExtension(),
   new LinkExtension(),
   new BlockquoteExtension(),
-  new BulletListExtension(),
+  new BulletListExtension({ enableSpine: true }),
   new OrderedListExtension(),
+  new ListItemExtension({ priority: ExtensionPriority.High, enableCollapsible: true }),
   new CodeExtension(),
   new CodeBlockExtension({ supportedLanguages: [jsx, typescript] }),
   new TrailingNodeExtension(),
@@ -343,8 +345,8 @@ playtime is just beginning
 ## List support
 
 - an unordered
-- list is a thing
-- of beauty
+  - list is a thing
+    - of beauty
 
 1. As is
 2. An ordered

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -3528,12 +3528,24 @@ button:active .remirror-menu-pane-shortcut,
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-list-theme.ts
  */
-.remirror-editor {
+/* don't show the custom markers in a ordered list */
+.remirror-editor ol > li > .remirror-list-item-marker-container {
+  display: none;
+}
+/* don't show the origin markers when using custom markers (checkbox / collapsible) */
+.remirror-editor ul > li.remirror-list-item-with-custom-mark {
+  list-style: none;
+}
+.remirror-editor .remirror-ul-list-content > li.remirror-list-item-with-custom-mark {
+  list-style: none;
 }
 
-.remirror-list-item-checkbox-container {
+.remirror-list-item-marker-container {
   position: absolute;
-  left: -24px;
+  left: -32px;
+  width: 24px;
+  display: inline-block;
+  text-align: center;
 }
 
 .remirror-list-item-checkbox {
@@ -3542,9 +3554,52 @@ button:active .remirror-menu-pane-shortcut,
   filter: hue-rotate(60deg);
 }
 
-.remirror-checkbox-list-item {
-  display: flex;
-  flex-direction: row;
+.remirror-collapsible-list-item-closed li {
+  display: none;
+}
+
+.remirror-collapsible-list-item-closed .remirror-collapsible-list-item-button {
+  background-color: var(--rmr-hue-gray-6);
+}
+
+.remirror-collapsible-list-item-button {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+
+  transition: background-color 0.25s ease;
+  background-color: var(--rmr-color-border);
+}
+
+.remirror-collapsible-list-item-button:hover {
+  background-color: var(--rmr-color-primary);
+}
+
+.remirror-collapsible-list-item-button.disabled,
+.remirror-collapsible-list-item-button.disabled:hover {
+  background-color: var(--rmr-color-border);
+  cursor: default;
+}
+
+.remirror-list-spine {
+  position: absolute;
+  top: 4px;
+  bottom: 0px;
+  left: -20px;
+  width: 16px;
+  cursor: pointer;
+
+  transition: border-left-color 0.25s ease;
+  border-left-color: var(--rmr-color-border);
+  border-left-style: solid;
+  border-left-width: 1px;
+}
+
+.remirror-list-spine:hover {
+  border-left-color: var(--rmr-color-primary);
 }
 
 /**

--- a/packages/remirror__styles/extension-list.css
+++ b/packages/remirror__styles/extension-list.css
@@ -1,12 +1,24 @@
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-list-theme.ts
  */
-.remirror-editor {
+/* don't show the custom markers in a ordered list */
+.remirror-editor ol > li > .remirror-list-item-marker-container {
+  display: none;
+}
+/* don't show the origin markers when using custom markers (checkbox / collapsible) */
+.remirror-editor ul > li.remirror-list-item-with-custom-mark {
+  list-style: none;
+}
+.remirror-editor .remirror-ul-list-content > li.remirror-list-item-with-custom-mark {
+  list-style: none;
 }
 
-.remirror-list-item-checkbox-container {
+.remirror-list-item-marker-container {
   position: absolute;
-  left: -24px;
+  left: -32px;
+  width: 24px;
+  display: inline-block;
+  text-align: center;
 }
 
 .remirror-list-item-checkbox {
@@ -15,7 +27,50 @@
   filter: hue-rotate(60deg);
 }
 
-.remirror-checkbox-list-item {
-  display: flex;
-  flex-direction: row;
+.remirror-collapsible-list-item-closed li {
+  display: none;
+}
+
+.remirror-collapsible-list-item-closed .remirror-collapsible-list-item-button {
+  background-color: var(--rmr-hue-gray-6);
+}
+
+.remirror-collapsible-list-item-button {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+
+  transition: background-color 0.25s ease;
+  background-color: var(--rmr-color-border);
+}
+
+.remirror-collapsible-list-item-button:hover {
+  background-color: var(--rmr-color-primary);
+}
+
+.remirror-collapsible-list-item-button.disabled,
+.remirror-collapsible-list-item-button.disabled:hover {
+  background-color: var(--rmr-color-border);
+  cursor: default;
+}
+
+.remirror-list-spine {
+  position: absolute;
+  top: 4px;
+  bottom: 0px;
+  left: -20px;
+  width: 16px;
+  cursor: pointer;
+
+  transition: border-left-color 0.25s ease;
+  border-left-color: var(--rmr-color-border);
+  border-left-style: solid;
+  border-left-width: 1px;
+}
+
+.remirror-list-spine:hover {
+  border-left-color: var(--rmr-color-primary);
 }

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -3553,12 +3553,24 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-list-theme.ts
  */
-  .remirror-editor {
+  /* don't show the custom markers in a ordered list */
+  .remirror-editor ol > li > .remirror-list-item-marker-container {
+    display: none;
+  }
+  /* don't show the origin markers when using custom markers (checkbox / collapsible) */
+  .remirror-editor ul > li.remirror-list-item-with-custom-mark {
+    list-style: none;
+  }
+  .remirror-editor .remirror-ul-list-content > li.remirror-list-item-with-custom-mark {
+    list-style: none;
   }
 
-  .remirror-list-item-checkbox-container {
+  .remirror-list-item-marker-container {
     position: absolute;
-    left: -24px;
+    left: -32px;
+    width: 24px;
+    display: inline-block;
+    text-align: center;
   }
 
   .remirror-list-item-checkbox {
@@ -3567,9 +3579,52 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     filter: hue-rotate(60deg);
   }
 
-  .remirror-checkbox-list-item {
-    display: flex;
-    flex-direction: row;
+  .remirror-collapsible-list-item-closed li {
+    display: none;
+  }
+
+  .remirror-collapsible-list-item-closed .remirror-collapsible-list-item-button {
+    background-color: var(--rmr-hue-gray-6);
+  }
+
+  .remirror-collapsible-list-item-button {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: inline-block;
+    vertical-align: middle;
+
+    transition: background-color 0.25s ease;
+    background-color: var(--rmr-color-border);
+  }
+
+  .remirror-collapsible-list-item-button:hover {
+    background-color: var(--rmr-color-primary);
+  }
+
+  .remirror-collapsible-list-item-button.disabled,
+  .remirror-collapsible-list-item-button.disabled:hover {
+    background-color: var(--rmr-color-border);
+    cursor: default;
+  }
+
+  .remirror-list-spine {
+    position: absolute;
+    top: 4px;
+    bottom: 0px;
+    left: -20px;
+    width: 16px;
+    cursor: pointer;
+
+    transition: border-left-color 0.25s ease;
+    border-left-color: var(--rmr-color-border);
+    border-left-style: solid;
+    border-left-width: 1px;
+  }
+
+  .remirror-list-spine:hover {
+    border-left-color: var(--rmr-color-primary);
   }
 `;
 

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -3584,12 +3584,24 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-list-theme.ts
  */
-  .remirror-editor {
+  /* don't show the custom markers in a ordered list */
+  .remirror-editor ol > li > .remirror-list-item-marker-container {
+    display: none;
+  }
+  /* don't show the origin markers when using custom markers (checkbox / collapsible) */
+  .remirror-editor ul > li.remirror-list-item-with-custom-mark {
+    list-style: none;
+  }
+  .remirror-editor .remirror-ul-list-content > li.remirror-list-item-with-custom-mark {
+    list-style: none;
   }
 
-  .remirror-list-item-checkbox-container {
+  .remirror-list-item-marker-container {
     position: absolute;
-    left: -24px;
+    left: -32px;
+    width: 24px;
+    display: inline-block;
+    text-align: center;
   }
 
   .remirror-list-item-checkbox {
@@ -3598,9 +3610,52 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     filter: hue-rotate(60deg);
   }
 
-  .remirror-checkbox-list-item {
-    display: flex;
-    flex-direction: row;
+  .remirror-collapsible-list-item-closed li {
+    display: none;
+  }
+
+  .remirror-collapsible-list-item-closed .remirror-collapsible-list-item-button {
+    background-color: var(--rmr-hue-gray-6);
+  }
+
+  .remirror-collapsible-list-item-button {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: inline-block;
+    vertical-align: middle;
+
+    transition: background-color 0.25s ease;
+    background-color: var(--rmr-color-border);
+  }
+
+  .remirror-collapsible-list-item-button:hover {
+    background-color: var(--rmr-color-primary);
+  }
+
+  .remirror-collapsible-list-item-button.disabled,
+  .remirror-collapsible-list-item-button.disabled:hover {
+    background-color: var(--rmr-color-border);
+    cursor: default;
+  }
+
+  .remirror-list-spine {
+    position: absolute;
+    top: 4px;
+    bottom: 0px;
+    left: -20px;
+    width: 16px;
+    cursor: pointer;
+
+    transition: border-left-color 0.25s ease;
+    border-left-color: var(--rmr-color-border);
+    border-left-style: solid;
+    border-left-width: 1px;
+  }
+
+  .remirror-list-spine:hover {
+    border-left-color: var(--rmr-color-primary);
   }
 `;
 

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -3583,12 +3583,24 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-list-theme.ts
  */
-  .remirror-editor {
+  /* don't show the custom markers in a ordered list */
+  .remirror-editor ol > li > .remirror-list-item-marker-container {
+    display: none;
+  }
+  /* don't show the origin markers when using custom markers (checkbox / collapsible) */
+  .remirror-editor ul > li.remirror-list-item-with-custom-mark {
+    list-style: none;
+  }
+  .remirror-editor .remirror-ul-list-content > li.remirror-list-item-with-custom-mark {
+    list-style: none;
   }
 
-  .remirror-list-item-checkbox-container {
+  .remirror-list-item-marker-container {
     position: absolute;
-    left: -24px;
+    left: -32px;
+    width: 24px;
+    display: inline-block;
+    text-align: center;
   }
 
   .remirror-list-item-checkbox {
@@ -3597,9 +3609,52 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     filter: hue-rotate(60deg);
   }
 
-  .remirror-checkbox-list-item {
-    display: flex;
-    flex-direction: row;
+  .remirror-collapsible-list-item-closed li {
+    display: none;
+  }
+
+  .remirror-collapsible-list-item-closed .remirror-collapsible-list-item-button {
+    background-color: var(--rmr-hue-gray-6);
+  }
+
+  .remirror-collapsible-list-item-button {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: inline-block;
+    vertical-align: middle;
+
+    transition: background-color 0.25s ease;
+    background-color: var(--rmr-color-border);
+  }
+
+  .remirror-collapsible-list-item-button:hover {
+    background-color: var(--rmr-color-primary);
+  }
+
+  .remirror-collapsible-list-item-button.disabled,
+  .remirror-collapsible-list-item-button.disabled:hover {
+    background-color: var(--rmr-color-border);
+    cursor: default;
+  }
+
+  .remirror-list-spine {
+    position: absolute;
+    top: 4px;
+    bottom: 0px;
+    left: -20px;
+    width: 16px;
+    cursor: pointer;
+
+    transition: border-left-color 0.25s ease;
+    border-left-color: var(--rmr-color-border);
+    border-left-style: solid;
+    border-left-width: 1px;
+  }
+
+  .remirror-list-spine:hover {
+    border-left-color: var(--rmr-color-primary);
   }
 `;
 

--- a/packages/remirror__theme/src/extension-list-theme.ts
+++ b/packages/remirror__theme/src/extension-list-theme.ts
@@ -1,18 +1,84 @@
 import { css } from '@linaria/core';
 
-export const EDITOR = css``;
+import { getTheme } from './utils';
 
-export const LIST_ITEM_CHECKBOX_CONTAINER = css`
+export const LIST_ITEM_WITH_CUSTOM_MARKER = 'remirror-list-item-with-custom-mark';
+export const UL_LIST_CONTENT = 'remirror-ul-list-content';
+
+export const EDITOR = css`
+  /* don't show the custom markers in a ordered list */
+  ol > li > .remirror-list-item-marker-container {
+    display: none;
+  }
+
+  /* don't show the origin markers when using custom markers (checkbox / collapsible) */
+  ul > li.${LIST_ITEM_WITH_CUSTOM_MARKER} {
+    list-style: none;
+  }
+  .${UL_LIST_CONTENT} > li.${LIST_ITEM_WITH_CUSTOM_MARKER} {
+    list-style: none;
+  }
+`;
+
+export const LIST_ITEM_MARKER_CONTAINER = css`
   position: absolute;
-  left: -24px;
-` as 'remirror-list-item-checkbox-container';
+  left: -32px;
+  width: 24px;
+  display: inline-block;
+  text-align: center;
+` as 'remirror-list-item-marker-container';
 
 export const LIST_ITEM_CHECKBOX = css`
   /* change the checkbox color from blue (default on Chrome) to purple. */
   filter: hue-rotate(60deg);
 ` as 'remirror-list-item-checkbox';
 
-export const CHECKBOX_LIST_ITEM = css`
-  display: flex;
-  flex-direction: row;
-` as 'remirror-checkbox-list-item';
+export const COLLAPSIBLE_LIST_ITEM_CLOSED = css`
+  & li {
+    display: none;
+  }
+
+  & .remirror-collapsible-list-item-button {
+    background-color: ${getTheme((t) => t.hue.gray[6])};
+  }
+` as 'remirror-collapsible-list-item-closed';
+
+export const COLLAPSIBLE_LIST_ITEM_BUTTON = css`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+
+  transition: background-color 0.25s ease;
+  background-color: ${getTheme((t) => t.color.border)};
+
+  &:hover {
+    background-color: ${getTheme((t) => t.color.primary)};
+  }
+
+  &.disabled,
+  &.disabled:hover {
+    background-color: ${getTheme((t) => t.color.border)};
+    cursor: default;
+  }
+` as 'remirror-collapsible-list-item-button';
+
+export const LIST_SPINE = css`
+  position: absolute;
+  top: 4px;
+  bottom: 0px;
+  left: -20px;
+  width: 16px;
+  cursor: pointer;
+
+  transition: border-left-color 0.25s ease;
+  border-left-color: ${getTheme((t) => t.color.border)};
+  border-left-style: solid;
+  border-left-width: 1px;
+
+  &:hover {
+    border-left-color: ${getTheme((t) => t.color.primary)};
+  }
+` as 'remirror-list-spine';


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->


This PR let list item collapsible. This includes two parts:

Part1: 

By using `ListItemExtension({enableCollapsible: true})`, we can create a small marker at the beginning of a bullet list item. This marker is clickable. It has three states:

1. Disabled. If a list item only has one child (which must be a paragraph based on the schema), then it is not collapsible. The marker will not be clickable.
1. Expand. Show its children. Will have a light gray background and will become purple when hoving.
1. Contract. Hide its children. Will have a dark gray background and will become purple when hoving.

Part2:

By using `BulletListExtension({ enableSpine: true })`, we can create a vertical clickable line at the left side of the list.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->

https://user-images.githubusercontent.com/24715727/116114883-5bf1d480-a6ec-11eb-8bfd-a78f68c8b43c.mov

