### PR TITLE
docs: organize extension stories in separate section

### DIFF
--- a/docs/extensions/annotation-extension.md
+++ b/docs/extensions/annotation-extension.md
@@ -65,7 +65,7 @@ The extension is provided by the `@remirror/extension-annotation` package. There
 
 ### Examples
 
-See [storybook](https://remirror.vercel.app/?path=/story/annotation-extension--basic) for example usage.
+See [storybook](https://remirror.vercel.app/?path=/story/extensions-annotation--basic) for example usage.
 
 ## API
 

--- a/docs/extensions/callout-extension.md
+++ b/docs/extensions/callout-extension.md
@@ -64,7 +64,7 @@ The extension is provided by the `@remirror/extension-callout` package. There ar
 
 ### Examples
 
-See [storybook](https://remirror.vercel.app/?path=/story/callouts--basic) for examples.
+See [storybook](https://remirror.vercel.app/?path=/story/extensions-callout--basic) for examples.
 
 ## API
 

--- a/docs/extensions/markdown-extension.md
+++ b/docs/extensions/markdown-extension.md
@@ -90,9 +90,7 @@ The extension is provided by the `@remirror/extension-markdown` package. There a
 
 ### Examples
 
-#### A pure markdown editor
-
-#### A dual editor with markdown
+See [storybook](https://remirror.vercel.app/?path=/story/markdown-editor--basic) for examples.
 
 ## API
 

--- a/docs/extensions/placeholder-extension.md
+++ b/docs/extensions/placeholder-extension.md
@@ -33,7 +33,7 @@ The extension is provided by the `@remirror/extension-placeholder` package. Ther
 
 ### Examples
 
-See [storybook](https://remirror.vercel.app/?path=/story/placeholder-extension--basic) for examples.
+See [storybook](https://remirror.vercel.app/?path=/story/extensions-placeholder--basic) for examples.
 
 ## API
 

--- a/packages/remirror__extension-annotation/__stories__/annotation-extension.stories.tsx
+++ b/packages/remirror__extension-annotation/__stories__/annotation-extension.stories.tsx
@@ -25,7 +25,7 @@ import {
   useRemirrorContext,
 } from '@remirror/react';
 
-export default { title: 'Annotation Extension' };
+export default { title: 'Extensions / Annotation' };
 
 const SAMPLE_TEXT = 'This is a sample text';
 

--- a/packages/remirror__extension-callout/__stories__/callout.stories.tsx
+++ b/packages/remirror__extension-callout/__stories__/callout.stories.tsx
@@ -15,7 +15,7 @@ import {
   useRemirrorContext,
 } from '@remirror/react';
 
-export default { title: 'Callouts' };
+export default { title: 'Extensions / Callout' };
 
 const EmojiPicker = () => {
   const pickerRef = useRef(new EmojiButton({ position: 'bottom', autoFocusSearch: false }));

--- a/packages/remirror__extension-code-block/__stories__/code-block.stories.tsx
+++ b/packages/remirror__extension-code-block/__stories__/code-block.stories.tsx
@@ -4,7 +4,7 @@ import { CodeBlockExtension } from 'remirror/extensions';
 import { ProsemirrorDevTools } from '@remirror/dev';
 import { Remirror, ThemeProvider, useEditorState, useRemirror } from '@remirror/react';
 
-export default { title: 'Code Block extension' };
+export default { title: 'Extensions / Code Block' };
 
 const Dev = () => {
   const updatedState = useEditorState();

--- a/packages/remirror__extension-codemirror5/__stories__/codemirror5.stories.tsx
+++ b/packages/remirror__extension-codemirror5/__stories__/codemirror5.stories.tsx
@@ -8,7 +8,7 @@ import CodeMirror from 'codemirror';
 import { CodeMirrorExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-export default { title: 'Codemirror5 extension' };
+export default { title: 'Extensions / Codemirror5' };
 
 export const Basic = (): JSX.Element => {
   const { manager, state } = useRemirror({ extensions, content, stringHandler: 'html' });

--- a/packages/remirror__extension-embed/__stories__/iframe.stories.tsx
+++ b/packages/remirror__extension-embed/__stories__/iframe.stories.tsx
@@ -5,7 +5,7 @@ import { IframeExtension } from 'remirror/extensions';
 import { htmlToProsemirrorNode } from '@remirror/core';
 import { Remirror, ThemeProvider, useCommands, useRemirror } from '@remirror/react';
 
-export default { title: 'Iframe' };
+export default { title: 'Extensions / Iframe' };
 
 export const Basic: React.FC = () => {
   const { manager, state, onChange } = useRemirror({

--- a/packages/remirror__extension-file/__stories__/file.stories.tsx
+++ b/packages/remirror__extension-file/__stories__/file.stories.tsx
@@ -9,7 +9,7 @@ import { createBaseuploadFileUploader } from '../src/file-uploaders/bashupload-f
 import { createObjectUrlFileUploader } from '../src/file-uploaders/object-url-file-uploader';
 import { createSlowFileUploader } from '../src/file-uploaders/slow-file-uploader';
 
-export default { title: 'File extension' };
+export default { title: 'Extensions / File' };
 
 export const Default = (): JSX.Element => {
   const extensions = useCallback(() => [new FileExtension({})], []);

--- a/packages/remirror__extension-image/__stories__/image.stories.tsx
+++ b/packages/remirror__extension-image/__stories__/image.stories.tsx
@@ -5,7 +5,7 @@ import { ImageExtension } from 'remirror/extensions';
 import { htmlToProsemirrorNode } from '@remirror/core';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-export default { title: 'Image' };
+export default { title: 'Extensions / Image' };
 
 const basicExtensions = () => [new ImageExtension()];
 

--- a/packages/remirror__extension-link/__stories__/link-extension.stories.tsx
+++ b/packages/remirror__extension-link/__stories__/link-extension.stories.tsx
@@ -33,7 +33,7 @@ import {
   useUpdateReason,
 } from '@remirror/react';
 
-export default { title: 'Link Extension' };
+export default { title: 'Extensions / Link' };
 
 const mentionAtomItems: MentionAtomNodeAttributes[] = [
   { id: 'tom', label: '@tom' },

--- a/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
+++ b/packages/remirror__extension-list/__stories__/list-extension.stories.tsx
@@ -10,7 +10,7 @@ import { EditorComponent, Remirror, ThemeProvider, useRemirror } from '@remirror
 
 import { TaskListExtension } from '../src/task-list-extension';
 
-export default { title: 'List Extension' };
+export default { title: 'Extensions / List' };
 
 export const Basic = (): JSX.Element => {
   const { manager, state } = useRemirror({

--- a/packages/remirror__extension-placeholder/__stories__/placeholder-extension.stories.tsx
+++ b/packages/remirror__extension-placeholder/__stories__/placeholder-extension.stories.tsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { PlaceholderExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-export default { title: 'Placeholder Extension' };
+export default { title: 'Extensions / Placeholder' };
 
 export const Basic = (): JSX.Element => {
   const extensions = useCallback(

--- a/packages/remirror__extension-positioner/__stories__/positioner-extension.stories.tsx
+++ b/packages/remirror__extension-positioner/__stories__/positioner-extension.stories.tsx
@@ -16,7 +16,7 @@ import {
   useRemirror,
 } from '@remirror/react';
 
-export default { title: 'Positioner Extension' };
+export default { title: 'Extensions / Positioner' };
 
 const extensions = () => [
   new HeadingExtension(),

--- a/packages/remirror__extension-react-tables/__stories__/react-tables-extension.stories.tsx
+++ b/packages/remirror__extension-react-tables/__stories__/react-tables-extension.stories.tsx
@@ -16,7 +16,7 @@ import {
   useRemirrorContext,
 } from '@remirror/react';
 
-export default { title: 'React Tables extension' };
+export default { title: 'Extensions / React Tables (complex)' };
 
 const CommandMenu: React.FC = () => {
   const { commands } = useRemirrorContext();

--- a/packages/remirror__extension-tables/__stories__/table.stories.tsx
+++ b/packages/remirror__extension-tables/__stories__/table.stories.tsx
@@ -7,7 +7,7 @@ import {
   useRemirrorContext,
 } from '@remirror/react';
 
-export default { title: 'Tables extension' };
+export default { title: 'Extensions / Tables (simple)' };
 
 const CommandMenu = () => {
   const ctx = useRemirrorContext();


### PR DESCRIPTION
### Description

By now, there are quite a bit of stories in storybook. The extension-related ones are now grouped into a separate section to make it easier to find them back.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/9339055/129601398-cc9a7bed-78a3-4a25-8e8a-d0bfbd22e1f7.png)
