### PR TITLE
fix: toolbar buttons didn't visualize active state

### DIFF
--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -6,8 +6,8 @@
 }
 
 .remirror-button-active {
-  color: var(--rmr-color-primary-text);
-  background-color: var(--rmr-color-primary);
+  color: var(--rmr-color-primary-text) !important;
+  background-color: var(--rmr-color-primary) !important;
 }
 
 .remirror-button {

--- a/packages/remirror__styles/components.css
+++ b/packages/remirror__styles/components.css
@@ -6,8 +6,8 @@
 }
 
 .remirror-button-active {
-  color: var(--rmr-color-primary-text);
-  background-color: var(--rmr-color-primary);
+  color: var(--rmr-color-primary-text) !important;
+  background-color: var(--rmr-color-primary) !important;
 }
 
 .remirror-button {

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -15,8 +15,8 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
   }
 
   .remirror-button-active {
-    color: var(--rmr-color-primary-text);
-    background-color: var(--rmr-color-primary);
+    color: var(--rmr-color-primary-text) !important;
+    background-color: var(--rmr-color-primary) !important;
   }
 
   .remirror-button {

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -14,8 +14,8 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
   }
 
   .remirror-button-active {
-    color: var(--rmr-color-primary-text);
-    background-color: var(--rmr-color-primary);
+    color: var(--rmr-color-primary-text) !important;
+    background-color: var(--rmr-color-primary) !important;
   }
 
   .remirror-button {

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -13,8 +13,8 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
   }
 
   .remirror-button-active {
-    color: var(--rmr-color-primary-text);
-    background-color: var(--rmr-color-primary);
+    color: var(--rmr-color-primary-text) !important;
+    background-color: var(--rmr-color-primary) !important;
   }
 
   .remirror-button {

--- a/packages/remirror__theme/src/components-theme.ts
+++ b/packages/remirror__theme/src/components-theme.ts
@@ -22,8 +22,8 @@ export const EDITOR_WRAPPER = css`
 `;
 
 export const BUTTON_ACTIVE = css`
-  color: ${primaryText};
-  background-color: ${primary};
+  color: ${primaryText}!important;
+  background-color: ${primary}!important;
 `;
 
 export const BUTTON = css`


### PR DESCRIPTION
### Description

The buttons in the toolbar didn't change their color when being active, e.g. the bold button when a bold text is selected.

The active style is correctly added to the button: `class="remirror-role remirror-button remirror-button-active remirror-tabbable"`. Yet, the CSS definitions themselves don't have any priority.

_Note: The alternative solution would be to introduce priority in the style definitions, e.g. `.remirror-button.remirror-button-active` instead of just `.remirror-button-active`. The CSS styles are generated by linaria but I didn't find a way to introduce sub classes._

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
