### PR TITLE
feat(doc): allow docAttributes to have default values

### DIFF
--- a/.changeset/rotten-guests-raise.md
+++ b/.changeset/rotten-guests-raise.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-doc': patch
+'remirror': patch
+---
+
+Add ability for doc node's `docAttributes` to have default attribute values

--- a/packages/remirror__extension-doc/__tests__/doc-extension.spec.ts
+++ b/packages/remirror__extension-doc/__tests__/doc-extension.spec.ts
@@ -1,5 +1,47 @@
+import { pmBuild } from 'jest-prosemirror';
 import { extensionValidityTest } from 'jest-remirror';
+import { createCoreManager } from 'remirror/extensions';
 
 import { DocExtension } from '../';
 
 extensionValidityTest(DocExtension);
+
+test('supports docAttributes with only keys', () => {
+  const { schema } = createCoreManager([new DocExtension({ docAttributes: ['foo', 'bar'] })]);
+  const { doc, p } = pmBuild(schema, {});
+
+  expect(doc(p('Hello!')).toJSON()).toEqual({
+    type: 'doc',
+    attrs: {
+      foo: null,
+      bar: null,
+    },
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello!' }],
+      },
+    ],
+  });
+});
+
+test('supports docAttributes with default values', () => {
+  const { schema } = createCoreManager([
+    new DocExtension({ docAttributes: { foo: 'bar', custom: 'value' } }),
+  ]);
+  const { doc, p } = pmBuild(schema, {});
+
+  expect(doc(p('Hello!')).toJSON()).toEqual({
+    type: 'doc',
+    attrs: {
+      foo: 'bar',
+      custom: 'value',
+    },
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Hello!' }],
+      },
+    ],
+  });
+});


### PR DESCRIPTION
### Description

Doc extension currently supports a `docAttributes` option, however is only allows an array of keys, defaulting the value to `null`.

This PR allows `docAttributes` to be passed as a record to set the default/initial value of the attribute.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

