### PR TITLE
fix(node-formatting): style attribute parse, invalid line-height

### DIFF
--- a/.changeset/red-beds-wait.md
+++ b/.changeset/red-beds-wait.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-node-formatting': patch
+---
+
+Fix eager parsing of style attribute, and limit valid `line-height` values in `NodeFormattingExtension`

--- a/packages/remirror__extension-node-formatting/src/node-formatting-utils.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-utils.ts
@@ -2,6 +2,7 @@ import {
   clamp,
   EditorState,
   extractPixelSize,
+  isNumber,
   last,
   NodeWithPosition,
   Shape,
@@ -117,4 +118,35 @@ export function extractIndent(indents: string[], marginLeft: string | null): num
   const indentIncrement = largestIndent / max;
 
   return clamp({ max, min: 0, value: Math.floor(value / indentIncrement) });
+}
+
+const NUMERIC_REGEX = /^\d+(?:\.\d+)?$/;
+const PERCENT_REGEX = /^(\d+(?:\.\d+)?)%$/;
+
+/**
+ * Extract the line height from numeric or percentage line-height values
+ */
+export function extractLineHeight(lineHeight: string | number | null): number | null {
+  if (isNumber(lineHeight)) {
+    return lineHeight;
+  }
+
+  if (!lineHeight) {
+    return null;
+  }
+
+  const lineHeightStr = lineHeight.trim();
+  const percentMatch = lineHeightStr.match(PERCENT_REGEX);
+
+  if (percentMatch) {
+    return Number.parseFloat(percentMatch[1] as string) / 100;
+  }
+
+  const numberMatch = lineHeightStr.match(NUMERIC_REGEX);
+
+  if (numberMatch) {
+    return Number.parseFloat(numberMatch[0] as string);
+  }
+
+  return null;
 }


### PR DESCRIPTION
### Description

The fixes added in #1071 seem to have caused an issue on copy-and-paste of HTML. The entire style attribute was parsed, leading to unpredictable results.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
