### PR TITLE
fix(multishift): items can be empty array

### DIFF
--- a/.changeset/yellow-cheetahs-kneel.md
+++ b/.changeset/yellow-cheetahs-kneel.md
@@ -1,0 +1,6 @@
+---
+'multishift': patch
+'@remirror/react-components': patch
+---
+
+Fix the situation where passing an array with zero items to `multishift` caused the editor to crash. This was raised in [#971](https://github.com/remirror/remirror/issues/971).

--- a/packages/multishift/src/multishift-utils.ts
+++ b/packages/multishift/src/multishift-utils.ts
@@ -657,13 +657,7 @@ export function getChangesFromItemClick<Item = any>({
   props,
   getItemId,
 }: GetChangesFromItemClickProps<Item>): MultishiftStateProps<Item> {
-  const selectedItem = assertGet(items, index);
-  const selectedItems = toggleSelectedItems(
-    state.selectedItems,
-    [selectedItem],
-    getItemId,
-    props.multiple,
-  );
+  const selectedItem = items[index];
   const isOpen = props.multiple ? true : defaultState.isOpen;
   const params = { state, getItemId };
   const defaultReturn: MultishiftStateProps<Item> = {
@@ -675,6 +669,13 @@ export function getChangesFromItemClick<Item = any>({
     // TODO check if this logic is desirable
     return { ...defaultReturn, isOpen };
   }
+
+  const selectedItems = toggleSelectedItems(
+    state.selectedItems,
+    [selectedItem],
+    getItemId,
+    props.multiple,
+  );
 
   // Check if the modifier for selecting multiple items is pressed.
   const shiftKeyPressed = modifiers.includes('shiftKey');

--- a/packages/remirror__react-components/src/components/emoji-popup-component.tsx
+++ b/packages/remirror__react-components/src/components/emoji-popup-component.tsx
@@ -1,6 +1,5 @@
 import { FC } from 'react';
 import { cx } from '@remirror/core';
-import { useCommands } from '@remirror/react-core';
 import { FlatEmojiWithUrl, useEmoji } from '@remirror/react-hooks';
 import { ExtensionEmojiTheme } from '@remirror/theme';
 
@@ -27,7 +26,6 @@ const emptyList: never[] = [];
  * This component renders the emoji suggestion dropdown for the user.
  */
 export const EmojiPopupComponent: FC = () => {
-  const { focus } = useCommands();
   const { state, getMenuProps, getItemProps, indexIsHovered, indexIsSelected } = useEmoji();
   const enabled = !!state;
 
@@ -49,10 +47,6 @@ export const EmojiPopupComponent: FC = () => {
                   isHovered && ExtensionEmojiTheme.EMOJI_POPUP_HOVERED,
                 )}
                 {...getItemProps({
-                  onClick: () => {
-                    state?.apply(emoji.emoji);
-                    focus();
-                  },
                   item: emoji,
                   index,
                 })}


### PR DESCRIPTION
### Description

Fix the situation where passing an array with zero items to `multishift` caused the editor to crash.

Fixes #971

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2021-06-19 14 10 02](https://user-images.githubusercontent.com/1160934/122643518-1f4cc300-d108-11eb-9979-ce5b4f9ee6e0.gif)

