### PR TITLE
fix(docs): remove duplicated menu option "more"

### DIFF
--- a/website/sidebar.js
+++ b/website/sidebar.js
@@ -35,11 +35,6 @@ const docs = [
     label: 'More',
     items: ['contributing', 'tooling', 'errors', 'projects'],
   },
-  {
-    type: 'category',
-    label: 'More',
-    items: ['contributing', 'tooling', 'errors', 'projects'],
-  },
 ];
 
 /** @type import('@docusaurus/plugin-content-docs/lib/types').SidebarItem[] */


### PR DESCRIPTION
### Description

The "more" menu option was presented twice in the docs:

![image](https://user-images.githubusercontent.com/9339055/128510616-ee8e9908-bcd8-4316-95fd-df4521eb1428.png)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
