### PR TITLE
docs: import `useMentionAtom` from `@remirror/react`

### DIFF
--- a/packages/remirror__react-hooks/__stories__/use-mention-atom.stories.tsx
+++ b/packages/remirror__react-hooks/__stories__/use-mention-atom.stories.tsx
@@ -4,9 +4,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { PlaceholderExtension } from 'remirror/extensions';
 import { cx } from '@remirror/core';
 import { MentionAtomExtension, MentionAtomNodeAttributes } from '@remirror/extension-mention-atom';
-import { FloatingWrapper, Remirror, ThemeProvider, useRemirror } from '@remirror/react';
-
-import { useMentionAtom } from '../src/use-mention-atom';
+import {
+  FloatingWrapper,
+  Remirror,
+  ThemeProvider,
+  useMentionAtom,
+  useRemirror,
+} from '@remirror/react';
 
 export default { title: 'React Hooks / useMentionAtom' };
 


### PR DESCRIPTION
### Description

Users will feel confused when they see `../src/use-mention-atom` in the storybook.
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 