### PR TITLE
fix(paste-rules-plugin): support nested nodes

### DIFF
--- a/.changeset/clean-moose-love.md
+++ b/.changeset/clean-moose-love.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Add support for replacing the selection of nested nodes. This fixes the issue when pasting a link on text within a list.

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -88,8 +88,8 @@ export function pasteRules(pasteRules: PasteRule[]): Plugin<void> {
                 Fragment.fromArray([
                   textNode.mark([markType.create(attributes), ...textNode.marks]),
                 ]),
-                $pos.depth,
-                $pos.depth,
+                slice.openStart,
+                slice.openEnd,
               );
             }
           }

--- a/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
+++ b/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
@@ -1,4 +1,9 @@
-import { BulletListExtension, HeadingExtension, OrderedListExtension } from 'remirror/extensions';
+import {
+  BulletListExtension,
+  HeadingExtension,
+  LinkExtension,
+  OrderedListExtension,
+} from 'remirror/extensions';
 import { EditorComponent, Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 import { TaskListExtension } from '../src/task-list-extension';
@@ -7,7 +12,7 @@ export default { title: 'List Extension' };
 
 export const Basic = (): JSX.Element => {
   const { manager, state } = useRemirror({
-    extensions: extensions,
+    extensions,
     content,
     stringHandler: 'html',
   });
@@ -42,6 +47,7 @@ const extensions = () => [
   new OrderedListExtension(),
   new TaskListExtension(),
   new HeadingExtension(),
+  new LinkExtension(),
 ];
 
 const extensionsWithSpine = () => [


### PR DESCRIPTION

### Description

Add support for replacing the selection of nested nodes. This fixes the issue when pasting a link on text within a list.

Fixes #977

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![2021-06-21 19 00 16](https://user-images.githubusercontent.com/1160934/122807104-105e4000-d2c3-11eb-8edf-abf6f7b27c05.gif)