### PR TITLE
docs: add links to storybook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
   <a href="#motivation"><strong>Motivation</strong></a> ·
   <a href="#status"><strong>Status</strong></a> ·
   <a href="https://remirror.io/docs"><strong>Documentation</strong></a> ·
-  <a href="https://remirror.io/playground"><strong>Playground</strong></a> ·
+  <a href="https://remirror.vercel.app"><strong>Storybook</strong></a> ·
   <a href="https://remirror.io/docs/contributing"><strong>Contributing</strong></a>
 </p>
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -68,6 +68,7 @@ module.exports = {
               label: 'Installation',
               to: 'docs/installation',
             },
+            { label: 'Storybook', href: 'https://remirror.vercel.app' },
           ],
         },
         {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -102,6 +102,9 @@ const Home = () => {
               <Link className={cx(styles.getStarted)} to={useBaseUrl('docs')}>
                 Documentation
               </Link>
+              <Link className={cx(styles.getStarted)} href='https://remirror.vercel.app'>
+                Storybook <ExternalIcon />
+              </Link>
               <Link className={cx(styles.getStarted)} href='https://github.com/remirror/remirror'>
                 GitHub <ExternalIcon />
               </Link>


### PR DESCRIPTION
### Description

Today, storybook is the best way to see what remirror can do. This commit adds links to storybook on the homepage, so that users can find it.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/9339055/129605696-df18ab42-e984-4668-b311-897f99642793.png)
