### PR TITLE
fix(styles): hide cursor when `GapCursor` is visible

### DIFF
--- a/.changeset/modern-tables-chew.md
+++ b/.changeset/modern-tables-chew.md
@@ -1,0 +1,6 @@
+---
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Fix the styles copied from `prosemirror-view` for hiding the `text-cursor` when the `GapCursor` selection is active.

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -618,16 +618,16 @@ button:active .remirror-menu-pane-shortcut,
   caret-color: var(--rmr-color-selection-caret);
   text-shadow: var(--rmr-color-selection-shadow);
 }
-.remirror-editor .ProseMirror-hideselection *::-moz-selection {
+.remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }
-.remirror-editor .ProseMirror-hideselection *::selection {
+.remirror-editor.ProseMirror-hideselection *::selection {
   background: transparent;
 }
-.remirror-editor .ProseMirror-hideselection *::-moz-selection {
+.remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }
-.remirror-editor .ProseMirror-hideselection {
+.remirror-editor.ProseMirror-hideselection {
   caret-color: transparent;
 }
 .remirror-editor .ProseMirror-selectednode {

--- a/packages/remirror__styles/core.css
+++ b/packages/remirror__styles/core.css
@@ -45,16 +45,16 @@
   caret-color: var(--rmr-color-selection-caret);
   text-shadow: var(--rmr-color-selection-shadow);
 }
-.remirror-editor .ProseMirror-hideselection *::-moz-selection {
+.remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }
-.remirror-editor .ProseMirror-hideselection *::selection {
+.remirror-editor.ProseMirror-hideselection *::selection {
   background: transparent;
 }
-.remirror-editor .ProseMirror-hideselection *::-moz-selection {
+.remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }
-.remirror-editor .ProseMirror-hideselection {
+.remirror-editor.ProseMirror-hideselection {
   caret-color: transparent;
 }
 .remirror-editor .ProseMirror-selectednode {

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -629,16 +629,16 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     caret-color: var(--rmr-color-selection-caret);
     text-shadow: var(--rmr-color-selection-shadow);
   }
-  .remirror-editor .ProseMirror-hideselection *::-moz-selection {
+  .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection *::selection {
+  .remirror-editor.ProseMirror-hideselection *::selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection *::-moz-selection {
+  .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection {
+  .remirror-editor.ProseMirror-hideselection {
     caret-color: transparent;
   }
   .remirror-editor .ProseMirror-selectednode {

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -632,16 +632,16 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     caret-color: var(--rmr-color-selection-caret);
     text-shadow: var(--rmr-color-selection-shadow);
   }
-  .remirror-editor .ProseMirror-hideselection *::-moz-selection {
+  .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection *::selection {
+  .remirror-editor.ProseMirror-hideselection *::selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection *::-moz-selection {
+  .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection {
+  .remirror-editor.ProseMirror-hideselection {
     caret-color: transparent;
   }
   .remirror-editor .ProseMirror-selectednode {

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -631,16 +631,16 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     caret-color: var(--rmr-color-selection-caret);
     text-shadow: var(--rmr-color-selection-shadow);
   }
-  .remirror-editor .ProseMirror-hideselection *::-moz-selection {
+  .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection *::selection {
+  .remirror-editor.ProseMirror-hideselection *::selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection *::-moz-selection {
+  .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
-  .remirror-editor .ProseMirror-hideselection {
+  .remirror-editor.ProseMirror-hideselection {
     caret-color: transparent;
   }
   .remirror-editor .ProseMirror-selectednode {

--- a/packages/remirror__theme/src/core-theme.ts
+++ b/packages/remirror__theme/src/core-theme.ts
@@ -46,15 +46,15 @@ export const EDITOR = css`
     }
   }
 
-  .ProseMirror-hideselection *::selection {
+  &.ProseMirror-hideselection *::selection {
     background: transparent;
   }
 
-  .ProseMirror-hideselection *::-moz-selection {
+  &.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }
 
-  .ProseMirror-hideselection {
+  &.ProseMirror-hideselection {
     caret-color: transparent;
   }
 


### PR DESCRIPTION

### Description

Fix the styles copied from `prosemirror-view` for hiding the `text-cursor` when the `GapCursor` selection is active.

Fixes #961

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2021-06-20 12 35 25](https://user-images.githubusercontent.com/1160934/122672587-2802cf00-d1c4-11eb-9b58-e19d0a63704b.gif)
