### PR TITLE
feat(extension-callout): add configurable emoji

### DIFF
--- a/.changeset/heavy-fishes-hammer.md
+++ b/.changeset/heavy-fishes-hammer.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-callout': minor
+'@remirror/styles': minor
+'@remirror/theme': minor
+---
+
+Added configurable emoji at the front of callout extension. Added a new type 'blank' to callout extension.

--- a/.changeset/heavy-fishes-hammer.md
+++ b/.changeset/heavy-fishes-hammer.md
@@ -4,4 +4,5 @@
 '@remirror/theme': minor
 ---
 
-Added configurable emoji at the front of callout extension. Added a new type 'blank' to callout extension.
+- Added configurable emoji to the start of the `CalloutExtension`.
+- Added a new type 'blank' to the `CalloutExtension`.

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -17,9 +17,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
-    # don't run this job from a fork repository
-    if: github.repository_owner == 'remirror'
-
     steps:
       - name: checkout code repository
         uses: actions/checkout@v2
@@ -55,7 +52,7 @@ jobs:
 
       - name: deploy storybook for pull request
         uses: amondnet/vercel-action@v20
-        if: github.ref != 'refs/heads/beta'
+        if: github.ref != 'refs/heads/beta' && github.event.pull_request.head.repo.full_name == github.repository # don't run this job from a fork repository
         with:
           working-directory: ./packages/storybook-react/storybook-static
           vercel-token: ${{ secrets.VERCEL_STORYBOOK_TOKEN }}

--- a/packages/remirror__extension-callout/__stories__/callout.stories.tsx
+++ b/packages/remirror__extension-callout/__stories__/callout.stories.tsx
@@ -1,15 +1,87 @@
 import 'remirror/styles/all.css';
 
-import React from 'react';
+import { EmojiButton } from '@joeattardi/emoji-button';
+import { Blobmoji } from '@svgmoji/blob';
+import React, { useCallback } from 'react';
 import { CalloutExtension } from 'remirror/extensions';
-import { htmlToProsemirrorNode } from '@remirror/core';
+import svgmojiData from 'svgmoji/emoji.json';
+import { EditorView, htmlToProsemirrorNode, ProsemirrorNode } from '@remirror/core';
+import { ProsemirrorDevTools } from '@remirror/dev';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 export default { title: 'Callouts' };
 
-const basicExtensions = () => [new CalloutExtension()];
+const renderDialogEmoji = (node: ProsemirrorNode, view: EditorView, getPos: () => number) => {
+  const { emoji: prevEmoji, type } = node.attrs;
+  const emoji = document.createElement('span');
+  emoji.textContent = prevEmoji;
 
-export const Basic: React.FC = () => {
+  const picker = new EmojiButton({
+    position: 'bottom',
+    autoFocusSearch: false,
+  });
+
+  /**
+   * Handle the selected emoji here
+   * Pass the new attributes to transaction to enable updating it from within the extension.
+   */
+  picker.on('emoji', (selection) => {
+    const transaction = view.state.tr.setNodeMarkup(getPos(), undefined, {
+      emoji: selection.emoji,
+      type,
+    });
+    view.dispatch(transaction);
+  });
+
+  emoji.addEventListener('click', (e) => {
+    e.preventDefault();
+    picker.togglePicker(emoji);
+  });
+
+  // Prevent ProseMirror from handling the `mousedown` event so that the cursor
+  // won't move when users click the emoji.
+  emoji.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+  });
+
+  return emoji;
+};
+
+const renderRandomEmoji = (node: ProsemirrorNode, view: EditorView, getPos: () => number) => {
+  const { emoji: emojiCode, type } = node.attrs;
+  const emoji = document.createElement('img');
+  emoji.style.height = '48px';
+  emoji.style.width = '48px';
+  const blobmoji = new Blobmoji({ data: svgmojiData, type: 'individual' });
+  emoji.src = blobmoji.url(emojiCode);
+
+  const choiceRandomEmoji = (currEmoji: string): string => {
+    const availableEmojis = ['😭', '😊', '🥰', '😂', '🙄', '😫', '🤔', '😌', '😍', '🤣'];
+    const nextEmoji = availableEmojis[Math.floor(Math.random() * availableEmojis.length)];
+    return currEmoji === nextEmoji ? choiceRandomEmoji(currEmoji) : nextEmoji!;
+  };
+
+  emoji.addEventListener('click', (e) => {
+    e.preventDefault();
+
+    const transaction = view.state.tr.setNodeMarkup(getPos(), undefined, {
+      emoji: choiceRandomEmoji(node.attrs.emoji),
+      type,
+    });
+    view.dispatch(transaction);
+  });
+
+  // Prevent ProseMirror from handle the `mousedown` event so that the cursor
+  // won't move when users click the emoji.
+  emoji.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+  });
+
+  return emoji;
+};
+
+export const Basic = (): JSX.Element => {
+  const basicExtensions = useCallback(() => [new CalloutExtension()], []);
   const { manager, state, onChange } = useRemirror({
     extensions: basicExtensions,
     content:
@@ -22,7 +94,58 @@ export const Basic: React.FC = () => {
 
   return (
     <ThemeProvider>
-      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end' />
+      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end'>
+        <ProsemirrorDevTools />
+      </Remirror>
+    </ThemeProvider>
+  );
+};
+
+Basic.args = {
+  autoLink: true,
+  openLinkOnClick: true,
+};
+
+export const WithEmojiPicker: React.FC = () => {
+  const basicExtensions = useCallback(
+    () => [new CalloutExtension({ renderEmoji: renderDialogEmoji, defaultEmoji: '💡' })],
+    [],
+  );
+  const { manager, state, onChange } = useRemirror({
+    extensions: basicExtensions,
+    content:
+      '<div data-callout-type="blank" data-callout-emoji="💡"><p>Blank callout</p></div><p />' +
+      '<div data-callout-type="warning" data-callout-emoji="💡"><p>Click the emoji to open a emoji picker.</p></div><p />' +
+      '<div data-callout-type="success" data-callout-emoji="💡"><p>Powered by https://www.npmjs.com/package/@joeattardi/emoji-button</p></div>',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end'>
+        <ProsemirrorDevTools />
+      </Remirror>
+    </ThemeProvider>
+  );
+};
+
+export const WithRandomEmoji: React.FC = () => {
+  const basicExtensions = useCallback(
+    () => [new CalloutExtension({ renderEmoji: renderRandomEmoji, defaultEmoji: '💡' })],
+    [],
+  );
+  const { manager, state, onChange } = useRemirror({
+    extensions: basicExtensions,
+    content:
+      '<div data-callout-type data-callout-emoji="💡"><p>Click the emoji to get a new random emoji.</p><p> Powered by https://github.com/svgmoji/svgmoji</p></div>',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end'>
+        <ProsemirrorDevTools />
+      </Remirror>
     </ThemeProvider>
   );
 };

--- a/packages/remirror__extension-callout/package.json
+++ b/packages/remirror__extension-callout/package.json
@@ -37,10 +37,14 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "1.0.0-next.60",
-    "@remirror/messages": "0.0.0"
+    "@remirror/messages": "0.0.0",
+    "@remirror/theme": "1.0.0-next.60"
   },
   "devDependencies": {
-    "@remirror/pm": "1.0.0-next.60"
+    "@joeattardi/emoji-button": "^4.6.0",
+    "@remirror/pm": "1.0.0-next.60",
+    "@svgmoji/blob": "^3.1.0",
+    "svgmoji": "^3.1.0"
   },
   "peerDependencies": {
     "@remirror/pm": "1.0.0-next.60"

--- a/packages/remirror__extension-callout/readme.md
+++ b/packages/remirror__extension-callout/readme.md
@@ -34,3 +34,21 @@ import { CalloutExtension } from '@remirror/extension-callout';
 
 const extension = new CalloutExtension();
 ```
+
+To render a emoji at the front.
+
+```ts
+import { CalloutExtension } from '@remirror/extension-callout';
+
+const basicExtensions = () => [new CalloutExtension({ renderEmoji, defaultEmoji: '💡' })];
+
+/**
+ *  If you want to update the emoji to a new one,
+ * you can dispatch a transaction to update the `emoji` attrs inside this function.
+ */
+const renderEmoji = (node: ProsemirrorNode) => {
+  const emoji = document.createElement('span');
+  emoji.textContent = node.attrs.emoji;
+  return emoji;
+};
+```

--- a/packages/remirror__extension-callout/src/callout-types.ts
+++ b/packages/remirror__extension-callout/src/callout-types.ts
@@ -1,4 +1,5 @@
-import type { LiteralUnion, ProsemirrorAttributes, Static } from '@remirror/core';
+import type { LiteralUnion, ProsemirrorAttributes, ProsemirrorNode, Static } from '@remirror/core';
+import { EditorView } from '@remirror/pm/view';
 
 /**
  * Options available to the [[`CalloutExtension`]].
@@ -16,9 +17,22 @@ export interface CalloutOptions {
   /**
    * The valid types for the callout node.
    *
-   * @default ['info', 'warning' , 'error' , 'success']
+   * @default ['info', 'warning' , 'error' , 'success', 'blank']
    */
   validTypes?: Static<string[]>;
+
+  /**
+   * The default emoji passed to attrsibute when none is provided.
+   *
+   * @default ''
+   */
+  defaultEmoji?: Static<string>;
+
+  /**
+   * The function passed into `calloutExtension` to render the emoji at the front.
+   *
+   */
+  renderEmoji?: (node: ProsemirrorNode, view: EditorView, getPos: () => number) => HTMLElement;
 }
 
 export interface CalloutAttributes extends ProsemirrorAttributes {
@@ -27,5 +41,5 @@ export interface CalloutAttributes extends ProsemirrorAttributes {
    *
    * @default 'info'
    */
-  type?: LiteralUnion<'info' | 'warning' | 'error' | 'success', string>;
+  type?: LiteralUnion<'info' | 'warning' | 'error' | 'success' | 'blank', string>;
 }

--- a/packages/remirror__extension-callout/src/callout-utils.ts
+++ b/packages/remirror__extension-callout/src/callout-utils.ts
@@ -7,12 +7,15 @@ import {
   isString,
   NodeType,
   ProsemirrorAttributes,
+  ProsemirrorNode,
 } from '@remirror/core';
 import { ExtensionCalloutMessages } from '@remirror/messages';
 
 import type { CalloutAttributes } from './callout-types';
 
 export const dataAttributeType = 'data-callout-type';
+
+export const dataAttributeEmoji = 'data-callout-emoji';
 
 /**
  * Check that the attributes exist and are valid for the codeBlock
@@ -86,4 +89,13 @@ export function getCalloutType(
   defaultType: string,
 ): string {
   return includes(validTypes, value) ? value : defaultType;
+}
+
+/**
+ * The default emoji render function.
+ */
+export function defaultEmojiRender(node: ProsemirrorNode): HTMLElement {
+  const emoji = document.createElement('span');
+  emoji.textContent = node.attrs.emoji;
+  return emoji;
 }

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -666,10 +666,20 @@ button:active .remirror-menu-pane-shortcut,
  * Styles extracted from: packages/remirror__theme/src/extension-callout-theme.ts
  */
 .remirror-editor div[data-callout-type] {
-  border-left: 2px solid transparent;
+  display: flex;
   margin-left: 0;
   margin-right: 0;
-  padding-left: 10px;
+  padding: 10px;
+  border-left: 2px solid transparent;
+}
+
+.remirror-editor div[data-callout-type] > .remirror-callout-emoji-wrapper {
+  min-width: 20px;
+  cursor: pointer;
+}
+
+.remirror-editor div[data-callout-type] > :not(.remirror-callout-emoji-wrapper) {
+  margin-left: 8px;
 }
 .remirror-editor div[data-callout-type='info'] {
   background: #eef6fc;
@@ -686,6 +696,9 @@ button:active .remirror-menu-pane-shortcut,
 .remirror-editor div[data-callout-type='success'] {
   background: #effaf3;
   border-left-color: #48c774;
+}
+.remirror-editor div[data-callout-type='blank'] {
+  background: #f8f8f8;
 }
 
 /**

--- a/packages/remirror__styles/extension-callout.css
+++ b/packages/remirror__styles/extension-callout.css
@@ -2,10 +2,20 @@
  * Styles extracted from: packages/remirror__theme/src/extension-callout-theme.ts
  */
 .remirror-editor div[data-callout-type] {
-  border-left: 2px solid transparent;
+  display: flex;
   margin-left: 0;
   margin-right: 0;
-  padding-left: 10px;
+  padding: 10px;
+  border-left: 2px solid transparent;
+}
+
+.remirror-editor div[data-callout-type] > .remirror-callout-emoji-wrapper {
+  min-width: 20px;
+  cursor: pointer;
+}
+
+.remirror-editor div[data-callout-type] > :not(.remirror-callout-emoji-wrapper) {
+  margin-left: 8px;
 }
 .remirror-editor div[data-callout-type='info'] {
   background: #eef6fc;
@@ -22,4 +32,7 @@
 .remirror-editor div[data-callout-type='success'] {
   background: #effaf3;
   border-left-color: #48c774;
+}
+.remirror-editor div[data-callout-type='blank'] {
+  background: #f8f8f8;
 }

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -681,10 +681,20 @@ export const extensionCalloutStyledCss: ReturnType<typeof css> = css`
  * Styles extracted from: packages/remirror__theme/src/extension-callout-theme.ts
  */
   .remirror-editor div[data-callout-type] {
-    border-left: 2px solid transparent;
+    display: flex;
     margin-left: 0;
     margin-right: 0;
-    padding-left: 10px;
+    padding: 10px;
+    border-left: 2px solid transparent;
+  }
+
+  .remirror-editor div[data-callout-type] > .remirror-callout-emoji-wrapper {
+    min-width: 20px;
+    cursor: pointer;
+  }
+
+  .remirror-editor div[data-callout-type] > :not(.remirror-callout-emoji-wrapper) {
+    margin-left: 8px;
   }
   .remirror-editor div[data-callout-type='info'] {
     background: #eef6fc;
@@ -701,6 +711,9 @@ export const extensionCalloutStyledCss: ReturnType<typeof css> = css`
   .remirror-editor div[data-callout-type='success'] {
     background: #effaf3;
     border-left-color: #48c774;
+  }
+  .remirror-editor div[data-callout-type='blank'] {
+    background: #f8f8f8;
   }
 `;
 

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -692,10 +692,20 @@ export const extensionCalloutStyledCss: ReturnType<typeof css> = css`
  * Styles extracted from: packages/remirror__theme/src/extension-callout-theme.ts
  */
   .remirror-editor div[data-callout-type] {
-    border-left: 2px solid transparent;
+    display: flex;
     margin-left: 0;
     margin-right: 0;
-    padding-left: 10px;
+    padding: 10px;
+    border-left: 2px solid transparent;
+  }
+
+  .remirror-editor div[data-callout-type] > .remirror-callout-emoji-wrapper {
+    min-width: 20px;
+    cursor: pointer;
+  }
+
+  .remirror-editor div[data-callout-type] > :not(.remirror-callout-emoji-wrapper) {
+    margin-left: 8px;
   }
   .remirror-editor div[data-callout-type='info'] {
     background: #eef6fc;
@@ -712,6 +722,9 @@ export const extensionCalloutStyledCss: ReturnType<typeof css> = css`
   .remirror-editor div[data-callout-type='success'] {
     background: #effaf3;
     border-left-color: #48c774;
+  }
+  .remirror-editor div[data-callout-type='blank'] {
+    background: #f8f8f8;
   }
 `;
 

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -691,10 +691,20 @@ export const extensionCalloutStyledCss: ReturnType<typeof css> = css`
  * Styles extracted from: packages/remirror__theme/src/extension-callout-theme.ts
  */
   .remirror-editor div[data-callout-type] {
-    border-left: 2px solid transparent;
+    display: flex;
     margin-left: 0;
     margin-right: 0;
-    padding-left: 10px;
+    padding: 10px;
+    border-left: 2px solid transparent;
+  }
+
+  .remirror-editor div[data-callout-type] > .remirror-callout-emoji-wrapper {
+    min-width: 20px;
+    cursor: pointer;
+  }
+
+  .remirror-editor div[data-callout-type] > :not(.remirror-callout-emoji-wrapper) {
+    margin-left: 8px;
   }
   .remirror-editor div[data-callout-type='info'] {
     background: #eef6fc;
@@ -711,6 +721,9 @@ export const extensionCalloutStyledCss: ReturnType<typeof css> = css`
   .remirror-editor div[data-callout-type='success'] {
     background: #effaf3;
     border-left-color: #48c774;
+  }
+  .remirror-editor div[data-callout-type='blank'] {
+    background: #f8f8f8;
   }
 `;
 

--- a/packages/remirror__theme/src/extension-callout-theme.ts
+++ b/packages/remirror__theme/src/extension-callout-theme.ts
@@ -5,12 +5,25 @@ import { css } from '@linaria/core';
  * automatically generated and placed into the `@remirror/styles/core.css` via
  * a `linaria` build script.
  */
+
+export const CALLOUT_EMOJI_WRAPPER = 'remirror-callout-emoji-wrapper';
+
 export const EDITOR = css`
   div[data-callout-type] {
-    border-left: 2px solid transparent;
+    display: flex;
     margin-left: 0;
     margin-right: 0;
-    padding-left: 10px;
+    padding: 10px;
+    border-left: 2px solid transparent;
+
+    & > .${CALLOUT_EMOJI_WRAPPER} {
+      min-width: 20px;
+      cursor: pointer;
+    }
+
+    & > :not(.${CALLOUT_EMOJI_WRAPPER}) {
+      margin-left: 8px;
+    }
   }
 
   div[data-callout-type='info'] {
@@ -31,5 +44,9 @@ export const EDITOR = css`
   div[data-callout-type='success'] {
     background: #effaf3;
     border-left-color: #48c774;
+  }
+
+  div[data-callout-type='blank'] {
+    background: #f8f8f8;
   }
 ` as 'remirror-editor';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1079,8 +1079,8 @@ importers:
       '@remirror/messages': 0.0.0
       '@remirror/pm': 1.0.0-next.60
       '@remirror/theme': 1.0.0-next.60
-      '@svgmoji/blob': ^3.2.0
-      svgmoji: ^3.2.0
+      '@svgmoji/blob': ^3.1.0
+      svgmoji: ^3.1.0
     dependencies:
       '@babel/runtime': 7.14.0
       '@remirror/core': link:../remirror__core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,15 +1074,23 @@ importers:
   packages/remirror__extension-callout:
     specifiers:
       '@babel/runtime': ^7.13.10
+      '@joeattardi/emoji-button': ^4.6.0
       '@remirror/core': 1.0.0-next.60
       '@remirror/messages': 0.0.0
       '@remirror/pm': 1.0.0-next.60
+      '@remirror/theme': 1.0.0-next.60
+      '@svgmoji/blob': ^3.2.0
+      svgmoji: ^3.2.0
     dependencies:
       '@babel/runtime': 7.14.0
       '@remirror/core': link:../remirror__core
       '@remirror/messages': link:../remirror__messages
+      '@remirror/theme': link:../remirror__theme
     devDependencies:
+      '@joeattardi/emoji-button': 4.6.0
       '@remirror/pm': link:../remirror__pm
+      '@svgmoji/blob': 3.2.0
+      svgmoji: 3.2.0
 
   packages/remirror__extension-code:
     specifiers:
@@ -5936,6 +5944,36 @@ packages:
     resolution: {integrity: sha512-cT2jQpooHBPDVaVuGxRdO8L6Nnd8ucbOGPOaGFgMpm7Cyzh9Psi0ay8tiEJXIWNV7+k0ycbn8OT/HA1J8xK9lQ==}
     dev: false
 
+  /@fortawesome/fontawesome-common-types/0.2.35:
+    resolution: {integrity: sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dev: true
+
+  /@fortawesome/fontawesome-svg-core/1.2.35:
+    resolution: {integrity: sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 0.2.35
+    dev: true
+
+  /@fortawesome/free-regular-svg-icons/5.15.3:
+    resolution: {integrity: sha512-q4/p8Xehy9qiVTdDWHL4Z+o5PCLRChePGZRTXkl+/Z7erDVL8VcZUuqzJjs6gUz6czss4VIPBRdCz6wP37/zMQ==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 0.2.35
+    dev: true
+
+  /@fortawesome/free-solid-svg-icons/5.15.3:
+    resolution: {integrity: sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 0.2.35
+    dev: true
+
   /@graphql-tools/batch-execute/7.1.2:
     resolution: {integrity: sha512-IuR2SB2MnC2ztA/XeTMTfWcA0Wy7ZH5u+nDkDNLAdX+AaSyDnsQS35sCmHqG0VOGTl7rzoyBWLCKGwSJplgtwg==}
     peerDependencies:
@@ -6492,6 +6530,21 @@ packages:
     dependencies:
       '@babel/runtime': 7.14.0
       regenerator-runtime: 0.13.7
+    dev: true
+
+  /@joeattardi/emoji-button/4.6.0:
+    resolution: {integrity: sha512-KwOE1j+YxX47JmT0pXNCa+9Ai4Wf2fmABtvuxy6JBJ5QV0HdoThRKjL6CxAreVwwLbNQ/PDoR36xpc5QJjLXPA==}
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 1.2.35
+      '@fortawesome/free-regular-svg-icons': 5.15.3
+      '@fortawesome/free-solid-svg-icons': 5.15.3
+      '@popperjs/core': 2.9.2
+      '@types/twemoji': 12.1.1
+      focus-trap: 5.1.0
+      fuzzysort: 1.1.4
+      tiny-emitter: 2.1.0
+      tslib: 2.3.0
+      twemoji: 13.1.0
     dev: true
 
   /@kyleshevlin/eslint-plugin/1.3.0_eslint@7.26.0:
@@ -7205,7 +7258,6 @@ packages:
 
   /@popperjs/core/2.9.2:
     resolution: {integrity: sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==}
-    dev: false
 
   /@preconstruct/cli/2.1.0:
     resolution: {integrity: sha512-FfyWlZbinuv3be7yss8p9Yq87V88XKa6XUskeRSFDKgcgH1FwtTg9xYrEJm7j5QV4KThiQfPqoUN4m7hLxWlHg==}
@@ -8567,6 +8619,13 @@ packages:
       '@babel/runtime': 7.14.0
       '@svgmoji/core': 3.1.0
 
+  /@svgmoji/blob/3.2.0:
+    resolution: {integrity: sha512-N96WOrH9GxPSPZ/FuvZl6T9Rh54stAEuUcBppIRFh9/WwkU7Hczrjabw4uunwxFLX5TgR+rHlKJl3/jaTnXJrQ==}
+    dependencies:
+      '@babel/runtime': 7.14.0
+      '@svgmoji/core': 3.2.0
+    dev: true
+
   /@svgmoji/core/3.1.0:
     resolution: {integrity: sha512-iztEW4uyavGbmd2/iKw+t2uc+53HLlkuJ2BAtEXhf1eCoY48+Ah4DvIzIIr1bcqr+fXrCQPG0o6AxjeceqB3Xg==}
     dependencies:
@@ -8577,11 +8636,29 @@ packages:
       match-sorter: 6.3.0
       type-fest: 0.21.3
 
+  /@svgmoji/core/3.2.0:
+    resolution: {integrity: sha512-QsD78Op3S/5kUVsa5ierr4Wu/xwAdYuMI3Zmc/Y2ekYBEMGEUY8QxilXQRSAQ4ku4PnNV4xlB9e7xhD5hy113A==}
+    dependencies:
+      '@babel/runtime': 7.14.0
+      emojibase: 5.2.0
+      emojibase-regex: 5.1.3
+      idb-keyval: 5.0.5
+      match-sorter: 6.3.0
+      type-fest: 1.2.1
+    dev: true
+
   /@svgmoji/noto/3.1.0:
     resolution: {integrity: sha512-Xc2cJ7gqHkEpWk6m7zLjP2pKcYxNdQxjPmkPFMLrZfYQnzpteEgyiKXNfLidwqgY0shz6+MxIa8gWHdLVKwAEA==}
     dependencies:
       '@babel/runtime': 7.14.0
       '@svgmoji/core': 3.1.0
+
+  /@svgmoji/noto/3.2.0:
+    resolution: {integrity: sha512-JgtNciB06hMDI1Pb1N2IgLh44XRMZUUNwBANzjY5jXTPqOCu1A1VA35ENvUsRhEUZOm8I+hbdAEHkwMVqxLeIQ==}
+    dependencies:
+      '@babel/runtime': 7.14.0
+      '@svgmoji/core': 3.2.0
+    dev: true
 
   /@svgmoji/openmoji/3.1.0:
     resolution: {integrity: sha512-8FpVItrNhQKWYlUJReVbpmSKOpLBdkLpk2c/GHp1ynMZNeyV16GGL2NaUOqj2Nhp3Qgqb7datmGNHIun/tQEaw==}
@@ -8589,11 +8666,25 @@ packages:
       '@babel/runtime': 7.14.0
       '@svgmoji/core': 3.1.0
 
+  /@svgmoji/openmoji/3.2.0:
+    resolution: {integrity: sha512-USHbG+O80HfmdoNAHbOnlO+2gppXJfHFWKSRFj53Th4aimWEx4/9MB3cFbC3KZ1NOqXaLBq9jDaw4vFuGDVTUQ==}
+    dependencies:
+      '@babel/runtime': 7.14.0
+      '@svgmoji/core': 3.2.0
+    dev: true
+
   /@svgmoji/twemoji/3.1.0:
     resolution: {integrity: sha512-7xbBE/7Hkr8oOuWIAP4WoP2ZjocOcO9aOIvr7ffKMVJ+exVUtIH5aE3h+4unZo92dzLkugmfEH9TAuwQO42cPQ==}
     dependencies:
       '@babel/runtime': 7.14.0
       '@svgmoji/core': 3.1.0
+
+  /@svgmoji/twemoji/3.2.0:
+    resolution: {integrity: sha512-6xqZgh9viFDKf5wvrxw56ImCR3Ni84IqwK45lxojOe1Gc1Mni1GpPfr4gb7WHDKjumfx+K7BHSvX0KXt3Nr3CQ==}
+    dependencies:
+      '@babel/runtime': 7.14.0
+      '@svgmoji/core': 3.2.0
+    dev: true
 
   /@svgr/babel-plugin-add-jsx-attribute/5.4.0:
     resolution: {integrity: sha512-ZFf2gs/8/6B8PnSofI0inYXr2SDNTDScPXhN7k5EqD4aZ3gi6u+rbmZHVB8IM3wDyx8ntKACZbtXSm7oZGRqVg==}
@@ -9629,6 +9720,10 @@ packages:
   /@types/turndown/5.0.0:
     resolution: {integrity: sha512-Y7KZn6SfSv1vzjByJGijrM9w99HoUbLiAgYwe+sGH6RYi5diIGLYOcr4Z1YqR2biFs9K5PnxKv/Fbkmh57pvzg==}
     dev: false
+
+  /@types/twemoji/12.1.1:
+    resolution: {integrity: sha512-dW1B1WHTfrWmEzXb/tp8xsZqQHAyMB9JwLwbBqkIQVzmNUI02R7lJqxUpKFM114ygNZHKA1r74oPugCAiYHt1A==}
+    dev: true
 
   /@types/ua-parser-js/0.7.36:
     resolution: {integrity: sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==}
@@ -16105,6 +16200,13 @@ packages:
       react: 17.0.2
     dev: true
 
+  /focus-trap/5.1.0:
+    resolution: {integrity: sha512-CkB/nrO55069QAUjWFBpX6oc+9V90Qhgpe6fBWApzruMq5gnlh90Oo7iSSDK7pKiV5ugG6OY2AXM5mxcmL3lwQ==}
+    dependencies:
+      tabbable: 4.0.0
+      xtend: 4.0.2
+    dev: true
+
   /follow-redirects/1.14.1:
     resolution: {integrity: sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==}
     engines: {node: '>=4.0'}
@@ -16424,6 +16526,10 @@ packages:
   /fuzzaldrin/2.1.0:
     resolution: {integrity: sha1-kCBMPi/appQbso0WZF1BgGOpDps=}
     dev: false
+
+  /fuzzysort/1.1.4:
+    resolution: {integrity: sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ==}
+    dev: true
 
   /gauge/2.7.4:
     resolution: {integrity: sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=}
@@ -19604,6 +19710,14 @@ packages:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
       graceful-fs: 4.2.6
+
+  /jsonfile/5.0.0:
+    resolution: {integrity: sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==}
+    dependencies:
+      universalify: 0.1.2
+    optionalDependencies:
+      graceful-fs: 4.2.6
+    dev: true
 
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -27869,6 +27983,17 @@ packages:
       '@svgmoji/openmoji': 3.1.0
       '@svgmoji/twemoji': 3.1.0
 
+  /svgmoji/3.2.0:
+    resolution: {integrity: sha512-tjmdQhIju2ZQ81FLBlPngg1aWMOhQjP9ErXb2ROikM0aBGA/hqI0/DN/5J0sDsXzJPHmODpSFhWfiSsUieU3bA==}
+    dependencies:
+      '@babel/runtime': 7.14.0
+      '@svgmoji/blob': 3.2.0
+      '@svgmoji/core': 3.2.0
+      '@svgmoji/noto': 3.2.0
+      '@svgmoji/openmoji': 3.2.0
+      '@svgmoji/twemoji': 3.2.0
+    dev: true
+
   /svgo/1.3.2:
     resolution: {integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==}
     engines: {node: '>=4.0.0'}
@@ -27927,6 +28052,10 @@ packages:
       buffer: 5.7.1
       node-fetch: 2.6.1
     dev: false
+
+  /tabbable/4.0.0:
+    resolution: {integrity: sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==}
+    dev: true
 
   /table/6.7.1:
     resolution: {integrity: sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==}
@@ -28197,7 +28326,6 @@ packages:
 
   /tiny-emitter/2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
-    optional: true
 
   /tiny-invariant/1.1.0:
     resolution: {integrity: sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==}
@@ -28437,6 +28565,10 @@ packages:
   /tslib/2.2.0:
     resolution: {integrity: sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==}
 
+  /tslib/2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+    dev: true
+
   /tslog/3.2.0:
     resolution: {integrity: sha512-xOCghepl5w+wcI4qXI7vJy6c53loF8OoC/EuKz1ktAPMtltEDz00yo1poKuyBYIQaq4ZDYKYFPD9PfqVrFXh0A==}
     engines: {node: '>=10'}
@@ -28512,6 +28644,19 @@ packages:
   /tweetnacl/0.14.5:
     resolution: {integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=}
 
+  /twemoji-parser/13.1.0:
+    resolution: {integrity: sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg==}
+    dev: true
+
+  /twemoji/13.1.0:
+    resolution: {integrity: sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==}
+    dependencies:
+      fs-extra: 8.1.0
+      jsonfile: 5.0.0
+      twemoji-parser: 13.1.0
+      universalify: 0.1.2
+    dev: true
+
   /typanion/3.3.1:
     resolution: {integrity: sha512-VogBiMj3ZQuWaHkbhXwSgd9jXE4s7EMaaV7VSEiKTNYnKJs/bPjvcOGbD7rTM9aPqTABvgLVEZ+iFP6ab12HtQ==}
     dev: false
@@ -28581,6 +28726,11 @@ packages:
     resolution: {integrity: sha512-RPDKc5KrIyKTP7Fk75LruUagqG6b+OTgXlCR2Z0aQDJFeIvL4/mhahSEtHmmVzXu4gmA0srkF/8FCH3WOWxTWA==}
     engines: {node: '>=10'}
     dev: false
+
+  /type-fest/1.2.1:
+    resolution: {integrity: sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==}
+    engines: {node: '>=10'}
+    dev: true
 
   /type-is/1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -189,7 +189,7 @@
   },
   {
     "name": "@remirror/extension-callout",
-    "limit": "5 KB",
+    "limit": "15 KB",
     "path": "packages/remirror__extension-callout/dist/remirror-extension-callout.browser.esm.js",
     "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,


### PR DESCRIPTION
### Description

Added configurable emoji to callouts. 

Added a new type: `blank`, so users are able to use a neutral background when they use the emoji as a semantic marker.

Fixes #871

### Checklist


- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots


https://user-images.githubusercontent.com/16329365/123252988-7f37d500-d51f-11eb-9c7c-90eea5e607d2.mov


https://user-images.githubusercontent.com/24715727/123256602-bc05cb00-d523-11eb-8989-e11af894c3c4.mov



I truly appreciate @ocavue 's patient guidance, helping me dive right in the remirror project and have a better understanding of how it works.
