### PR TITLE
fix(annotation): types and add tests

### DIFF
--- a/.changeset/gold-shirts-own.md
+++ b/.changeset/gold-shirts-own.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-annotation': patch
+'@remirror/extension-yjs': patch
+---
+
+Fix types for Yjs extension relative/absolute position transforms Add tests and JSDoc for Annotation extension options

--- a/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
+++ b/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
@@ -508,3 +508,75 @@ describe('custom styling', () => {
     `);
   });
 });
+
+describe('custom map like via getMap', () => {
+  it('should use the provided map like object passed via `getMap`', () => {
+    const myMap = new Map();
+    const options = {
+      getMap: () => myMap,
+    };
+    const {
+      add,
+      nodes: { p, doc },
+      commands,
+      helpers,
+    } = create(options);
+
+    add(doc(p('Hello <start>again<end> my friend')));
+
+    commands.addAnnotation({ id: 'an-id' });
+
+    expect(myMap.size).toBe(1);
+    expect(myMap.get('an-id')).toEqual({
+      id: 'an-id',
+      from: 7,
+      to: 12,
+    });
+
+    expect(helpers.getAnnotations()).toEqual([
+      {
+        id: 'an-id',
+        from: 7,
+        to: 12,
+        text: 'again',
+      },
+    ]);
+  });
+});
+
+describe('custom positions', () => {
+  it('should use the provided map like object passed via `getMap`', () => {
+    const myMap = new Map();
+    const options = {
+      getMap: () => myMap,
+      transformPosition: (pos: number) => ({ pos, meta: { mock: 'data' } }),
+      transformPositionBeforeRender: (obj: any) => obj.pos,
+    };
+    const {
+      add,
+      nodes: { p, doc },
+      commands,
+      helpers,
+    } = create(options);
+
+    add(doc(p('Hello <start>transforms<end> my old friend')));
+
+    commands.addAnnotation({ id: 'some-id' });
+
+    expect(myMap.size).toBe(1);
+    expect(myMap.get('some-id')).toStrictEqual({
+      id: 'some-id',
+      from: { pos: 7, meta: { mock: 'data' } },
+      to: { pos: 17, meta: { mock: 'data' } },
+    });
+
+    expect(helpers.getAnnotations()).toEqual([
+      {
+        id: 'some-id',
+        from: 7,
+        to: 17,
+        text: 'transforms',
+      },
+    ]);
+  });
+});

--- a/packages/remirror__extension-annotation/src/annotation-plugin.ts
+++ b/packages/remirror__extension-annotation/src/annotation-plugin.ts
@@ -9,7 +9,13 @@ import {
   UpdateAnnotationAction,
 } from './annotation-actions';
 import { toSegments } from './annotation-segments';
-import type { Annotation, GetStyle, MapLike, OmitText } from './annotation-types';
+import type {
+  Annotation,
+  GetStyle,
+  MapLike,
+  OmitText,
+  TransformedAnnotation,
+} from './annotation-types';
 
 interface ApplyProps extends TransactionProps {
   action: any;
@@ -26,9 +32,9 @@ export class AnnotationState<Type extends Annotation = Annotation> {
 
   constructor(
     private readonly getStyle: GetStyle<Type>,
-    private readonly map: MapLike<string, OmitText<Type>>,
-    private readonly transformPosition: (pos: number) => number,
-    private readonly transformPositionBeforeRender: (pos: number) => number | null,
+    private readonly map: MapLike<string, TransformedAnnotation<Type>>,
+    private readonly transformPosition: (pos: number) => any,
+    private readonly transformPositionBeforeRender: (rpos: any) => number | null,
   ) {}
 
   addAnnotation(addAction: AddAnnotationAction<Type>): void {
@@ -37,7 +43,7 @@ export class AnnotationState<Type extends Annotation = Annotation> {
       ...addAction.annotationData,
       from: this.transformPosition(addAction.from),
       to: this.transformPosition(addAction.to),
-    } as OmitText<Type>);
+    } as TransformedAnnotation<Type>);
   }
 
   updateAnnotation(updateAction: UpdateAnnotationAction<Type>): void {
@@ -46,7 +52,7 @@ export class AnnotationState<Type extends Annotation = Annotation> {
     this.map.set(updateAction.annotationId, {
       ...this.map.get(updateAction.annotationId),
       ...updateAction.annotationData,
-    } as OmitText<Type>);
+    } as TransformedAnnotation<Type>);
   }
 
   removeAnnotations(removeAction: RemoveAnnotationsAction): void {
@@ -69,7 +75,7 @@ export class AnnotationState<Type extends Annotation = Annotation> {
         ...annotation,
         from: this.transformPosition(from),
         to: this.transformPosition(to),
-      } as OmitText<Type>);
+      } as TransformedAnnotation<Type>);
     });
   }
 

--- a/packages/remirror__extension-annotation/src/annotation-plugin.ts
+++ b/packages/remirror__extension-annotation/src/annotation-plugin.ts
@@ -64,8 +64,7 @@ export class AnnotationState<Type extends Annotation = Annotation> {
   setAnnotations(setAction: SetAnnotationsAction<Type>): void {
     // YJS maps don't support clear
     this.map.clear?.();
-    // eslint-disable-next-line prefer-arrow-callback
-    this.map.forEach(function (_, id, map) {
+    this.map.forEach((_, id, map) => {
       map.delete(id);
     });
 

--- a/packages/remirror__extension-annotation/src/annotation-types.ts
+++ b/packages/remirror__extension-annotation/src/annotation-types.ts
@@ -35,11 +35,40 @@ export interface AnnotationOptions<Type extends Annotation = Annotation> {
    */
   blockSeparator?: AcceptUndefined<string>;
 
-  getMap?: () => MapLike<string, OmitText<Type>>;
+  /**
+   * Allows a custom map-like object for storing internal annotations
+   *
+   * @remarks
+   *
+   * This can be used to pass something like a Yjs Y.Map for shared annotations
+   */
+  getMap?: () => MapLike<string, TransformedAnnotation<Type>>;
 
-  transformPosition?: (pos: number) => number;
+  /**
+   * Allows a custom transform function that modifies how positions are stored
+   * internally
+   *
+   * @remarks
+   *
+   * This can be used to transform positions to other representations, like a
+   * Yjs Relative Position
+   *
+   * @see AnnotationOptions.transformPositionBeforeRender
+   */
+  transformPosition?: (pos: number) => any;
 
-  transformPositionBeforeRender?: (pos: number) => number | null;
+  /**
+   * Allows a custom transform function that modifies how internal positions
+   * representations are returned externally
+   *
+   * @remarks
+   *
+   * This can be used to transform positions from other representations, like a
+   * Yjs Relative Position to a ProseMirror integer (absolute) position
+   *
+   * @see AnnotationOptions.transformPosition
+   */
+  transformPositionBeforeRender?: (rpos: any) => number | null;
 }
 
 export interface Annotation {
@@ -71,6 +100,18 @@ export interface Annotation {
    */
   className?: string;
 }
+
+export type TransformedAnnotation<T extends object> = T & {
+  /**
+   * Document transformed position where the annotation starts.
+   */
+  from: any;
+
+  /**
+   * Document transformed position where the annotation ends.
+   */
+  to: any;
+};
 
 /**
  * Remove the text field from an annotation.

--- a/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
+++ b/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
@@ -54,6 +54,8 @@ describe('configuration', () => {
 });
 
 describe('commands', () => {
+  hideConsoleError(true);
+
   it('can undo', () => {
     const { nodes, add } = create();
     const { p, doc } = nodes;
@@ -89,6 +91,8 @@ describe('commands', () => {
 });
 
 describe('keymap', () => {
+  hideConsoleError(true);
+
   it('can undo', () => {
     const { nodes, add } = create();
     const { p, doc } = nodes;

--- a/packages/remirror__extension-yjs/src/yjs-extension.ts
+++ b/packages/remirror__extension-yjs/src/yjs-extension.ts
@@ -10,7 +10,7 @@ import {
   yUndoPlugin,
   yUndoPluginKey,
 } from 'y-prosemirror';
-import type { Doc, UndoManager } from 'yjs';
+import type { Doc, RelativePosition, UndoManager } from 'yjs';
 import {
   AcceptUndefined,
   command,
@@ -150,8 +150,8 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
     try {
       this.store.manager.getExtension(AnnotationExtension).setOptions({
         getMap: () => this.provider.doc.getMap('annotations'),
-        transformPosition: this.transformPosition.bind(this),
-        transformPositionBeforeRender: this.transformPositionBeforeRender.bind(this),
+        transformPosition: this.absolutePositionToRelativePosition.bind(this),
+        transformPositionBeforeRender: this.relativePositionToAbsolutePosition.bind(this),
       });
       this.provider.doc.on('update', () => {
         this.store.commands.redrawAnnotations?.();
@@ -308,16 +308,16 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
     return this.yRedo()(props);
   }
 
-  private transformPosition(pos: number): number {
+  private absolutePositionToRelativePosition(pos: number): RelativePosition {
     const state = this.store.getState();
     const { type, binding } = ySyncPluginKey.getState(state);
     return absolutePositionToRelativePosition(pos, type, binding.mapping);
   }
 
-  private transformPositionBeforeRender(pos: number): number | null {
+  private relativePositionToAbsolutePosition(relPos: RelativePosition): number | null {
     const state = this.store.getState();
     const { type, binding } = ySyncPluginKey.getState(state);
-    return relativePositionToAbsolutePosition(this.provider.doc, type, pos, binding.mapping);
+    return relativePositionToAbsolutePosition(this.provider.doc, type, relPos, binding.mapping);
   }
 }
 


### PR DESCRIPTION
### Description

Fix types related to #956, the private helpers added in the YJS extension return/consume relative positions, not integers.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
