### PR TITLE
docs: organize stories in sections

### DIFF
--- a/packages/storybook-react/preview.js
+++ b/packages/storybook-react/preview.js
@@ -1,1 +1,9 @@
 import './storybook.css';
+
+export const parameters = {
+  options: {
+    storySort: {
+      order: ['Editors', 'Extensions', 'React Hooks'],
+    },
+  },
+};

--- a/packages/storybook-react/stories/react-editors/markdown-editor.stories.tsx
+++ b/packages/storybook-react/stories/react-editors/markdown-editor.stories.tsx
@@ -35,7 +35,7 @@ import {
   UseRemirrorReturn,
 } from '@remirror/react';
 
-export default { title: 'Markdown Editor' };
+export default { title: 'Editors / Markdown' };
 
 /**
  * The editor which is used to create the annotation. Supports formatting.

--- a/packages/storybook-react/stories/react-editors/social-editor.stories.tsx
+++ b/packages/storybook-react/stories/react-editors/social-editor.stories.tsx
@@ -1,6 +1,6 @@
 import { SocialEditor } from '@remirror/react-editors/social';
 
-export default { title: 'Social Editor' };
+export default { title: 'Editors / Social' };
 
 export const Basic = () => {
   return <SocialEditor />;

--- a/packages/storybook-react/stories/react-editors/wysiwyg-editor.stories.tsx
+++ b/packages/storybook-react/stories/react-editors/wysiwyg-editor.stories.tsx
@@ -1,1 +1,1 @@
-export default { title: 'Wysiwyg Editor' };
+export default { title: 'Editors / Wysiwyg' };

--- a/packages/storybook-react/stories/react-renderer/react-renderer.stories.tsx
+++ b/packages/storybook-react/stories/react-renderer/react-renderer.stories.tsx
@@ -13,7 +13,7 @@ import {
 
 import { SAMPLE_DOC } from './sample-doc';
 
-export default { title: 'React Renderer (static HTML)' };
+export default { title: 'Editors / React Renderer (static HTML)' };
 
 const typeMap: MarkMap = {
   blockquote: 'blockquote',

--- a/packages/storybook-react/stories/react/controlled.stories.tsx
+++ b/packages/storybook-react/stories/react/controlled.stories.tsx
@@ -16,7 +16,7 @@ const DOC = {
   ],
 };
 
-export default { title: 'Controlled Editor' };
+export default { title: 'Editors / Controlled' };
 
 const extensions = () => [];
 


### PR DESCRIPTION
### Description

As there are now lots of stories for storybook, we need to categorize them in sections.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
