### PR TITLE
fix(yjs): ignore unnecessary handling of own changes to Yjs doc

### DIFF
--- a/.changeset/dry-countries-jog.md
+++ b/.changeset/dry-countries-jog.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-yjs': minor
+---
+
+Ignore unnecessary handling of own changes to Yjs document


### PR DESCRIPTION
### Description

Avoid generating additional transactions for things that have already been actioned.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
