### PR TITLE
fix(core): fix onChange so `firstRender` only occurs once

### DIFF
--- a/.changeset/swift-suns-push.md
+++ b/.changeset/swift-suns-push.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Ensure `onChange` callback is only called with `firstRender` once.

--- a/packages/remirror__core/src/framework/framework.ts
+++ b/packages/remirror__core/src/framework/framework.ts
@@ -392,11 +392,13 @@ export abstract class Framework<
    * Use this method in the `onUpdate` event to run all change handlers.
    */
   readonly onChange = (props: ListenerProps<Extension> = object()): void => {
-    this.props.onChange?.(this.eventListenerProps(props));
+    const onChangeProps = this.eventListenerProps(props);
 
     if (this.#firstRender) {
       this.#firstRender = false;
     }
+
+    this.props.onChange?.(onChangeProps);
   };
 
   /**


### PR DESCRIPTION
### Description

Context

```tsx
const handleChange = useCallback(({ firstRender }) => {
  if (firstRender) {
    doSomethingOnLoad();
  }
}, []);

return (
  <Remirror
    manager={manager}
    onChange={handleChange}
    autoRender
  />
);
```

Perhaps I'm mis-using the `firstRender` property of the `onChange` handler, but I expected `onChange` to be called with `firstRender` once?

I have found in practice this is not the case, due to the way private properties are transpiled, it actually creates a function `_classPrivateFieldSet(_this, _firstRender, false)` which I guess get pushed onto the stack and not immediately executed. This means onChange can be called multiple times with `firstRender = true`

This PR rearranges the code, so `onChange` with `firstRender = true` only happens once.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
