### PR TITLE
feat(prosemirror-paste-rules): allow custom content for node

### DIFF
--- a/.changeset/cold-parrots-sip.md
+++ b/.changeset/cold-parrots-sip.md
@@ -4,4 +4,4 @@
 
 Update the API:
 
-- For `type: "node"`: removed the `transformMatch` parameter and added a new `getContent` parameter, which can add custom content to the created node. By using `getContent`, users can set content as not only a text node, but also `undefined` or something more complex.
+- For `type: "node"`: removed the `transformMatch` parameter and added a new optional `getContent` parameter, which is a function that transforms the match into content when creating the node. By using `getContent`, users can set content as not only a text node, but also `undefined` or something more complex.

--- a/.changeset/cold-parrots-sip.md
+++ b/.changeset/cold-parrots-sip.md
@@ -1,5 +1,5 @@
 ---
-'prosemirror-paste-rules': minor
+'prosemirror-paste-rules': major
 ---
 
 Update the API:

--- a/.changeset/cold-parrots-sip.md
+++ b/.changeset/cold-parrots-sip.md
@@ -4,6 +4,4 @@
 
 Update the API:
 
-- for `type: "text"`: nothing change;
-- for `type: "mark"`: removed the `transformMatch` parameter;
-- for `type: "node"`: removed the `transformMatch` parameter and added a new `getContent` parameter, which can add custom content to the created node.
+- For `type: "node"`: removed the `transformMatch` parameter and added a new `getContent` parameter, which can add custom content to the created node. By using `getContent`, users can set content as not only a text node, but also `undefined` or something more complex.

--- a/.changeset/cold-parrots-sip.md
+++ b/.changeset/cold-parrots-sip.md
@@ -1,0 +1,9 @@
+---
+'prosemirror-paste-rules': minor
+---
+
+Update the API:
+
+- for `type: "text"`: nothing change;
+- for `type: "mark"`: removed the `transformMatch` parameter;
+- for `type: "node"`: removed the `transformMatch` parameter and added a new `getContent` parameter, which can add custom content to the created node.

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -11,8 +11,8 @@ import {
   tableCell,
   tableRow,
 } from 'jest-prosemirror';
+import type { Node as ProsemirrorNode } from 'prosemirror-model';
 
-import { ProsemirrorNode } from '@remirror/pm';
 import { pasteRules } from '../';
 
 describe('pasteRules', () => {

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -103,6 +103,52 @@ describe('pasteRules', () => {
           );
         });
     });
+
+    it('should replace selection', () => {
+      const plugin1 = pasteRules([
+        {
+          regexp: /(@[a-z]+)/,
+          markType: schema.marks.strong,
+          type: 'mark',
+          replaceSelection: (replacedText) => {
+            return !!replacedText.trim();
+          },
+        },
+      ]);
+      createEditor(doc(p('<start>   <end>')), { plugins: [plugin1] })
+        .paste('@test')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(doc(p('', strong('@test'))));
+        });
+      createEditor(doc(p('<start>selected text is not empty<end>')), { plugins: [plugin1] })
+        .paste('@test')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(
+            doc(p('', strong('selected text is not empty'))),
+          );
+        });
+
+      const plugin2 = pasteRules([
+        {
+          regexp: /(@[a-z]+)/,
+          markType: schema.marks.strong,
+          type: 'mark',
+          replaceSelection: true,
+        },
+      ]);
+      createEditor(doc(p('<start>   <end>')), { plugins: [plugin2] })
+        .paste('@test')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(doc(p('', strong('   '))));
+        });
+      createEditor(doc(p('<start>selected text is not empty<end>')), { plugins: [plugin2] })
+        .paste('@test')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(
+            doc(p('', strong('selected text is not empty'))),
+          );
+        });
+    });
   });
 
   describe('type: text', () => {

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -12,7 +12,7 @@ import {
   tableRow,
 } from 'jest-prosemirror';
 
-import { ProsemirrorNode } from '../../jest-prosemirror/node_modules/@remirror/pm/src';
+import { ProsemirrorNode } from '@remirror/pm';
 import { pasteRules } from '../';
 
 describe('pasteRules', () => {

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -277,6 +277,8 @@ export interface NodePasteRule extends BaseContentPasteRule {
    * A function that transforms the match into the content to use when creating
    * a node.
    *
+   * Pass `() => {}` to remove the matched text.
+   *
    * If this function is undefined, then the text node cutted from the match
    * will be used as the content.
    */
@@ -480,7 +482,7 @@ function nodeRuleTransformer(props: TransformerProps<NodePasteRule>) {
   const { nodes, rule, textNode, match } = props;
   const { getAttributes, nodeType, getContent } = rule;
   const attributes = isFunction(getAttributes) ? getAttributes(match, false) : getAttributes;
-  const content = getContent ? getContent(match) : textNode;
+  const content = (getContent ? getContent(match) : textNode) || undefined;
   nodes.push(nodeType.createChecked(attributes, content));
 }
 

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -286,7 +286,7 @@ export interface NodePasteRule extends BaseContentPasteRule {
    *
    * Pass `() => {}` to remove the matched text.
    *
-   * If this function is undefined, then the text node cutted from the match
+   * If this function is undefined, then the text node that is cut from the match
    * will be used as the content.
    */
   getContent?: (


### PR DESCRIPTION
### Description

Update the API:

- For `type: "node"`: removed the `transformMatch` parameter and added a new optional `getContent` parameter, which is a function that transforms the match into content when creating the node. By using `getContent`, users can set content as not only a text node, but also `undefined` or something more complex.



### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
