### PR TITLE
fix(extension-react-tables): reduce bundle size

### DIFF
--- a/.changeset/clever-baboons-brake.md
+++ b/.changeset/clever-baboons-brake.md
@@ -1,0 +1,8 @@
+---
+'@remirror/extension-react-tables': patch
+'@remirror/icons': patch
+'@remirror/react': patch
+'@remirror/react-components': patch
+---
+
+Reduce bundle size by removing `@remirror/icons/all` and `@remirror/react-icons/all-icons` from the package `@remirror/react-tables-extension`.

--- a/packages/remirror__extension-react-tables/src/components/table-delete-button.tsx
+++ b/packages/remirror__extension-react-tables/src/components/table-delete-button.tsx
@@ -8,8 +8,7 @@ import {
   Positioner,
 } from '@remirror/extension-positioner';
 import { deleteColumn, deleteRow, isCellSelection, TableMap } from '@remirror/pm/tables';
-import { PositionerPortal } from '@remirror/react-components';
-import { CloseFillIcon } from '@remirror/react-components/all-icons';
+import { Icon, PositionerPortal } from '@remirror/react-components';
 import { useRemirrorContext } from '@remirror/react-core';
 import type { UsePositionerReturn } from '@remirror/react-hooks';
 import { usePositioner } from '@remirror/react-hooks';
@@ -150,7 +149,7 @@ export const TableDeleteRowColumnInnerButton: React.FC<TableDeleteRowColumnInner
       }
       className={ExtensionTablesTheme.TABLE_DELETE_ROW_COLUMN_INNER_BUTTON}
     >
-      <CloseFillIcon size={size} color={'#ffffff'} />
+      <Icon name='closeFill' size={size} color={'#ffffff'} />
     </div>
   );
 };

--- a/packages/remirror__extension-react-tables/src/components/table-insert-button.ts
+++ b/packages/remirror__extension-react-tables/src/components/table-insert-button.ts
@@ -1,5 +1,5 @@
 import { EditorView, Transaction } from '@remirror/core';
-import { addFill } from '@remirror/icons/all';
+import { addFill } from '@remirror/icons';
 import { TableRect } from '@remirror/pm/tables';
 import { ExtensionTablesTheme } from '@remirror/theme';
 

--- a/packages/remirror__icons/src/all-icons.ts
+++ b/packages/remirror__icons/src/all-icons.ts
@@ -227,15 +227,6 @@ export const addCircleLine: IconTree[] = [
 ];
 
 /**
- * The icon for `add-fill.svg` created by [RemixIcons](https://remixicons.com).
- * ![Add Fill](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/add-fill.svg)
- */
-export const addFill: IconTree[] = [
-  { tag: 'path', attr: { fill: 'none', d: 'M0 0h24v24H0z' } },
-  { tag: 'path', attr: { d: 'M11 11V5h2v6h6v2h-6v6h-2v-6H5v-2z' } },
-];
-
-/**
  * The icon for `admin-fill.svg` created by [RemixIcons](https://remixicons.com).
  * ![Admin Fill](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/User/admin-fill.svg)
  */
@@ -5168,20 +5159,6 @@ export const closeCircleFill: IconTree[] = [
     tag: 'path',
     attr: {
       d: 'M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-11.414L9.172 7.757 7.757 9.172 10.586 12l-2.829 2.828 1.415 1.415L12 13.414l2.828 2.829 1.415-1.415L13.414 12l2.829-2.828-1.415-1.415L12 10.586z',
-    },
-  },
-];
-
-/**
- * The icon for `close-fill.svg` created by [RemixIcons](https://remixicons.com).
- * ![Close Fill](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/close-fill.svg)
- */
-export const closeFill: IconTree[] = [
-  { tag: 'path', attr: { fill: 'none', d: 'M0 0h24v24H0z' } },
-  {
-    tag: 'path',
-    attr: {
-      d: 'M12 10.586l4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636z',
     },
   },
 ];

--- a/packages/remirror__icons/src/core-icons.ts
+++ b/packages/remirror__icons/src/core-icons.ts
@@ -17,6 +17,15 @@ export const ab: IconTree[] = [
 ];
 
 /**
+ * The icon for `add-fill.svg` created by [RemixIcons](https://remixicons.com).
+ * ![Add Fill](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/add-fill.svg)
+ */
+export const addFill: IconTree[] = [
+  { tag: 'path', attr: { fill: 'none', d: 'M0 0h24v24H0z' } },
+  { tag: 'path', attr: { d: 'M11 11V5h2v6h6v2h-6v6h-2v-6H5v-2z' } },
+];
+
+/**
  * The icon for `add-line.svg` created by [RemixIcons](https://remixicons.com).
  * ![Add Line](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/add-line.svg)
  */
@@ -332,6 +341,20 @@ export const closeCircleLine: IconTree[] = [
     tag: 'path',
     attr: {
       d: 'M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm0-9.414l2.828-2.829 1.415 1.415L13.414 12l2.829 2.828-1.415 1.415L12 13.414l-2.828 2.829-1.415-1.415L10.586 12 7.757 9.172l1.415-1.415L12 10.586z',
+    },
+  },
+];
+
+/**
+ * The icon for `close-fill.svg` created by [RemixIcons](https://remixicons.com).
+ * ![Close Fill](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/close-fill.svg)
+ */
+export const closeFill: IconTree[] = [
+  { tag: 'path', attr: { fill: 'none', d: 'M0 0h24v24H0z' } },
+  {
+    tag: 'path',
+    attr: {
+      d: 'M12 10.586l4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636z',
     },
   },
 ];

--- a/packages/remirror__react-components/src/icons/all.ts
+++ b/packages/remirror__react-components/src/icons/all.ts
@@ -13,7 +13,6 @@ import {
   addBoxLine,
   addCircleFill,
   addCircleLine,
-  addFill,
   adminFill,
   adminLine,
   advertisementFill,
@@ -378,7 +377,6 @@ import {
   closeCircleFill,
   closedCaptioningFill,
   closedCaptioningLine,
-  closeFill,
   cloudFill,
   cloudLine,
   cloudOffFill,
@@ -2259,14 +2257,6 @@ export const AddCircleFillIcon: IconType = (props) => {
  */
 export const AddCircleLineIcon: IconType = (props) => {
   return GenIcon(addCircleLine)(props);
-};
-
-/**
- * The react component for the `add-fill.svg` icon created by [RemixIcons](https://remixicons.com).
- * ![Add Fill Icon](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/add-fill.svg)
- */
-export const AddFillIcon: IconType = (props) => {
-  return GenIcon(addFill)(props);
 };
 
 /**
@@ -5163,14 +5153,6 @@ export const ClockwiseLineIcon: IconType = (props) => {
  */
 export const CloseCircleFillIcon: IconType = (props) => {
   return GenIcon(closeCircleFill)(props);
-};
-
-/**
- * The react component for the `close-fill.svg` icon created by [RemixIcons](https://remixicons.com).
- * ![Close Fill Icon](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/close-fill.svg)
- */
-export const CloseFillIcon: IconType = (props) => {
-  return GenIcon(closeFill)(props);
 };
 
 /**

--- a/packages/remirror__react-components/src/icons/core.ts
+++ b/packages/remirror__react-components/src/icons/core.ts
@@ -2,6 +2,7 @@
 
 import {
   ab,
+  addFill,
   addLine,
   alertLine,
   alignBottom,
@@ -29,6 +30,7 @@ import {
   clipboardFill,
   clipboardLine,
   closeCircleLine,
+  closeFill,
   closeLine,
   codeLine,
   codeView,
@@ -154,6 +156,14 @@ import { GenIcon, IconType } from './icons-base';
  */
 export const ABIcon: IconType = (props) => {
   return GenIcon(ab)(props);
+};
+
+/**
+ * The react component for the `add-fill.svg` icon created by [RemixIcons](https://remixicons.com).
+ * ![Add Fill Icon](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/add-fill.svg)
+ */
+export const AddFillIcon: IconType = (props) => {
+  return GenIcon(addFill)(props);
 };
 
 /**
@@ -370,6 +380,14 @@ export const ClipboardLineIcon: IconType = (props) => {
  */
 export const CloseCircleLineIcon: IconType = (props) => {
   return GenIcon(closeCircleLine)(props);
+};
+
+/**
+ * The react component for the `close-fill.svg` icon created by [RemixIcons](https://remixicons.com).
+ * ![Close Fill Icon](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/System/close-fill.svg)
+ */
+export const CloseFillIcon: IconType = (props) => {
+  return GenIcon(closeFill)(props);
 };
 
 /**

--- a/packages/remirror__react/src/index.ts
+++ b/packages/remirror__react/src/index.ts
@@ -1,7 +1,6 @@
 export * from '@remirror/extension-react-component';
 export * from '@remirror/extension-react-ssr';
 export * from '@remirror/extension-react-tables';
-export * from '@remirror/extension-react-tables';
 export * from '@remirror/preset-react';
 export * from '@remirror/react-components';
 export * from '@remirror/react-core';

--- a/support/root/jest.config.js
+++ b/support/root/jest.config.js
@@ -68,6 +68,10 @@ module.exports = {
     // of remirror for simplification.
     '!packages/multishift/**',
 
+    // No need to test these static icon files.
+    '!packages/remirror__icons/src/all-icons.ts',
+    '!packages/remirror__react-components/src/icons/all.ts',
+
     // Deprecated package
     '!packages/remirror__react-wysiwyg/**',
 

--- a/support/scripts/data/icons.json
+++ b/support/scripts/data/icons.json
@@ -48,6 +48,8 @@
     "delete-bin-fill.svg",
     "pencil-line.svg",
     "pencil-fill.svg",
+    "close-fill.svg",
+    "add-fill.svg",
 
     "a-b.svg",
     "align-bottom.svg",


### PR DESCRIPTION
### Description

Reduce bundle size by removing `@remirror/icons/all` and `@remirror/react-icons/all-icons` from the package `@remirror/react-tables-extension`.

Issue raised in [discord](https://discord.com/channels/726035064831344711/745695521305526302/867105486049902662
) .

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
