### PR TITLE
chore: deprecate `@remirror/extension-react-native-bridge`

### DIFF
--- a/.changeset/sixty-rivers-sniff.md
+++ b/.changeset/sixty-rivers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-react-native-bridge': patch
+---
+
+Deprecate `@remirror/extension-react-native-bridge`.

--- a/packages/remirror__extension-react-native-bridge/readme.md
+++ b/packages/remirror__extension-react-native-bridge/readme.md
@@ -1,5 +1,7 @@
 # @remirror/extension-react-native-bridge
 
+**DEPRECATED**
+
 > **Support for communication between the webview and native editor.**
 
 [![Version][version]][npm] [![Weekly Downloads][downloads-badge]][npm] [![Bundled size][size-badge]][size] [![Typed Codebase][typescript]](#) [![MIT License][license]](#)


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
