### PR TITLE
fix(react-tables): add controller to table cells in create transaction

### DIFF
--- a/.changeset/brave-crews-sleep.md
+++ b/.changeset/brave-crews-sleep.md
@@ -1,0 +1,10 @@
+---
+'@remirror/extension-react-tables': minor
+'@remirror/extension-tables': patch
+---
+
+Fix to make React tables compatible with Yjs extension
+
+The controller injection is now done is a single create transaction, rather than an additional transaction. The previous implementation with multiple rapid transactions triggered conflict resolution behaviour in Yjs, leading to unpredictable behaviour.
+
+Exposes a `createTable` command from the React Tables extension directly

--- a/packages/remirror__extension-react-tables/__stories__/react-tables-extension.stories.tsx
+++ b/packages/remirror__extension-react-tables/__stories__/react-tables-extension.stories.tsx
@@ -1,5 +1,8 @@
 import { Story } from '@storybook/react';
 import { useEffect, useState } from 'react';
+import { YjsExtension } from 'remirror/extensions';
+import { WebrtcProvider } from 'y-webrtc';
+import * as Y from 'yjs';
 import { ProsemirrorDevTools } from '@remirror/dev';
 import {
   EditorComponent,
@@ -97,7 +100,7 @@ const ProsemirrorDocData: React.FC = () => {
   );
 };
 
-export const Table: Story = ({ children }) => {
+export const Table: Story = ({ children, extensions = defaultExtensions }) => {
   const { manager, state } = useRemirror({ extensions });
 
   return (
@@ -126,4 +129,20 @@ export const TableWithDevTools: Story = () => {
   );
 };
 
-const extensions = () => [new ReactComponentExtension(), new TableExtension()];
+export const TableWithYjs: Story = () => {
+  return (
+    <Table extensions={yjsExtensions}>
+      <ProsemirrorDevTools />
+    </Table>
+  );
+};
+
+const defaultExtensions = () => [new ReactComponentExtension(), new TableExtension()];
+
+const doc = new Y.Doc();
+const yjsExtensions = () => [
+  ...defaultExtensions(),
+  new YjsExtension({
+    getProvider: () => new WebrtcProvider('remirror-react-tables', doc),
+  }),
+];

--- a/packages/remirror__extension-react-tables/package.json
+++ b/packages/remirror__extension-react-tables/package.json
@@ -61,7 +61,9 @@
     "@types/react": "^17.0.11",
     "@types/react-dom": "^17.0.8",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "y-webrtc": "^10.2.0",
+    "yjs": "^13.5.10"
   },
   "peerDependencies": {
     "@remirror/pm": "1.0.0-next.60",

--- a/packages/remirror__extension-react-tables/src/utils/controller.ts
+++ b/packages/remirror__extension-react-tables/src/utils/controller.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { EditorView, FindProsemirrorNodeResult, ResolvedPos, Transaction } from '@remirror/core';
+import { EditorSchema, EditorView, FindProsemirrorNodeResult, ResolvedPos } from '@remirror/core';
 import { Fragment, Node as ProsemirrorNode } from '@remirror/pm/model';
 import { cellAround, CellSelection, TableMap } from '@remirror/pm/tables';
 
@@ -12,25 +12,20 @@ import { repeat } from './array';
 import { CellAxis, FindTable } from './types';
 
 export interface InjectControllersProps {
-  view: EditorView;
+  schema: EditorSchema;
   getMap: () => TableMap;
-  getPos: () => number;
-  tr: Transaction;
   table: ProsemirrorNode;
 }
 export function injectControllers({
-  view,
+  schema,
   getMap,
-  getPos,
-  tr,
   table: oldTable,
-}: InjectControllersProps): Transaction {
-  const schema = view.state.schema;
-  const controllerCell = view.state.schema.nodes.tableControllerCell!.create();
+}: InjectControllersProps): ProsemirrorNode {
+  const controllerCell = schema.nodes.tableControllerCell!.create();
   const headerControllerCells: ProsemirrorNode[] = repeat(controllerCell, getMap().width + 1);
 
-  const crotrollerRow: ProsemirrorNode = schema.nodes.tableRow!.create({}, headerControllerCells);
-  const newRowsArray: ProsemirrorNode[] = [crotrollerRow];
+  const controllerRow: ProsemirrorNode = schema.nodes.tableRow!.create({}, headerControllerCells);
+  const newRowsArray: ProsemirrorNode[] = [controllerRow];
 
   const oldRows = oldTable.content;
   oldRows.forEach((oldRow) => {
@@ -53,8 +48,7 @@ export function injectControllers({
     isControllersInjected: true,
   };
 
-  const pos = getPos();
-  return tr.replaceRangeWith(pos, pos + oldTable.nodeSize, newTable);
+  return newTable;
 }
 
 export function createControllerEvents({

--- a/packages/remirror__extension-react-tables/src/views/table-view.tsx
+++ b/packages/remirror__extension-react-tables/src/views/table-view.tsx
@@ -6,7 +6,6 @@ import { ExtensionTablesTheme } from '@remirror/theme';
 
 import TableInsertButton, { shouldHideInsertButton } from '../components/table-insert-button';
 import { ReactTableNodeAttrs } from '../table-extensions';
-import { injectControllers } from '../utils/controller';
 import { h } from '../utils/dom';
 import { setNodeAttrs } from '../utils/prosemirror';
 
@@ -51,22 +50,6 @@ export class TableView<Schema extends EditorSchema = EditorSchema> implements No
     this.table = h('table', { className: ExtensionTablesTheme.TABLE }, this.colgroup, this.tbody);
     this.insertButtonWrapper = h('div');
     this.root = h('div', null, this.table, this.insertButtonWrapper);
-
-    if (!this.attrs().isControllersInjected) {
-      setTimeout(() => {
-        let tr = view.state.tr;
-        tr = injectControllers({
-          view: this.view,
-          getMap: () => this.map,
-          getPos: this.getPos,
-          tr,
-          table: node,
-        });
-        view.dispatch(tr);
-      }, 0); // TODO: better way to do the injection then setTimeout?
-      // TODO: add a event listener to detect `this.root` insertion
-      // see also: https://davidwalsh.name/detect-node-insertion
-    }
 
     this.render();
 

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -19,7 +19,6 @@ import {
   ProsemirrorPlugin,
   StateUpdateLifecycleProps,
 } from '@remirror/core';
-import { ExtensionTablesMessages as Messages } from '@remirror/messages';
 import { TextSelection } from '@remirror/pm/state';
 import {
   addColumnAfter,
@@ -46,14 +45,9 @@ import {
   createTable,
   CreateTableCommand,
   createTableNodeSchema,
+  createTableOptions,
   TableSchemaSpec,
 } from './table-utils';
-
-const createTableCommand: Remirror.CommandDecoratorOptions = {
-  icon: 'table2',
-  description: ({ t }) => t(Messages.CREATE_COMMAND_DESCRIPTION),
-  label: ({ t }) => t(Messages.CREATE_COMMAND_LABEL),
-};
 
 export interface TableOptions {
   /**
@@ -124,7 +118,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
   /**
    * Create a table in the editor at the current selection point.
    */
-  @command(createTableCommand)
+  @command(createTableOptions)
   createTable(options: CreateTableCommand = {}): CommandFunction {
     return (props) => {
       const { tr, dispatch, state } = props;

--- a/packages/remirror__extension-tables/src/table-utils.ts
+++ b/packages/remirror__extension-tables/src/table-utils.ts
@@ -12,6 +12,7 @@ import {
   SchemaProps,
   values,
 } from '@remirror/core';
+import { ExtensionTablesMessages } from '@remirror/messages';
 import type { Node as ProsemirrorNode } from '@remirror/pm/model';
 
 export interface TableSchemaSpec extends NodeExtensionSpec {
@@ -250,3 +251,11 @@ export function createTable(props: CreateTableProps): ProsemirrorNode<EditorSche
 
   return table.createChecked(null, rows);
 }
+
+const { CREATE_COMMAND_DESCRIPTION, CREATE_COMMAND_LABEL } = ExtensionTablesMessages;
+
+export const createTableOptions: Remirror.CommandDecoratorOptions = {
+  icon: 'table2',
+  description: ({ t }) => t(CREATE_COMMAND_DESCRIPTION),
+  label: ({ t }) => t(CREATE_COMMAND_LABEL),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1648,6 +1648,8 @@ importers:
       jsx-dom: ^6.4.23
       react: ^17.0.2
       react-dom: ^17.0.2
+      y-webrtc: ^10.2.0
+      yjs: ^13.5.10
     dependencies:
       '@babel/runtime': 7.14.6
       '@emotion/css': 11.1.3_@babel+core@7.14.6
@@ -1670,6 +1672,8 @@ importers:
       '@types/react-dom': 17.0.8
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
+      y-webrtc: 10.2.0
+      yjs: 13.5.10
 
   packages/remirror__extension-search:
     specifiers:


### PR DESCRIPTION
### Description

Fixes #994 

This PR combines the `injectControllers` behaviour with the `createTable` command, so both actions are performed in a single transaction. This prevents merge resolution behaviour being triggered in Yjs.

This PR also adds a Storybook story for React Tables + Yjs 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

