### PR TITLE
fix: add missing changelog for earlier node formatting PR

### DIFF
--- a/.changeset/chatty-buttons-rush.md
+++ b/.changeset/chatty-buttons-rush.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-node-formatting': patch
+---
+
+Node formatting wasn't reflected in style attribute


### PR DESCRIPTION
### Description

This adds the changelog entry that was missed in PR https://github.com/remirror/remirror/pull/1071

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
