### PR TITLE
ci: fix the storybook workflow on the beta branch

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # don't run this job from a fork repository
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository_owner == 'remirror'
 
     steps:
       - name: checkout code repository


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Just found that the storybook deployment for the `beta` branch (https://remirror.vercel.app/) haven't been triggered since 2021-04-22. This PR fixed this workflow.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 