### PR TITLE
feat(extension-yjs): add ability to collaborate on annonations

### DIFF
--- a/.changeset/dull-impalas-bathe.md
+++ b/.changeset/dull-impalas-bathe.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-annotation': minor
+'@remirror/extension-yjs': minor
+---
+
+Add the ability to share annotations via YJS if both extensions are present in the editor

--- a/packages/remirror__extension-annotation/src/annotation-types.ts
+++ b/packages/remirror__extension-annotation/src/annotation-types.ts
@@ -3,6 +3,17 @@ import type { AcceptUndefined } from '@remirror/core';
 export type GetStyle<Type extends Annotation> = (
   annotations: Array<OmitText<Type>>,
 ) => string | undefined;
+
+export interface MapLike<K extends string, V> {
+  clear?: () => void;
+  delete: (key: K) => any;
+  forEach: (callbackfn: (value: V, key: K, map: MapLike<K, V>) => void, thisArg?: any) => void;
+  get: (key: K) => V | undefined;
+  has: (key: K) => boolean;
+  set: (key: K, value: V) => any;
+  readonly size: number;
+}
+
 export interface AnnotationOptions<Type extends Annotation = Annotation> {
   /**
    * Method to calculate styles for a segment with one or more annotations
@@ -23,6 +34,12 @@ export interface AnnotationOptions<Type extends Annotation = Annotation> {
    * @see ProsemirrorNode.textBetween
    */
   blockSeparator?: AcceptUndefined<string>;
+
+  getMap?: () => MapLike<string, OmitText<Type>>;
+
+  transformPosition?: (pos: number) => number;
+
+  transformPositionBeforeRender?: (pos: number) => number | null;
 }
 
 export interface Annotation {

--- a/packages/remirror__extension-yjs/__tests__/tsconfig.json
+++ b/packages/remirror__extension-yjs/__tests__/tsconfig.json
@@ -35,6 +35,9 @@
       "path": "../../remirror__core/src"
     },
     {
+      "path": "../../remirror__extension-annotation/src"
+    },
+    {
       "path": "../../remirror__messages/src"
     }
   ]

--- a/packages/remirror__extension-yjs/package.json
+++ b/packages/remirror__extension-yjs/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "1.0.0-next.60",
+    "@remirror/extension-annotation": "1.0.0-next.60",
     "@remirror/messages": "0.0.0",
     "y-prosemirror": "^1.0.6",
     "y-protocols": "^1.0.4"

--- a/packages/remirror__extension-yjs/src/tsconfig.json
+++ b/packages/remirror__extension-yjs/src/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../../remirror__core/src"
     },
     {
+      "path": "../../remirror__extension-annotation/src"
+    },
+    {
       "path": "../../remirror__messages/src"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1832,6 +1832,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.13.10
       '@remirror/core': 1.0.0-next.60
+      '@remirror/extension-annotation': 1.0.0-next.60
       '@remirror/messages': 0.0.0
       '@remirror/pm': 1.0.0-next.60
       y-prosemirror: ^1.0.6
@@ -1841,6 +1842,7 @@ importers:
     dependencies:
       '@babel/runtime': 7.14.0
       '@remirror/core': link:../remirror__core
+      '@remirror/extension-annotation': link:../remirror__extension-annotation
       '@remirror/messages': link:../remirror__messages
       y-prosemirror: 1.0.9_y-protocols@1.0.4+yjs@13.5.6
       y-protocols: 1.0.4

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -642,7 +642,13 @@
     "name": "@remirror/extension-yjs",
     "limit": "115 KB",
     "path": "packages/remirror__extension-yjs/dist/remirror-extension-yjs.browser.esm.js",
-    "ignore": ["@remirror/pm", "yjs", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "yjs",
+      "@remirror/core",
+      "@remirror/extension-annotation",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },


### PR DESCRIPTION
### Description

If both the YJS and annotations extensions are present in the editor, use the provided YDoc to share annotations via a YMap.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
