### PR TITLE
feat(extension-list): don't require a `NodeSelection` to fire `toggleCheckboxChecked`

### DIFF
--- a/.changeset/shiny-trains-promise.md
+++ b/.changeset/shiny-trains-promise.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Don't require a `NodeSelection` to fire `toggleCheckboxChecked` anymore.

--- a/packages/remirror__extension-list/__tests__/list-commands.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-commands.spec.ts
@@ -338,7 +338,7 @@ describe('toggleCheckboxChecked', () => {
     new TaskListExtension(),
   ]);
   const {
-    nodes: { doc, paragraph: p, taskList, bulletList: ul, listItem: li, orderedList: ol },
+    nodes: { doc, paragraph: p, taskList },
     attributeNodes: { taskListItem },
   } = editor;
   const checked = taskListItem({ checked: true });

--- a/packages/remirror__extension-list/__tests__/list-commands.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-commands.spec.ts
@@ -329,3 +329,126 @@ describe('toggleList', () => {
     expect(view.state.doc).toEqualProsemirrorNode(unchanged);
   });
 });
+
+describe('toggleCheckboxChecked', () => {
+  const editor = renderEditor([
+    new ListItemExtension(),
+    new BulletListExtension(),
+    new OrderedListExtension(),
+    new TaskListExtension(),
+  ]);
+  const {
+    nodes: { doc, paragraph: p, taskList, bulletList: ul, listItem: li, orderedList: ol },
+    attributeNodes: { taskListItem },
+  } = editor;
+  const checked = taskListItem({ checked: true });
+  const unchecked = taskListItem({ checked: false });
+
+  it('toggles checkbox checked when the cursor is at the end of a task list item', () => {
+    const from = doc(
+      taskList(
+        unchecked(p('hello<cursor>')), //
+      ),
+    );
+    const to = doc(
+      taskList(
+        checked(p('hello')), //
+      ),
+    );
+    editor.add(from).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
+
+  it('toggles checkbox checked when the cursor is at the begining of a task list item', () => {
+    const from = doc(
+      taskList(
+        unchecked(p('<cursor>hello')), //
+      ),
+    );
+    const to = doc(
+      taskList(
+        checked(p('hello')), //
+      ),
+    );
+    editor.add(from).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
+
+  it('toggles checkbox checked when the cursor is at the middle of a task list item', () => {
+    const from = doc(
+      taskList(
+        checked(p('h<start>ell<end>o')), //
+      ),
+    );
+    const to = doc(
+      taskList(
+        unchecked(p('hello')), //
+      ),
+    );
+    editor.add(from).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
+
+  it('does not toggle checkbox checked when the cursor is outside of a task list item', () => {
+    const from = doc(
+      taskList(
+        checked(p('hello')), //
+      ),
+      p('<cursor>world'),
+    );
+    const to = doc(
+      taskList(
+        checked(p('hello')), //
+      ),
+      p('world'),
+    );
+    editor.add(from).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
+
+  it('only toggles the first item', () => {
+    const from = doc(
+      taskList(
+        checked(p('111111')),
+        checked(p('2222<start>22')),
+        unchecked(p('333333')),
+        unchecked(p('4444<end>44')),
+        unchecked(p('555555')), //
+      ),
+    );
+    const to = doc(
+      taskList(
+        checked(p('111111')),
+        unchecked(p('222222')),
+        unchecked(p('333333')),
+        unchecked(p('444444')),
+        unchecked(p('555555')), //
+      ),
+    );
+    editor.add(from).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
+
+  it('accepts an optional boolean paramter', () => {
+    const checkedDoc = doc(taskList(checked(p('hello<cursor>'))));
+    const uncheckedDoc = doc(taskList(unchecked(p('hello<cursor>'))));
+
+    editor.add(checkedDoc).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(uncheckedDoc);
+
+    editor.add(checkedDoc).commands.toggleCheckboxChecked(true);
+    expect(editor.view.state.doc).toEqualProsemirrorNode(checkedDoc);
+
+    editor.add(checkedDoc).commands.toggleCheckboxChecked(false);
+    expect(editor.view.state.doc).toEqualProsemirrorNode(uncheckedDoc);
+
+    editor.add(uncheckedDoc).commands.toggleCheckboxChecked();
+    expect(editor.view.state.doc).toEqualProsemirrorNode(checkedDoc);
+
+    editor.add(uncheckedDoc).commands.toggleCheckboxChecked(true);
+    expect(editor.view.state.doc).toEqualProsemirrorNode(checkedDoc);
+
+    editor.add(uncheckedDoc).commands.toggleCheckboxChecked(false);
+    expect(editor.view.state.doc).toEqualProsemirrorNode(uncheckedDoc);
+  });
+});

--- a/packages/remirror__extension-list/__tests__/list-commands.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-commands.spec.ts
@@ -429,7 +429,7 @@ describe('toggleCheckboxChecked', () => {
     expect(editor.view.state.doc).toEqualProsemirrorNode(to);
   });
 
-  it('accepts an optional boolean paramter', () => {
+  it('accepts an optional boolean parameter', () => {
     const checkedDoc = doc(taskList(checked(p('hello<cursor>'))));
     const uncheckedDoc = doc(taskList(unchecked(p('hello<cursor>'))));
 

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -130,14 +130,15 @@ export class TaskListItemExtension extends NodeExtension {
     return ({ tr, dispatch }) => {
       const { selection } = tr;
 
-      // Make sure the list item is selected. Otherwise do nothing.
-      if (!isNodeSelection(selection) || selection.node.type.name !== this.name) {
+      const found = findParentNodeOfType({ selection, types: this.type });
+
+      if (!found) {
         return false;
       }
 
-      const { node, from } = selection;
+      const { node, pos } = found;
       const attrs = { ...node.attrs, checked: checked ?? !node.attrs.checked };
-      dispatch?.(tr.setNodeMarkup(from, undefined, attrs));
+      dispatch?.(tr.setNodeMarkup(pos, undefined, attrs));
 
       return true;
     };

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -7,7 +7,6 @@ import {
   findParentNodeOfType,
   getMatchString,
   isElementDomNode,
-  isNodeSelection,
   KeyBindings,
   NodeExtension,
   NodeExtensionSpec,


### PR DESCRIPTION

### Description

When using shortcut to toggle a checkbox, I don't want the cursor to move. That's why I feel we should allow a non-NodeSelecton when firing`toggleCheckboxChecked`.
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 