### PR TITLE
fix(node-formatting): decrease indent by clicking `Shift-Tab`

### DIFF
--- a/.changeset/odd-weeks-wash.md
+++ b/.changeset/odd-weeks-wash.md
@@ -1,0 +1,6 @@
+---
+'remirror': patch
+'@remirror/extension-node-formatting': patch
+---
+
+Fix decreasing node indent with keyboard shortcut `Shift-Tab`.

--- a/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
@@ -111,7 +111,7 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
   @command()
   setIndent(level: number | '+1' | '-1'): CommandFunction {
     return this.setNodeAttribute(({ node }) => {
-      const currentIndent: number = node.attrs.indent ?? 0;
+      const currentIndent: number = node.attrs.nodeIndent ?? 0;
       const value = level === '-1' ? currentIndent - 1 : level === '+1' ? currentIndent + 1 : level;
       const indent = clamp({ min: 0, max: this.options.indents.length - 1, value });
 


### PR DESCRIPTION
### Description

Quick fix for a bug with decreasing node indent by clicking `Shift-Tab` in `NodeFormattingExtension`.

Reproducible example [codesandbox](https://codesandbox.io/s/remirror-pr-000-pr70626-forked-b1wsw?file=/src/App.tsx)

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

`NodeFormattingExtension` is not tested yet, so would appreciate some help with adding a test case for that change 🙇‍♀️ 
