### PR TITLE
fix: font-size failed to mixed string/number

### DIFF
--- a/packages/remirror__extension-font-size/src/font-size-extension.ts
+++ b/packages/remirror__extension-font-size/src/font-size-extension.ts
@@ -135,7 +135,12 @@ export class FontSizeExtension extends MarkExtension<FontSizeOptions> {
    */
   @command(setFontSizeOptions)
   setFontSize(size: string | number, options?: SizeCommandOptions): CommandFunction {
-    return this.store.commands.applyMark.original(this.type, { size }, options?.selection);
+    return this.store.commands.applyMark.original(
+      this.type,
+      // Store always as string. This removes the need to treat string vs number when using the value
+      { size: String(size) },
+      options?.selection,
+    );
   }
 
   @command(increaseFontSizeOptions)


### PR DESCRIPTION
### Description

The font-size extension through an exception when increasing/decreating the font size because it mixed up the representation of the size attribute. The reading code assumed it to be always string - whereas the writing code would set it to string or number.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
