### PR TITLE
fix(react-components): open emoji after `:`

### DIFF
--- a/.changeset/curly-swans-talk.md
+++ b/.changeset/curly-swans-talk.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-components': patch
+---
+
+Show the `EmojiPopupComponent` immediately after typing `:`.

--- a/packages/remirror__react-components/src/components/emoji-popup-component.tsx
+++ b/packages/remirror__react-components/src/components/emoji-popup-component.tsx
@@ -32,7 +32,7 @@ export const EmojiPopupComponent: FC = () => {
   const enabled = !!state;
 
   return (
-    <FloatingWrapper positioner='nearestWord' enabled={enabled} placement='auto-end'>
+    <FloatingWrapper positioner='cursor' enabled={enabled} placement='auto-end'>
       <div {...getMenuProps()}>
         {enabled &&
           (state?.list ?? emptyList).map((emoji, index) => {


### PR DESCRIPTION
### Description

Show the `EmojiPopupComponent` immediately after typing `:`.

Fixes #968

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2021-06-18 12 24 07](https://user-images.githubusercontent.com/1160934/122553877-256f7080-d030-11eb-9d01-f25e119e3af7.gif)
