### PR TITLE
fix: bring back the social editor

### DIFF
--- a/packages/remirror__react-editors/src/social/social-editor.tsx
+++ b/packages/remirror__react-editors/src/social/social-editor.tsx
@@ -1,35 +1,111 @@
-import { FC } from 'react';
+import { FC, useCallback, useMemo, useState } from 'react';
 import { IdentifierSchemaAttributes } from 'remirror';
-import { EmojiExtension, LinkExtension, MentionExtension } from 'remirror/extensions';
+import {
+  EmojiExtension,
+  LinkExtension,
+  MentionAtomExtension,
+  MentionAtomNodeAttributes,
+  PlaceholderExtension,
+  wysiwygPreset,
+} from 'remirror/extensions';
 import data from 'svgmoji/emoji.json';
 import {
+  ComponentItem,
   EditorComponent,
   EmojiPopupComponent,
+  FloatingToolbar,
+  MentionAtomPopupComponent,
+  MentionAtomState,
   Remirror,
   ThemeProvider,
+  ToolbarItemUnion,
   useRemirror,
 } from '@remirror/react';
 import { AllStyledComponent } from '@remirror/styles/emotion';
-
-const extensions = () => [
-  new LinkExtension({ autoLink: true }),
-  new MentionExtension({
-    matchers: [
-      { name: 'at', char: '@', appendText: ' ' },
-      { name: 'tag', char: '#', appendText: ' ' },
-    ],
-  }),
-  new EmojiExtension({ plainText: false, data, moji: 'noto' }),
-];
 
 const extraAttributes: IdentifierSchemaAttributes[] = [
   { identifiers: ['mention', 'emoji'], attributes: { role: { default: 'presentation' } } },
   { identifiers: ['mention'], attributes: { href: { default: null } } },
 ];
 
-export interface SocialEditorProps {}
+export interface SocialEditorProps extends Pick<MentionComponentProps, 'users' | 'tags'> {
+  placeholder?: string;
+}
 
-export const SocialEditor: FC = (props) => {
+const floatingToolbarItems: ToolbarItemUnion[] = [
+  {
+    type: ComponentItem.ToolbarGroup,
+    label: 'Simple Formatting',
+    items: [
+      {
+        type: ComponentItem.ToolbarCommandButton,
+        commandName: 'toggleHeading',
+        display: 'icon',
+        attrs: { level: 1 },
+      },
+      {
+        type: ComponentItem.ToolbarCommandButton,
+        commandName: 'toggleHeading',
+        display: 'icon',
+        attrs: { level: 2 },
+      },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleBold', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleItalic', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleUnderline', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleStrike', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleCode', display: 'icon' },
+    ],
+  },
+];
+
+interface MentionComponentProps<
+  UserData extends MentionAtomNodeAttributes = MentionAtomNodeAttributes,
+> {
+  users?: UserData[];
+  tags?: string[];
+}
+
+function MentionComponent({ users, tags }: MentionComponentProps) {
+  const [mentionState, setMentionState] = useState<MentionAtomState | null>();
+  const tagItems = useMemo(
+    () => (tags ?? []).map((tag) => ({ id: tag, label: `#${tag}` })),
+    [tags],
+  );
+  const items = useMemo(() => {
+    if (!mentionState) {
+      return [];
+    }
+
+    const allItems = mentionState.name === 'at' ? users : tagItems;
+
+    if (!allItems) {
+      return [];
+    }
+
+    const query = mentionState.query.full.toLowerCase() ?? '';
+    return allItems.filter((item) => item.label.toLowerCase().includes(query)).sort();
+  }, [mentionState, users, tagItems]);
+
+  return <MentionAtomPopupComponent onChange={setMentionState} items={items} />;
+}
+
+export const SocialEditor: FC<SocialEditorProps> = ({ placeholder, ...props }) => {
+  const extensions = useCallback(
+    () => [
+      new PlaceholderExtension({ placeholder }),
+      new LinkExtension({ autoLink: true }),
+      new MentionAtomExtension({
+        matchers: [
+          { name: 'at', char: '@', appendText: ' ' },
+          { name: 'tag', char: '#', appendText: ' ' },
+        ],
+      }),
+      new EmojiExtension({ plainText: false, data, moji: 'noto' }),
+      ...wysiwygPreset(),
+    ],
+    [placeholder],
+  );
+
   const { children } = props;
   const { manager } = useRemirror({ extensions, extraAttributes });
 
@@ -39,6 +115,8 @@ export const SocialEditor: FC = (props) => {
         <Remirror manager={manager}>
           <EditorComponent />
           <EmojiPopupComponent />
+          <MentionComponent {...props} />
+          <FloatingToolbar items={floatingToolbarItems} positioner='selection' placement='bottom' />
           {children}
         </Remirror>
       </ThemeProvider>

--- a/packages/remirror__react-editors/src/social/social-editor.tsx
+++ b/packages/remirror__react-editors/src/social/social-editor.tsx
@@ -6,6 +6,7 @@ import {
   MentionAtomExtension,
   MentionAtomNodeAttributes,
   PlaceholderExtension,
+  TaskListExtension,
   wysiwygPreset,
 } from 'remirror/extensions';
 import data from 'svgmoji/emoji.json';
@@ -171,6 +172,7 @@ export const SocialEditor: FC<SocialEditorProps> = ({ placeholder, ...props }) =
         ],
       }),
       new EmojiExtension({ plainText: false, data, moji: 'noto' }),
+      new TaskListExtension({}),
       ...wysiwygPreset(),
     ],
     [placeholder],

--- a/packages/remirror__react-editors/src/social/social-editor.tsx
+++ b/packages/remirror__react-editors/src/social/social-editor.tsx
@@ -18,6 +18,7 @@ import {
   MentionAtomState,
   Remirror,
   ThemeProvider,
+  Toolbar,
   ToolbarItemUnion,
   useRemirror,
 } from '@remirror/react';
@@ -32,10 +33,35 @@ export interface SocialEditorProps extends Pick<MentionComponentProps, 'users' |
   placeholder?: string;
 }
 
-const floatingToolbarItems: ToolbarItemUnion[] = [
+const toolbarItems: ToolbarItemUnion[] = [
   {
     type: ComponentItem.ToolbarGroup,
-    label: 'Simple Formatting',
+    label: 'History',
+    items: [
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'undo', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'redo', display: 'icon' },
+      {
+        type: ComponentItem.ToolbarCommandButton,
+        commandName: 'toggleColumns',
+        display: 'icon',
+        attrs: { count: 2 },
+      },
+    ],
+    separator: 'end',
+  },
+  {
+    type: ComponentItem.ToolbarGroup,
+    label: 'Clipboard',
+    items: [
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'copy', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'cut', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'paste', display: 'icon' },
+    ],
+    separator: 'end',
+  },
+  {
+    type: ComponentItem.ToolbarGroup,
+    label: 'Heading Formatting',
     items: [
       {
         type: ComponentItem.ToolbarCommandButton,
@@ -49,6 +75,50 @@ const floatingToolbarItems: ToolbarItemUnion[] = [
         display: 'icon',
         attrs: { level: 2 },
       },
+      {
+        type: ComponentItem.ToolbarCommandButton,
+        commandName: 'toggleHeading',
+        display: 'icon',
+        attrs: { level: 3 },
+      },
+    ],
+    separator: 'end',
+  },
+  {
+    type: ComponentItem.ToolbarGroup,
+    label: 'Simple Formatting',
+    items: [
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleBold', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleItalic', display: 'icon' },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleUnderline', display: 'icon' },
+    ],
+    separator: 'end',
+  },
+  {
+    type: ComponentItem.ToolbarGroup,
+    label: 'Lists',
+    items: [
+      {
+        type: ComponentItem.ToolbarCommandButton,
+        commandName: 'toggleBulletList',
+        display: 'icon',
+      },
+      {
+        type: ComponentItem.ToolbarCommandButton,
+        commandName: 'toggleOrderedList',
+        display: 'icon',
+      },
+      { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleTaskList', display: 'icon' },
+    ],
+    separator: 'none',
+  },
+];
+
+const floatingToolbarItems: ToolbarItemUnion[] = [
+  {
+    type: ComponentItem.ToolbarGroup,
+    label: 'Simple Formatting',
+    items: [
       { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleBold', display: 'icon' },
       { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleItalic', display: 'icon' },
       { type: ComponentItem.ToolbarCommandButton, commandName: 'toggleUnderline', display: 'icon' },
@@ -113,6 +183,7 @@ export const SocialEditor: FC<SocialEditorProps> = ({ placeholder, ...props }) =
     <AllStyledComponent>
       <ThemeProvider>
         <Remirror manager={manager}>
+          <Toolbar items={toolbarItems} refocusEditor label='Top Toolbar' />
           <EditorComponent />
           <EmojiPopupComponent />
           <MentionComponent {...props} />

--- a/packages/storybook-react/stories/react-editors/social-editor.stories.tsx
+++ b/packages/storybook-react/stories/react-editors/social-editor.stories.tsx
@@ -1,7 +1,22 @@
+import { ProsemirrorDevTools } from '@remirror/dev';
 import { SocialEditor } from '@remirror/react-editors/social';
 
 export default { title: 'Editors / Social' };
 
+const ALL_USERS = [
+  { id: 'joe', label: 'Joe' },
+  { id: 'sue', label: 'Sue' },
+  { id: 'pat', label: 'Pat' },
+  { id: 'tom', label: 'Tom' },
+  { id: 'jim', label: 'Jim' },
+];
+
+const TAGS = ['editor', 'remirror', 'opensource', 'prosemirror'];
+
 export const Basic = () => {
-  return <SocialEditor />;
+  return (
+    <SocialEditor placeholder='Mention @joe or add #remirror' users={ALL_USERS} tags={TAGS}>
+      <ProsemirrorDevTools />
+    </SocialEditor>
+  );
 };


### PR DESCRIPTION
### Description

The social editor is a pre-packaged editor with mentioning and tagging. It got lost from pre-v1 to v1.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/9339055/130759513-17b0f1e8-757e-48c1-9c5f-3de709026d35.png)