### PR TITLE
fix(i18n): set `sideEffect` as true because of global initialization

### DIFF
--- a/.changeset/fifty-weeks-visit.md
+++ b/.changeset/fifty-weeks-visit.md
@@ -1,0 +1,5 @@
+---
+'@remirror/i18n': patch
+---
+
+Set `sideEffect` as true.

--- a/packages/remirror__i18n/package.json
+++ b/packages/remirror__i18n/package.json
@@ -12,7 +12,7 @@
   "contributors": [
     "Ifiok Jr. <ifiokotung@gmail.com>"
   ],
-  "sideEffects": false,
+  "sideEffects": true,
   "exports": {
     ".": {
       "import": "./dist/remirror-i18n.esm.js",


### PR DESCRIPTION
### Description

Right now with Webpack 5 i got error
```
Plurals for locale undefined aren't loaded. Use i18n.loadLocaleData method to load plurals for specific locale. Using other plural rule as a fallback.
```
It's happen because package @remirror/i18n run side effects in index.ts file and with sideEffects:true webpack 5 remove that code

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
