### PR TITLE
fix: create a newline in the current paragraph

### DIFF
--- a/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
+++ b/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
@@ -49,6 +49,10 @@ const extensions = () => [
   new TaskListExtension(),
   new HeadingExtension(),
   new LinkExtension(),
+  /**
+   * `HardBreakExtension` allows us to create a newline inside paragraphs .
+   *  e.g. in a list item
+   */
   new HardBreakExtension(),
 ];
 

--- a/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
+++ b/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
@@ -1,5 +1,6 @@
 import {
   BulletListExtension,
+  HardBreakExtension,
   HeadingExtension,
   LinkExtension,
   OrderedListExtension,
@@ -48,6 +49,7 @@ const extensions = () => [
   new TaskListExtension(),
   new HeadingExtension(),
   new LinkExtension(),
+  new HardBreakExtension(),
 ];
 
 const extensionsWithSpine = () => [
@@ -55,6 +57,7 @@ const extensionsWithSpine = () => [
   new OrderedListExtension(),
   new TaskListExtension(),
   new HeadingExtension(),
+  new HardBreakExtension(),
 ];
 
 const html = String.raw; // Just for better editor support

--- a/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
+++ b/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
@@ -211,6 +211,10 @@ const extensions = () => [
   new TrailingNodeExtension(),
   new TableExtension(),
   new MarkdownExtension({ copyAsMarkdown: false }),
+  /**
+   * `HardBreakExtension` allows us to create a newline inside paragraphs.
+   * e.g. in a list item
+   */
   new HardBreakExtension(),
 ];
 

--- a/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
+++ b/packages/remirror__react-editors/__stories__/markdown-editor.stories.tsx
@@ -13,6 +13,7 @@ import {
   CodeBlockExtension,
   CodeExtension,
   DocExtension,
+  HardBreakExtension,
   HeadingExtension,
   ItalicExtension,
   LinkExtension,
@@ -210,6 +211,7 @@ const extensions = () => [
   new TrailingNodeExtension(),
   new TableExtension(),
   new MarkdownExtension({ copyAsMarkdown: false }),
+  new HardBreakExtension(),
 ];
 
 const toolbarItems: ToolbarItemUnion[] = [


### PR DESCRIPTION
### Description

`HardBreakExtension` gives paragraphs the ability to add a `<br/>`  inside itself by pressing `Shift + Enter` or `Mod + Enter`.
 resolves #896 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/16329365/123671696-25ae0e00-d871-11eb-9f1a-cb4d0363c8d9.mov

https://user-images.githubusercontent.com/16329365/123671657-19c24c00-d871-11eb-9bd1-04a9d2fee254.mov



