### PR TITLE
feat(extension-positioner): add `helpers` to the `BasePositionerProps`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "checks:fix": "run-s -c fix typecheck test build size build:dev",
     "checks:release": "run-s checks build e2e",
     "clean": "pnpm if-clean git clean -- -fdx --exclude=.config.json --exclude=node_modules --exclude=**/node_modules",
-    "clean:all": "git clean -fdX --exclude='.config.json'",
+    "clean:all": "git clean -fdX --exclude='.config.json' --exclude='.idea'",
     "clean:modules": "git clean -fdX packages support",
     "clean:tsconfig": "rimraf packages/**/tsconfig.json",
     "cli": "node packages/remirror__cli/bin.js",

--- a/packages/remirror__extension-positioner/src/core-positioners.ts
+++ b/packages/remirror__extension-positioner/src/core-positioners.ts
@@ -38,7 +38,9 @@ export const defaultAbsolutePosition: PositionerPosition = {
  * It spans the full width and height of the block.
  */
 export const blockNodePositioner = Positioner.create<FindProsemirrorNodeResult>({
-  hasChanged: hasStateChanged,
+  hasChanged: (props) => {
+    return hasStateChanged(props);
+  },
 
   /**
    * This is only active for empty top level nodes. The data is the cursor start

--- a/packages/remirror__extension-positioner/src/positioner-extension.ts
+++ b/packages/remirror__extension-positioner/src/positioner-extension.ts
@@ -127,6 +127,7 @@ export class PositionerExtension extends PlainExtension<PositionerOptions> {
       ...update,
       previousState: update.firstUpdate ? undefined : update.previousState,
       event: 'state',
+      helpers: this.store.helpers,
     });
   }
 
@@ -197,6 +198,7 @@ export class PositionerExtension extends PlainExtension<PositionerOptions> {
     const previousState = this.store.previousState;
 
     return {
+      helpers: this.store.helpers,
       event,
       firstUpdate: false,
       previousState,

--- a/packages/remirror__extension-positioner/src/positioner.ts
+++ b/packages/remirror__extension-positioner/src/positioner.ts
@@ -1,5 +1,6 @@
 import { createNanoEvents, Unsubscribe } from 'nanoevents';
 import {
+  AnyFunction,
   EditorState,
   EditorViewProps,
   ErrorConstant,
@@ -133,6 +134,8 @@ export interface SetActiveElement {
 }
 
 export interface BasePositionerProps extends Omit<StateUpdateLifecycleProps, 'previousState'> {
+  helpers: Record<string, AnyFunction>;
+
   previousState: undefined | EditorState;
 
   /**


### PR DESCRIPTION
### Description

Add helpers to the `BasePositionerProps`. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
