### PR TITLE
chore: deprecate `@remirror/react-native` and `@remirror/react-debugger`

### DIFF
--- a/.changeset/big-students-dream.md
+++ b/.changeset/big-students-dream.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-debugger': patch
+---
+
+Deprecate `@remirror/react-debugger`.

--- a/.changeset/quiet-tips-ring.md
+++ b/.changeset/quiet-tips-ring.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-native': patch
+---
+
+Deprecate `@remirror/react-native`.

--- a/packages/remirror__react-debugger/readme.md
+++ b/packages/remirror__react-debugger/readme.md
@@ -1,5 +1,7 @@
 # @remirror/react-debugger
 
+**DEPRECATED**
+
 [![npm bundle size (scoped)](https://img.shields.io/bundlephobia/minzip/@remirror/react-debugger.svg?)](https://bundlephobia.com/result?p=@remirror/react-debugger) [![npm](https://img.shields.io/npm/dm/@remirror/react-debugger.svg?&logo=npm)](https://www.npmjs.com/package/@remirror/react-debugger)
 
 Debug your `remirror` editor via this debugging tool.

--- a/packages/remirror__react-native/README.md
+++ b/packages/remirror__react-native/README.md
@@ -1,6 +1,6 @@
-i
-
 # @remirror/react-native
+
+**DEPRECATED**
 
 > Run your remirror editor for `React Native`
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->



### Checklist

 
- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
