### PR TITLE
feat(extension-list): turn a list item into a task list item

### DIFF
--- a/.changeset/early-pigs-pretend.md
+++ b/.changeset/early-pigs-pretend.md
@@ -2,5 +2,5 @@
 '@remirror/extension-list': minor
 ---
 
-- Add a new input rule to `TaskListItemExtension`. When a user types `[]`, `[ ]`, `[x]` or `[X]` at the beginning of a `listItem` node, the editor will turn this node into a `taskListItem` node and do some other necessary transforms.
+- Add a new input rule to `TaskListItemExtension`. When a user types `[]`, `[ ]`, `[x]` or `[X]` at the beginning of a `listItem` node, the editor will turn this node into a `taskListItem` node and also do some necessary transforms.
 - Add a new command `liftListItemOutOfList` to `ListItemExtension`, which can lift the content inside a list item out of list.

--- a/.changeset/early-pigs-pretend.md
+++ b/.changeset/early-pigs-pretend.md
@@ -2,5 +2,5 @@
 '@remirror/extension-list': minor
 ---
 
-- Add a new input rule to `TaskListItemExtension`. When a user types `[]`, `[ ]`, `[x]` or `[X]` at the begin of a list item, the editor will turn this list item into a task list item and do other some necessary transforms.
+- Add a new input rule to `TaskListItemExtension`. When a user types `[]`, `[ ]`, `[x]` or `[X]` at the beginning of a `listItem` node, the editor will turn this node into a `taskListItem` node and do some other necessary transforms.
 - Add a new command `liftListItemOutOfList` to `ListItemExtension`, which can lift the content inside a list item out of list.

--- a/.changeset/early-pigs-pretend.md
+++ b/.changeset/early-pigs-pretend.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-list': minor
+---
+
+- Add a new input rule to `TaskListItemExtension`. When a user types `[]`, `[ ]`, `[x]` or `[X]` at the begin of a list item, the editor will turn this list item into a task list item and do other some necessary transforms.
+- Add a new command `liftListItemOutOfList` to `ListItemExtension`, which can lift the content inside a list item out of list.

--- a/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
@@ -1,0 +1,95 @@
+import { createEditor, doc, li, ol, p, schema, ul } from 'jest-prosemirror';
+import { renderEditor } from 'jest-remirror';
+import {
+  BulletListExtension,
+  ListItemExtension,
+  OrderedListExtension,
+  TaskListExtension,
+  toggleList,
+} from 'remirror/extensions';
+
+describe('create a list', () => {
+  const editor = renderEditor([
+    new BulletListExtension({}),
+    new ListItemExtension({}),
+    new OrderedListExtension(),
+    new TaskListExtension(),
+  ]);
+
+  const {
+    nodes: { bulletList, taskList, listItem, doc, p },
+    attributeNodes: { taskListItem, orderedList },
+  } = editor;
+
+  const uncheckedItem = taskListItem({ checked: false });
+  const checkedItem = taskListItem({ checked: true });
+
+  it('creates a bulletList', () => {
+    editor.add(doc(p(''))).insertText('- ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(bulletList(listItem(p('')))));
+
+    editor.add(doc(p(''))).insertText('+ ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(bulletList(listItem(p('')))));
+
+    editor.add(doc(p(''))).insertText('* ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(bulletList(listItem(p('')))));
+  });
+
+  it('creates an orderedList', () => {
+    editor.add(doc(p(''))).insertText('1. ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(orderedList({ order: 1 })(listItem(p('')))));
+
+    editor.add(doc(p(''))).insertText('999. ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(orderedList({ order: 999 })(listItem(p('')))));
+  });
+
+  it('creates a taskList', () => {
+    editor.add(doc(p(''))).insertText('[] ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(taskList(uncheckedItem(p('')))));
+
+    editor.add(doc(p(''))).insertText('[ ] ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(taskList(uncheckedItem(p('')))));
+
+    editor.add(doc(p(''))).insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(taskList(checkedItem(p('')))));
+
+    editor.add(doc(p(''))).insertText('[X] ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(taskList(checkedItem(p('')))));
+  });
+
+  it('creates a taskList in a bulletListItem', () => {
+    editor.add(
+      doc(
+        bulletList(
+          listItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('[ ] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        taskList(
+          uncheckedItem(p('')), //
+        ),
+      ),
+    );
+  });
+
+  it('creates a taskList in an ordered ListItem', () => {
+    editor.add(
+      doc(
+        orderedList({ order: 1 })(
+          listItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        taskList(
+          checkedItem(p('')), //
+        ),
+      ),
+    );
+  });
+});

--- a/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
@@ -92,4 +92,210 @@ describe('create a list', () => {
       ),
     );
   });
+
+  it('creates a taskList in a multi-items list', () => {
+    editor.add(
+      doc(
+        bulletList(
+          listItem(p('123')),
+          listItem(p('456')),
+          listItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(p('123')), //
+          listItem(p('456')), //
+        ),
+        taskList(
+          checkedItem(p('')), //
+        ),
+      ),
+    );
+
+    editor.add(
+      doc(
+        bulletList(
+          listItem(p('123')),
+          listItem(p('<cursor>')), //
+          listItem(p('789')),
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(p('123')), //
+        ),
+        taskList(
+          checkedItem(p('')), //
+        ),
+        bulletList(
+          listItem(p('789')), //
+        ),
+      ),
+    );
+
+    editor.add(
+      doc(
+        bulletList(
+          listItem(p('<cursor>')), //
+          listItem(p('456')),
+          listItem(p('789')),
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        taskList(
+          checkedItem(p('')), //
+        ),
+        bulletList(
+          listItem(p('456')), //
+          listItem(p('789')), //
+        ),
+      ),
+    );
+  });
+
+  it('creates a taskList in a nested list', () => {
+    editor.add(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            bulletList(
+              listItem(p('<cursor>')), //
+            ),
+          ),
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            taskList(
+              checkedItem(p('<cursor>')), //
+            ),
+          ),
+        ),
+      ),
+    );
+
+    editor.add(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            bulletList(
+              listItem(p('abc')), //
+              listItem(p('<cursor>')), //
+            ),
+          ),
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            bulletList(
+              listItem(p('abc')), //
+            ),
+            taskList(
+              checkedItem(p('<cursor>')), //
+            ),
+          ),
+        ),
+      ),
+    );
+
+    editor.add(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            bulletList(
+              listItem(p('<cursor>')), //
+              listItem(p('def')), //
+            ),
+          ),
+        ),
+      ),
+    );
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            taskList(
+              checkedItem(p('<cursor>')), //
+            ),
+            bulletList(
+              listItem(p('def')), //
+            ),
+          ),
+        ),
+      ),
+    );
+
+    editor.add(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            bulletList(
+              listItem(p('abc')), //
+              listItem(p('<cursor>')), //
+              listItem(p('def')), //
+            ),
+          ),
+        ),
+      ),
+    );
+    editor.insertText('[ ] ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(
+            p('123'),
+            bulletList(
+              listItem(p('abc')), //
+            ),
+            taskList(
+              uncheckedItem(p('<cursor>')), //
+            ),
+            bulletList(
+              listItem(p('def')), //
+            ),
+          ),
+        ),
+      ),
+    );
+  });
+
+  it('does not create a list if already inside a such list', () => {
+    editor.add(doc(bulletList(listItem(p('<cursor>')))));
+    editor.insertText('- ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(bulletList(listItem(p('- ')))));
+
+    editor.add(doc(orderedList({ order: 1 })(listItem(p('<cursor>')))));
+    editor.insertText('1. ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(orderedList({ order: 1 })(listItem(p('1. ')))));
+
+    editor.add(doc(taskList(uncheckedItem(p('<cursor>')))));
+    editor.insertText('[x] ');
+    expect(editor.doc).toEqualProsemirrorNode(doc(taskList(uncheckedItem(p('[x] ')))));
+  });
 });

--- a/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
@@ -1,11 +1,9 @@
-import { createEditor, doc, li, ol, p, schema, ul } from 'jest-prosemirror';
 import { renderEditor } from 'jest-remirror';
 import {
   BulletListExtension,
   ListItemExtension,
   OrderedListExtension,
   TaskListExtension,
-  toggleList,
 } from 'remirror/extensions';
 
 describe('create a list', () => {

--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -254,7 +254,7 @@ export function sharedLiftListItem(allExtensions: AnyExtension[]): CommandFuncti
   };
 }
 
-// Copy from `prosemirror-schema-list`
+// Copied from `prosemirror-schema-list`
 function liftOutOfList(state: EditorState, dispatch: DispatchFunction, range: NodeRange) {
   const tr = state.tr,
     list = range.parent;
@@ -311,7 +311,11 @@ function liftOutOfList(state: EditorState, dispatch: DispatchFunction, range: No
   return true;
 }
 
-export function forceToggleList(type: NodeType, itemType: NodeType): CommandFunction {
+/**
+ * Build a command to lift the content inside a list item around the selection
+ * out of list
+ */
+export function liftListItemOutOfList(itemType: NodeType): CommandFunction {
   return (props) => {
     const { dispatch, tr } = props;
     const state = chainableEditorState(tr, props.state);
@@ -323,19 +327,6 @@ export function forceToggleList(type: NodeType, itemType: NodeType): CommandFunc
       (node) => node.childCount && node.firstChild.type === itemType,
     );
 
-    // if (!range) {
-    //   return false;
-    // }
-
-    const parentList = findParentNode({
-      predicate: (node) => isList(node),
-      selection: tr.selection,
-    });
-
-    console.log('aaaa');
-
-    // if (parentList.node.type === type) {
-    // return liftListItem(itemType)(state, dispatch);
     if (!dispatch) {
       return true;
     }

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -18,7 +18,7 @@ import {
 import { NodeSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
-import { splitListItem } from './list-commands';
+import { liftListItemOutOfList, splitListItem } from './list-commands';
 import { createCustomMarkListItemNodeView } from './list-item-node-view';
 import { ListItemSharedExtension } from './list-item-shared-extension';
 
@@ -126,6 +126,14 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
 
       return true;
     };
+  }
+
+  /**
+   * Lift the content inside a list item around the selection out of list
+   */
+  @command()
+  liftListItemOutOfList(): CommandFunction {
+    return liftListItemOutOfList(this.type);
   }
 }
 

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -1,6 +1,5 @@
 import {
   ApplySchemaAttributes,
-  assertGet,
   command,
   CommandFunction,
   ExtensionTag,
@@ -17,11 +16,10 @@ import {
   ProsemirrorAttributes,
 } from '@remirror/core';
 import { InputRule } from '@remirror/pm/inputrules';
-import { NodeType } from '@remirror/pm/model';
 import { EditorState, NodeSelection, TextSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
-import { forceToggleList, splitListItem, toggleList } from './list-commands';
+import { splitListItem } from './list-commands';
 import { createCustomMarkListItemNodeView } from './list-item-node-view';
 import { ListItemSharedExtension } from './list-item-shared-extension';
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->
- Add a new input rule to `TaskListItemExtension`. When a user types `[]`, `[ ]`, `[x]` or `[X]` at the beginning of a `listItem` node, the editor will turn this node into a `taskListItem` node and also do some necessary transforms.
- Add a new command `liftListItemOutOfList` to `ListItemExtension`, which can lift the content inside a list item out of list.



### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->

https://user-images.githubusercontent.com/24715727/124384528-3abcee00-dd04-11eb-9c1f-484745e86bac.mov

