### PR TITLE
docs: match story title with extension name

### DIFF
--- a/packages/remirror__extension-embed/__stories__/iframe.stories.tsx
+++ b/packages/remirror__extension-embed/__stories__/iframe.stories.tsx
@@ -5,7 +5,7 @@ import { IframeExtension } from 'remirror/extensions';
 import { htmlToProsemirrorNode } from '@remirror/core';
 import { Remirror, ThemeProvider, useCommands, useRemirror } from '@remirror/react';
 
-export default { title: 'Extensions / Iframe' };
+export default { title: 'Extensions / Embed' };
 
 export const Basic: React.FC = () => {
   const { manager, state, onChange } = useRemirror({


### PR DESCRIPTION
### Description

The story were called "iFrame" whereas the extension is called "Embed".

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
