### PR TITLE
docs: add styles to the create an editor step

### DIFF
--- a/docs/react/create-editor.md
+++ b/docs/react/create-editor.md
@@ -25,7 +25,7 @@ const Editor = () => {
       {/* the className is used to define css variables necessary for the editor */}
       <Remirror manager={manager} />;
     </div>
-  )
+  );
 };
 ```
 

--- a/docs/react/create-editor.md
+++ b/docs/react/create-editor.md
@@ -10,10 +10,11 @@ Creating an editor consists of two steps.
 1. Creating the wrapper with `Remirror` which sets up the editor functionality by passing in the extension manager.
 
 ```tsx
+import 'remirror/styles/all.css';
+
 import React from 'react';
 import { BoldExtension, ItalicExtension, UnderlineExtension } from 'remirror/extensions';
 import { Remirror, useRemirror } from '@remirror/react';
-import 'remirror/styles/all.css'
 
 const extensions = () => [new BoldExtension(), new ItalicExtension(), new UnderlineExtension()];
 

--- a/docs/react/create-editor.md
+++ b/docs/react/create-editor.md
@@ -13,13 +13,18 @@ Creating an editor consists of two steps.
 import React from 'react';
 import { BoldExtension, ItalicExtension, UnderlineExtension } from 'remirror/extensions';
 import { Remirror, useRemirror } from '@remirror/react';
+import 'remirror/styles/all.css'
 
 const extensions = () => [new BoldExtension(), new ItalicExtension(), new UnderlineExtension()];
 
 const Editor = () => {
   const { manager } = useRemirror({ extensions });
 
-  return <Remirror manager={manager} />;
+  return (
+    <div className='remirror-theme'>
+      {/* the className is used to define css variables necessary for the editor */}
+      <Remirror manager={manager} />;
+    </div>
 };
 ```
 

--- a/docs/react/create-editor.md
+++ b/docs/react/create-editor.md
@@ -25,6 +25,7 @@ const Editor = () => {
       {/* the className is used to define css variables necessary for the editor */}
       <Remirror manager={manager} />;
     </div>
+  )
 };
 ```
 


### PR DESCRIPTION
This is likely one of the first places people will look to create an editor, if someone copies and pastes the code as is, it will appear slightly buggy. Adding the css import and the class should ensure that it will function as intended

### Description

this is in response to a question in the discord server. Essentially to help alleviate confusion, let's add the css import and className to this early example to help new people get up and running

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [] My code follows the code style of this project and `pnpm fix` completed successfully.
  - I didn't check this as i  didn't pull down and install everything since this is just a readme update.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

