### PR TITLE
fix(i18n): fix the bold command label

### DIFF
--- a/.changeset/eight-pans-report.md
+++ b/.changeset/eight-pans-report.md
@@ -1,6 +1,7 @@
 ---
 'remirror': patch
 '@remirror/i18n': patch
+'@remirror/messages': patch
 ---
 
 Fix i18n bold command label.

--- a/.changeset/eight-pans-report.md
+++ b/.changeset/eight-pans-report.md
@@ -1,0 +1,6 @@
+---
+"remirror": patch
+"@remirror/i18n": patch
+---
+
+Fix i18n bold command label.

--- a/.changeset/eight-pans-report.md
+++ b/.changeset/eight-pans-report.md
@@ -1,6 +1,6 @@
 ---
-"remirror": patch
-"@remirror/i18n": patch
+'remirror': patch
+'@remirror/i18n': patch
 ---
 
 Fix i18n bold command label.

--- a/packages/remirror__i18n/src/en/messages.po
+++ b/packages/remirror__i18n/src/en/messages.po
@@ -259,7 +259,7 @@ msgstr "Add bold formatting to the selected text"
 #: packages/remirror__messages/src/extension-bold-messages.ts:4
 #: packages/remirror__messages/src/extension-emoji-messages.ts:4
 msgid "extension.command.toggle-bold.label"
-msgstr "Insert Emoji"
+msgstr "Bold"
 
 #. Description for inserting a bullet list into the editor.
 #: packages/remirror__messages/src/extension-list-messages.ts:10

--- a/packages/remirror__i18n/src/en/messages.ts
+++ b/packages/remirror__i18n/src/en/messages.ts
@@ -62,7 +62,7 @@
     'Add blockquote formatting to the selected text',
   'extension.command.toggle-blockquote.label': 'Blockquote',
   'extension.command.toggle-bold.description': 'Add bold formatting to the selected text',
-  'extension.command.toggle-bold.label': 'Insert Emoji',
+  'extension.command.toggle-bold.label': 'Bold',
   'extension.command.toggle-bullet-list.description': 'Bulleted list',
   'extension.command.toggle-callout.description': [
     [

--- a/packages/remirror__messages/src/extension-emoji-messages.ts
+++ b/packages/remirror__messages/src/extension-emoji-messages.ts
@@ -2,7 +2,7 @@ import type { MessageDescriptor } from '@lingui/core';
 import { defineMessage } from '@lingui/macro';
 
 export const INSERT_EMOJI_LABEL: MessageDescriptor = defineMessage({
-  id: 'extension.command.toggle-bold.label',
+  id: 'extension.command.insert-emoji.label',
   comment: 'Label for inserting an emoji.',
   message: 'Insert Emoji',
 });


### PR DESCRIPTION
### Description

Fix incorrect label in `remirror__i18n` package when using `ToolbarCommandButton`'s `toggleBold` command.

Fixes #1032

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/26342387/128029382-780ec74b-47e4-4644-80bb-3595d791734b.png)
