### PR TITLE
fix(theme): fix parent classname for blockquote, node-formatting styles

### DIFF
--- a/.changeset/yellow-turtles-tan.md
+++ b/.changeset/yellow-turtles-tan.md
@@ -1,0 +1,5 @@
+---
+'@remirror/theme': patch
+---
+
+Fix parent classname for blockquote and node-formatting extensions

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -651,14 +651,14 @@ button:active .remirror-menu-pane-shortcut,
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-blockquote-theme.ts
  */
-.remirror-editor.Prosemirror blockquote {
+.remirror-editor.ProseMirror blockquote {
   border-left: 3px solid var(--rmr-hue-gray-3);
   margin-left: 0;
   margin-right: 0;
   padding-left: 10px;
   font-style: italic;
 }
-.remirror-editor.Prosemirror blockquote p {
+.remirror-editor.ProseMirror blockquote p {
   color: #888;
 }
 
@@ -3614,7 +3614,7 @@ button:active .remirror-menu-pane-shortcut,
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-node-formatting-theme.ts
  */
-.remirror-editor.Prosemirror {
+.remirror-editor.ProseMirror {
 }
 
 /**

--- a/packages/remirror__styles/extension-blockquote.css
+++ b/packages/remirror__styles/extension-blockquote.css
@@ -1,13 +1,13 @@
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-blockquote-theme.ts
  */
-.remirror-editor.Prosemirror blockquote {
+.remirror-editor.ProseMirror blockquote {
   border-left: 3px solid var(--rmr-hue-gray-3);
   margin-left: 0;
   margin-right: 0;
   padding-left: 10px;
   font-style: italic;
 }
-.remirror-editor.Prosemirror blockquote p {
+.remirror-editor.ProseMirror blockquote p {
   color: #888;
 }

--- a/packages/remirror__styles/extension-node-formatting.css
+++ b/packages/remirror__styles/extension-node-formatting.css
@@ -1,5 +1,5 @@
 /**
  * Styles extracted from: packages/remirror__theme/src/extension-node-formatting-theme.ts
  */
-.remirror-editor.Prosemirror {
+.remirror-editor.ProseMirror {
 }

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -664,14 +664,14 @@ export const extensionBlockquoteStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-blockquote-theme.ts
  */
-  .remirror-editor.Prosemirror blockquote {
+  .remirror-editor.ProseMirror blockquote {
     border-left: 3px solid var(--rmr-hue-gray-3);
     margin-left: 0;
     margin-right: 0;
     padding-left: 10px;
     font-style: italic;
   }
-  .remirror-editor.Prosemirror blockquote p {
+  .remirror-editor.ProseMirror blockquote p {
     color: #888;
   }
 `;
@@ -3643,7 +3643,7 @@ export const extensionNodeFormattingStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-node-formatting-theme.ts
  */
-  .remirror-editor.Prosemirror {
+  .remirror-editor.ProseMirror {
   }
 `;
 

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -671,14 +671,14 @@ export const extensionBlockquoteStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-blockquote-theme.ts
  */
-  .remirror-editor.Prosemirror blockquote {
+  .remirror-editor.ProseMirror blockquote {
     border-left: 3px solid var(--rmr-hue-gray-3);
     margin-left: 0;
     margin-right: 0;
     padding-left: 10px;
     font-style: italic;
   }
-  .remirror-editor.Prosemirror blockquote p {
+  .remirror-editor.ProseMirror blockquote p {
     color: #888;
   }
 `;
@@ -3682,7 +3682,7 @@ export const extensionNodeFormattingStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-node-formatting-theme.ts
  */
-  .remirror-editor.Prosemirror {
+  .remirror-editor.ProseMirror {
   }
 `;
 

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -670,14 +670,14 @@ export const extensionBlockquoteStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-blockquote-theme.ts
  */
-  .remirror-editor.Prosemirror blockquote {
+  .remirror-editor.ProseMirror blockquote {
     border-left: 3px solid var(--rmr-hue-gray-3);
     margin-left: 0;
     margin-right: 0;
     padding-left: 10px;
     font-style: italic;
   }
-  .remirror-editor.Prosemirror blockquote p {
+  .remirror-editor.ProseMirror blockquote p {
     color: #888;
   }
 `;
@@ -3681,7 +3681,7 @@ export const extensionNodeFormattingStyledCss: ReturnType<typeof css> = css`
   /**
  * Styles extracted from: packages/remirror__theme/src/extension-node-formatting-theme.ts
  */
-  .remirror-editor.Prosemirror {
+  .remirror-editor.ProseMirror {
   }
 `;
 

--- a/packages/remirror__theme/src/extension-blockquote-theme.ts
+++ b/packages/remirror__theme/src/extension-blockquote-theme.ts
@@ -8,7 +8,7 @@ import { getTheme } from './utils';
  * a `linaria` build script.
  */
 export const EDITOR = css`
-  &.Prosemirror {
+  &.ProseMirror {
     blockquote {
       border-left: 3px solid ${getTheme((t) => t.hue.gray[3])};
       margin-left: 0;

--- a/packages/remirror__theme/src/extension-node-formatting-theme.ts
+++ b/packages/remirror__theme/src/extension-node-formatting-theme.ts
@@ -6,6 +6,6 @@ import { css } from '@linaria/core';
 export const NODE_FORMATTING_INDENT_ATTRIBUTE = 'data-node-formatting-indent';
 
 export const EDITOR = css`
-  &.Prosemirror {
+  &.ProseMirror {
   }
 ` as 'remirror-editor';


### PR DESCRIPTION
### Description

A quick fix for the blockquote extension, as styles weren't be applied because of incorrect case on the `.ProseMirror` classname

Also applied the same fix for the node-formatting extension, although this seems to be empty at present.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
