### PR TITLE
fix(extension-list): don't move the content when splitting a closed item

### DIFF
--- a/.changeset/wet-elephants-lick.md
+++ b/.changeset/wet-elephants-lick.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Keep the content in its origin list item when splitting a closed item.

--- a/.changeset/wet-elephants-lick.md
+++ b/.changeset/wet-elephants-lick.md
@@ -2,4 +2,4 @@
 '@remirror/extension-list': patch
 ---
 
-Keep the content in its origin list item when splitting a closed item.
+When splitting a closed item, keep its content in the origin list item.

--- a/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
+++ b/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
@@ -5,6 +5,7 @@ import {
   LinkExtension,
   OrderedListExtension,
 } from 'remirror/extensions';
+import { ProsemirrorDevTools } from '@remirror/dev';
 import { EditorComponent, Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 import { TaskListExtension } from '../src/task-list-extension';
@@ -22,6 +23,7 @@ export const Basic = (): JSX.Element => {
     <ThemeProvider>
       <Remirror manager={manager} initialContent={state}>
         <EditorComponent />
+        <ProsemirrorDevTools />
       </Remirror>
     </ThemeProvider>
   );
@@ -38,6 +40,7 @@ export const Collapsible = (): JSX.Element => {
     <ThemeProvider>
       <Remirror manager={manager} initialContent={state}>
         <EditorComponent />
+        <ProsemirrorDevTools />
       </Remirror>
     </ThemeProvider>
   );

--- a/packages/remirror__extension-list/__tests__/list-keymap.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-keymap.spec.ts
@@ -10,8 +10,9 @@ describe('Enter', () => {
   ]);
   const {
     nodes: { doc, paragraph: p, orderedList: ol, bulletList: ul, listItem: li, taskList: tl },
-    attributeNodes: { taskListItem },
+    attributeNodes: { taskListItem, listItem },
   } = editor;
+  const closed = listItem({ closed: true });
   const unchecked = taskListItem({ checked: false });
   const checked = taskListItem({ checked: true });
 
@@ -81,6 +82,81 @@ describe('Enter', () => {
 
     from = doc(tl(checked(p('hello world<cursor>'))));
     to = doc(tl(checked(p('hello world')), unchecked(p(''))));
+    editor.add(from).press('Enter');
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
+
+  it('keeps the content in its origin list item when splitting a closed item', () => {
+    from = doc(
+      ul(
+        closed(
+          p('hello world<cursor>'),
+          ul(
+            li(p('nested list item')), //
+          ),
+        ),
+      ),
+    );
+    to = doc(
+      ul(
+        closed(
+          p('hello world'),
+          ul(
+            li(p('nested list item')), //
+          ),
+        ),
+        li(p()),
+      ),
+    );
+    editor.add(from).press('Enter');
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+
+    from = doc(
+      ul(
+        closed(
+          p('hello <start>world<end>'),
+          ul(
+            li(p('nested list item')), //
+          ),
+        ),
+      ),
+    );
+    to = doc(
+      ul(
+        closed(
+          p('hello '),
+          ul(
+            li(p('nested list item')), //
+          ),
+        ),
+        li(p()),
+      ),
+    );
+    editor.add(from).press('Enter');
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+
+    // Don't keep the content in its origin list item when it's not a closed list item.
+    from = doc(
+      ul(
+        li(
+          p('hello world<cursor>'),
+          ul(
+            li(p('nested list item')), //
+          ),
+        ),
+      ),
+    );
+    to = doc(
+      ul(
+        li(p('hello world')),
+        li(
+          p(),
+          ul(
+            li(p('nested list item')), //
+          ),
+        ),
+      ),
+    );
     editor.add(from).press('Enter');
     expect(editor.view.state.doc).toEqualProsemirrorNode(to);
   });


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

See also: https://github.com/remirror/remirror/issues/1043

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->

https://user-images.githubusercontent.com/24715727/128639612-d7e62026-e5ce-4ae9-b0b1-9cd93f513031.mp4

