### PR TITLE
feat(extension-link): custom `target` attribute

### DIFF
--- a/.changeset/eighty-students-wink.md
+++ b/.changeset/eighty-students-wink.md
@@ -1,0 +1,12 @@
+---
+'@remirror/extension-link': minor
+---
+
+Add `supportedTargets` option to `LinkExtension`.
+
+```ts
+new LinkExtension({ supportedTargets: ['_blank'] });
+
+// Insert a link with a target attribute.
+commands.insertHtml('<a target="_blank" href="//example.com">Awesome</a>');
+```

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -725,3 +725,54 @@ describe('spanning', () => {
     `);
   });
 });
+
+describe('target', () => {
+  it('should allow `supportedTargets`', () => {
+    const editor = renderEditor([new LinkExtension({ supportedTargets: ['_blank'] })]);
+    const {
+      attributeMarks: { link: a },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>')));
+    editor.chain
+      .insertHtml('<a href="//test.com" target="_blank">test</a>')
+      .selectText('end')
+      .run();
+    const link = a({ href: '//test.com', target: '_blank' });
+    // editor.debug();
+    expect(editor.doc).toEqualRemirrorDocument(doc(p(link('test'))));
+  });
+
+  it('should not allow non `supportedTargets`', () => {
+    const editor = renderEditor([new LinkExtension({ supportedTargets: ['_blank'] })]);
+    const {
+      attributeMarks: { link: a },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>')));
+    editor.chain
+      .insertHtml('<a href="//test.com" target="_parent">test</a>')
+      .selectText('end')
+      .run();
+    const link = a({ href: '//test.com' });
+    expect(editor.doc).toEqualRemirrorDocument(doc(p(link('test'))));
+  });
+
+  it('should add `defaultTarget` to supported targets', () => {
+    const editor = renderEditor([new LinkExtension({ defaultTarget: '_blank' })]);
+    const {
+      attributeMarks: { link: a },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>')));
+    editor.chain
+      .insertHtml('<a href="//test.com" target="_blank">test</a>')
+      .selectText('end')
+      .run();
+    const link = a({ href: '//test.com', target: '_blank' });
+    expect(editor.doc).toEqualRemirrorDocument(doc(p(link('test'))));
+  });
+});

--- a/packages/remirror__playground/src/tsconfig.json
+++ b/packages/remirror__playground/src/tsconfig.json
@@ -50,6 +50,9 @@
       "path": "../../prosemirror-paste-rules/src"
     },
     {
+      "path": "../../prosemirror-resizable-view/src"
+    },
+    {
       "path": "../../prosemirror-suggest/src"
     },
     {


### PR DESCRIPTION
### Description

Add `supportedTargets` option to `LinkExtension`.

```ts
new LinkExtension({ supportedTargets: ['_blank'] });

// Insert a link with a target attribute.
commands.insertHtml('<a target="_blank" href="//example.com">Awesome</a>');
```

Fixes #966

_This is a draft PR until #965 is merged._

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
