### PR TITLE
fix(extension-node-formatting): formatting wasn't reflected in style

### DIFF
--- a/packages/remirror__extension-node-formatting/__stories__/node-formatting.stories.tsx
+++ b/packages/remirror__extension-node-formatting/__stories__/node-formatting.stories.tsx
@@ -1,0 +1,59 @@
+import 'remirror/styles/all.css';
+
+import React from 'react';
+import { NodeFormattingExtension } from 'remirror/extensions';
+import { htmlToProsemirrorNode } from '@remirror/core';
+import { Remirror, ThemeProvider, useCommands, useRemirror } from '@remirror/react';
+
+export default { title: 'Extensions / Node Formatting' };
+
+export const Basic: React.FC = () => {
+  const { manager, state, onChange } = useRemirror({
+    extensions: () => [new NodeFormattingExtension()],
+    content: '<p>Click buttons to change alignment, indent,<br> and line height</p>',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} autoFocus onChange={onChange} state={state} autoRender='end'>
+        <AlignButtons />
+        &nbsp;
+        <IndentButtons />
+        &nbsp;
+        <LineHeightButtons />
+      </Remirror>
+    </ThemeProvider>
+  );
+};
+
+const AlignButtons = () => {
+  const commands = useCommands();
+  return (
+    <>
+      <button onClick={() => commands.leftAlign()}>Left</button>
+      <button onClick={() => commands.centerAlign()}>Center</button>
+      <button onClick={() => commands.rightAlign()}>Right</button>
+    </>
+  );
+};
+
+const IndentButtons = () => {
+  const commands = useCommands();
+  return (
+    <>
+      <button onClick={() => commands.decreaseIndent()}>&lt;&lt;</button>
+      <button onClick={() => commands.increaseIndent()}>&gt;&gt;</button>
+    </>
+  );
+};
+
+const LineHeightButtons = () => {
+  const commands = useCommands();
+  return (
+    <>
+      <button onClick={() => commands.setLineHeight(1)}>Narrow</button>
+      <button onClick={() => commands.setLineHeight(2)}>Wide</button>
+    </>
+  );
+};

--- a/packages/remirror__extension-node-formatting/__stories__/tsconfig.json
+++ b/packages/remirror__extension-node-formatting/__stories__/tsconfig.json
@@ -1,0 +1,53 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > '__stories__'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [],
+    "declaration": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove",
+    "paths": {
+      "react": [
+        "../../../node_modules/.pnpm/@types+react@17.0.14/node_modules/@types/react/index.d.ts"
+      ],
+      "react/jsx-dev-runtime": [
+        "../../../node_modules/.pnpm/@types+react@17.0.14/node_modules/@types/react/jsx-dev-runtime.d.ts"
+      ],
+      "react/jsx-runtime": [
+        "../../../node_modules/.pnpm/@types+react@17.0.14/node_modules/@types/react/jsx-runtime.d.ts"
+      ],
+      "react-dom": [
+        "../../../node_modules/.pnpm/@types+react-dom@17.0.9/node_modules/@types/react-dom/index.d.ts"
+      ],
+      "reakit": [
+        "../../../node_modules/.pnpm/reakit@1.3.8_react-dom@17.0.2+react@17.0.2/node_modules/reakit/ts/index.d.ts"
+      ],
+      "@remirror/react": ["../../remirror__react/src/index.ts"],
+      "@storybook/react": [
+        "../../../node_modules/.pnpm/@storybook+react@6.3.4_5adcf14f16f83a2edb2923710ccaaea0/node_modules/@storybook/react/types-6-0.d.ts"
+      ],
+      "@remirror/dev": ["../../remirror__dev/src/index.ts"]
+    }
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../../testing/src"
+    },
+    {
+      "path": "../../remirror/src"
+    },
+    {
+      "path": "../../remirror__core/src"
+    },
+    {
+      "path": "../../remirror__messages/src"
+    }
+  ]
+}

--- a/support/root/tsconfig.json
+++ b/support/root/tsconfig.json
@@ -330,6 +330,9 @@
       "path": "packages/remirror__extension-mention/src"
     },
     {
+      "path": "packages/remirror__extension-node-formatting/__stories__"
+    },
+    {
       "path": "packages/remirror__extension-node-formatting/__tests__"
     },
     {


### PR DESCRIPTION
### Description

The SchemaAttributesObject didn't have access to the current style. This meant that only one of the formatting attributes was reflected in the style.

Solution provided by @whawker

Fixes https://github.com/remirror/remirror/issues/1063

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
