### PR TITLE
fix: website header too narrow on large screens

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -24,6 +24,10 @@ html[data-theme='dark'] {
   --ifm-menu-color-background-active: #fff;
 }
 
+.navbar--fixed-top {
+  width: 100%;
+}
+
 .navbar__items {
   color: #fff;
 }


### PR DESCRIPTION
### Description

On larger screens, the website header wouldn't stretch to the full page width.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/9339055/130568406-76e7399b-b547-4ba4-b43a-8a629ff217d6.mov
