### PR TITLE
fix: supported font cases

### DIFF
--- a/packages/remirror__extension-text-case/src/text-case-extension.ts
+++ b/packages/remirror__extension-text-case/src/text-case-extension.ts
@@ -96,7 +96,7 @@ export class TextCaseExtension extends MarkExtension<TextCaseOptions> {
           casing = 'none';
         }
 
-        const property = casing === 'smallCaps' ? 'fontVariant' : 'textTransform';
+        const property = casing === 'small-caps' ? 'fontVariant' : 'textTransform';
         style = joinStyles({ [property]: casing }, style);
 
         return ['span', { ...extraAttrs, style, [TEXT_CASE_ATTRIBUTE]: casing }, 0];

--- a/packages/remirror__extension-text-case/src/text-case-extension.ts
+++ b/packages/remirror__extension-text-case/src/text-case-extension.ts
@@ -27,7 +27,7 @@ import {
  */
 @extension<TextCaseOptions>({
   defaultOptions: {
-    defaultCasing: 'upper',
+    defaultCasing: 'none',
   },
   staticKeys: ['defaultCasing'],
 })

--- a/packages/remirror__extension-text-case/src/text-case-utils.ts
+++ b/packages/remirror__extension-text-case/src/text-case-utils.ts
@@ -8,7 +8,7 @@ export const toggleTextCaseOptions: Remirror.CommandDecoratorOptions = {
 
 export const TEXT_CASE_ATTRIBUTE = 'data-text-case';
 
-const VALID_CASING = ['upper', 'lower', 'upper', 'capitalize', 'smallCaps'];
+const VALID_CASING = ['uppercase', 'lowercase', 'capitalize', 'small-caps'];
 
 export function isValidCasing(value: unknown): value is Exclude<Casing, 'none'> {
   return includes(VALID_CASING, value);
@@ -23,7 +23,7 @@ export interface TextCaseOptions {
   defaultCasing?: Static<Casing>;
 }
 
-export type Casing = 'none' | 'upper' | 'lower' | 'upper' | 'capitalize' | 'smallCaps';
+export type Casing = 'none' | 'uppercase' | 'lowercase' | 'capitalize' | 'small-caps';
 export type TextCaseAttributes = ProsemirrorAttributes<{
   /**
    * The active text case for the


### PR DESCRIPTION
### Description

The pre-defined font cases didn't match the ones defined by the CSS spec.

@see https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
@see https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
