### PR TITLE
feat(extension-list): allow using command to create a checkbox list item

### DIFF
--- a/.changeset/serious-humans-hide.md
+++ b/.changeset/serious-humans-hide.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': minor
+---
+
+Make the command `toggleCheckboxChecked` set the attribute `hasCheckbox`.

--- a/packages/remirror__core/src/commands.ts
+++ b/packages/remirror__core/src/commands.ts
@@ -21,7 +21,7 @@ import type {
 } from '@remirror/core-types';
 import { convertCommand, getCursor, getTextSelection, isMarkActive } from '@remirror/core-utils';
 import { toggleMark as originalToggleMark } from '@remirror/pm/commands';
-import type { SelectionRange, Transaction } from '@remirror/pm/state';
+import type { SelectionRange } from '@remirror/pm/state';
 
 /**
  * The parameter that is passed into `DelayedCommand`s.

--- a/packages/remirror__core/src/commands.ts
+++ b/packages/remirror__core/src/commands.ts
@@ -21,7 +21,7 @@ import type {
 } from '@remirror/core-types';
 import { convertCommand, getCursor, getTextSelection, isMarkActive } from '@remirror/core-utils';
 import { toggleMark as originalToggleMark } from '@remirror/pm/commands';
-import type { SelectionRange } from '@remirror/pm/state';
+import type { SelectionRange, Transaction } from '@remirror/pm/state';
 
 /**
  * The parameter that is passed into `DelayedCommand`s.

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -8,6 +8,7 @@ import {
   ExtensionTag,
   getMatchString,
   InputRule,
+  isBoolean,
   isNodeSelection,
   KeyBindings,
   NodeExtension,
@@ -136,10 +137,15 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
   }
 
   /**
-   * Toggles the current checkbox state
+   * Toggles the current checkbox state and transform a normal list item into a
+   * checkbox list item when necessary.
+   *
+   * @param checked - the `checked` attribute. If it's a boolean value, then it
+   * will be set as an attribute. If it's undefined, then the `checked` attribuate
+   * will be toggled.
    */
   @command()
-  toggleCheckboxChecked(): CommandFunction {
+  toggleCheckboxChecked(checked?: true | false | undefined): CommandFunction {
     return ({ state: { tr, selection }, dispatch }) => {
       // Make sure the list item is selected. Otherwise do nothing.
       if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
@@ -147,20 +153,22 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       }
 
       const { node, from } = selection;
-      dispatch?.(
-        tr.setNodeMarkup(from, undefined, { ...node.attrs, checked: !node.attrs.checked }),
-      );
+      checked = isBoolean(checked) ? checked : !node.attrs.checked;
+      dispatch?.(tr.setNodeMarkup(from, undefined, { ...node.attrs, checked, hasCheckbox: true }));
 
       return true;
     };
   }
 
   /**
-   * Toggles the current list item
+   * Toggles the current list item.
+   *
+   * @param closed - the `closed` attribute. If it's a boolean value, then it
+   * will be set as an attribute. If it's undefined, then the `closed` attribuate
+   * will be toggled.
    */
   @command()
   toggleListItemClosed(closed?: true | false | undefined): CommandFunction {
-    // TODO: rename
     return ({ state: { tr, selection }, dispatch }) => {
       // Make sure the list item is selected. Otherwise do nothing.
       if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
@@ -168,12 +176,8 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       }
 
       const { node, from } = selection;
-      dispatch?.(
-        tr.setNodeMarkup(from, undefined, {
-          ...node.attrs,
-          closed: closed === undefined ? !node.attrs.closed : closed,
-        }),
-      );
+      closed = isBoolean(closed) ? closed : !node.attrs.closed;
+      dispatch?.(tr.setNodeMarkup(from, undefined, { ...node.attrs, closed }));
 
       return true;
     };

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -145,7 +145,7 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
    * will be toggled.
    */
   @command()
-  toggleCheckboxChecked(checked?: true | false | undefined): CommandFunction {
+  toggleCheckboxChecked(checked?: boolean | undefined): CommandFunction {
     return ({ state: { tr, selection }, dispatch }) => {
       // Make sure the list item is selected. Otherwise do nothing.
       if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
@@ -168,7 +168,7 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
    * will be toggled.
    */
   @command()
-  toggleListItemClosed(closed?: true | false | undefined): CommandFunction {
+  toggleListItemClosed(closed?: boolean | undefined): CommandFunction {
     return ({ state: { tr, selection }, dispatch }) => {
       // Make sure the list item is selected. Otherwise do nothing.
       if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {


### PR DESCRIPTION

### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Make the command `toggleCheckboxChecked` not only change the `checked` attribute, but also transform a normal list item into a checkbox list item when necessary.




### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 