### PR TITLE
fix(react-core): update `editable` when controlled

### DIFF
--- a/.changeset/dry-turkeys-run.md
+++ b/.changeset/dry-turkeys-run.md
@@ -1,0 +1,7 @@
+---
+'@remirror/react-core': major
+---
+
+Change `onUpdate` method signature in the `ReactFramework` class.
+
+This has been done to fix the update issues for controlled editors.

--- a/packages/remirror__react-core/__tests__/controlled.spec.tsx
+++ b/packages/remirror__react-core/__tests__/controlled.spec.tsx
@@ -80,6 +80,41 @@ describe('Remirror Controlled Component', () => {
     expect(chain.dom).toMatchSnapshot();
   });
 
+  it('updates with the editable prop', () => {
+    const chain = create();
+
+    const value = chain.manager.createState({
+      content: '<p>Not terrible</p>',
+    });
+    const onChange = jest.fn();
+
+    const { rerender } = strictRender(
+      <Remirror
+        {...props}
+        manager={chain.manager}
+        state={value}
+        onChange={onChange}
+        autoRender='start'
+        editable
+      />,
+    );
+
+    expect(chain.dom.getAttribute('contenteditable')).toBe('true');
+
+    rerender(
+      <Remirror
+        {...props}
+        manager={chain.manager}
+        state={value}
+        onChange={onChange}
+        autoRender='start'
+        editable={false}
+      />,
+    );
+
+    expect(chain.dom.getAttribute('contenteditable')).toBe('false');
+  });
+
   it('responds to updates to the editor state', () => {
     const chain = create();
 

--- a/packages/remirror__react-core/src/hooks/use-react-framework.tsx
+++ b/packages/remirror__react-core/src/hooks/use-react-framework.tsx
@@ -64,12 +64,10 @@ export function useReactFramework<Extension extends AnyExtension>(
     };
   }, [framework]);
 
-  const previousEditable = usePrevious(editable);
-
   // Handle editor updates
   useEffect(() => {
-    framework.onUpdate(previousEditable);
-  }, [previousEditable, framework]);
+    framework.onUpdate();
+  }, [editable, framework]);
 
   // Handle the controlled editor usage.
   useControlledEditor(framework);

--- a/packages/remirror__react-core/src/react-framework.tsx
+++ b/packages/remirror__react-core/src/react-framework.tsx
@@ -289,12 +289,12 @@ export class ReactFramework<Extension extends AnyExtension> extends Framework<
   /**
    * Called for every update of the props and state.
    */
-  onUpdate(previousEditable: boolean | undefined): void {
+  onUpdate(): void {
     // Ensure that `children` is still a render prop
     // propIsFunction(this.props.children);
 
     // Check whether the editable prop has been updated
-    if (this.props.editable !== previousEditable && this.view && this.#editorRef) {
+    if (this.view && this.#editorRef) {
       this.view.setProps({ ...this.view.props, editable: () => this.props.editable ?? true });
     }
   }

--- a/packages/remirror__react/__stories__/controlled.stories.tsx
+++ b/packages/remirror__react/__stories__/controlled.stories.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { BoldExtension, ItalicExtension, UnderlineExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+export default { title: 'Controlled Editor' };
+
+const extensions = () => [new BoldExtension({}), new ItalicExtension(), new UnderlineExtension()];
+
+export const Basic = (): JSX.Element => {
+  const { manager, state, onChange } = useRemirror({
+    extensions,
+    content: '<p><u>Hello</u> there <b>friend</b> and <em>partner</em>.</p>',
+    stringHandler: 'html',
+  });
+
+  const [editable, setEditable] = useState(true);
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} state={state} onChange={onChange} editable={editable} />
+      <button onClick={() => setEditable(!editable)}>
+        Toggle editable (currently {editable.toString()})
+      </button>
+    </ThemeProvider>
+  );
+};

--- a/packages/remirror__react/__stories__/tsconfig.json
+++ b/packages/remirror__react/__stories__/tsconfig.json
@@ -1,0 +1,83 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > '__stories__'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [],
+    "declaration": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove",
+    "paths": {
+      "react": [
+        "../../../node_modules/.pnpm/@types+react@17.0.5/node_modules/@types/react/index.d.ts"
+      ],
+      "react/jsx-dev-runtime": [
+        "../../../node_modules/.pnpm/@types+react@17.0.5/node_modules/@types/react/jsx-dev-runtime.d.ts"
+      ],
+      "react/jsx-runtime": [
+        "../../../node_modules/.pnpm/@types+react@17.0.5/node_modules/@types/react/jsx-runtime.d.ts"
+      ],
+      "react-dom": [
+        "../../../node_modules/.pnpm/@types+react-dom@17.0.5/node_modules/@types/react-dom/index.d.ts"
+      ],
+      "reakit": [
+        "../../../node_modules/.pnpm/reakit@1.3.8_react-dom@17.0.2+react@17.0.2/node_modules/reakit/ts/index.d.ts"
+      ],
+      "@remirror/react": ["../src/index.ts"],
+      "@storybook/react": [
+        "../../../node_modules/.pnpm/@storybook+react@6.2.9_ef2a1341ea5c49fb9984343923e18942/node_modules/@storybook/react/types-6-0.d.ts"
+      ],
+      "@remirror/dev": ["../../remirror__dev/src/index.ts"]
+    }
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../../testing/src"
+    },
+    {
+      "path": "../../remirror/src"
+    },
+    {
+      "path": "../../remirror__extension-placeholder/src"
+    },
+    {
+      "path": "../../remirror__extension-positioner/src"
+    },
+    {
+      "path": "../../remirror__extension-react-component/src"
+    },
+    {
+      "path": "../../remirror__extension-react-ssr/src"
+    },
+    {
+      "path": "../../remirror__extension-react-tables/src"
+    },
+    {
+      "path": "../../remirror__preset-react/src"
+    },
+    {
+      "path": "../../remirror__react-components/src"
+    },
+    {
+      "path": "../../remirror__react-core/src"
+    },
+    {
+      "path": "../../remirror__react-hooks/src"
+    },
+    {
+      "path": "../../remirror__react-renderer/src"
+    },
+    {
+      "path": "../../remirror__react-ssr/src"
+    },
+    {
+      "path": "../../remirror__react-utils/src"
+    }
+  ]
+}

--- a/support/root/tsconfig.json
+++ b/support/root/tsconfig.json
@@ -561,6 +561,9 @@
       "path": "packages/remirror__react-utils/src"
     },
     {
+      "path": "packages/remirror__react/__stories__"
+    },
+    {
       "path": "packages/remirror__react/src"
     },
     {


### PR DESCRIPTION
### Description

Fixes #913

Change `onUpdate` method signature in the `ReactFramework` class. This has been done to fix the update issues for controlled editors.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2021-06-21 06 12 09](https://user-images.githubusercontent.com/1160934/122710669-ad37c380-d258-11eb-83c5-d8b85dc27e56.gif)
