### PR TITLE
docs: remove non-functioning inline example

### DIFF
--- a/docs/extensions/markdown-extension.md
+++ b/docs/extensions/markdown-extension.md
@@ -3,8 +3,6 @@ hide_title: true
 title: MarkdownExtension
 ---
 
-import { Example } from '@components';
-
 # `MarkdownExtension`
 
 ## Summary
@@ -18,8 +16,6 @@ This extension transforms the **ProseMirror** content of your editor to markdown
 Markdown can be used to reduce the storage needed for your documents. It takes less space than a JSON object describing the same editor content.
 
 The following example shows a hook which can be used to automatically persist content as markdown.
-
-<Example name="" />
 
 ```ts
 import delay from 'delay';


### PR DESCRIPTION
### Description

We had initially considered to use inline examples (powered by the playground). Yet, this never fully worked, and we decided to use storybook for now. Hence, this commit removes the non-functioning inline example to avoid confusing the reader.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
