### PR TITLE
fix(theme): reset some CSS on IMG separator nodes

### DIFF
--- a/.changeset/lazy-crews-speak.md
+++ b/.changeset/lazy-crews-speak.md
@@ -1,0 +1,6 @@
+---
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Reset some CSS on IMG separator nodes.

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -618,6 +618,14 @@ button:active .remirror-menu-pane-shortcut,
   caret-color: var(--rmr-color-selection-caret);
   text-shadow: var(--rmr-color-selection-shadow);
 }
+
+/* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */
+
+.remirror-editor.ProseMirror img.ProseMirror-separator {
+  display: inline !important;
+  border: none !important;
+  margin: 0 !important;
+}
 .remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }

--- a/packages/remirror__styles/core.css
+++ b/packages/remirror__styles/core.css
@@ -45,6 +45,14 @@
   caret-color: var(--rmr-color-selection-caret);
   text-shadow: var(--rmr-color-selection-shadow);
 }
+
+/* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */
+
+.remirror-editor.ProseMirror img.ProseMirror-separator {
+  display: inline !important;
+  border: none !important;
+  margin: 0 !important;
+}
 .remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
 }

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -629,6 +629,14 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     caret-color: var(--rmr-color-selection-caret);
     text-shadow: var(--rmr-color-selection-shadow);
   }
+
+  /* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */
+
+  .remirror-editor.ProseMirror img.ProseMirror-separator {
+    display: inline !important;
+    border: none !important;
+    margin: 0 !important;
+  }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -632,6 +632,14 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     caret-color: var(--rmr-color-selection-caret);
     text-shadow: var(--rmr-color-selection-shadow);
   }
+
+  /* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */
+
+  .remirror-editor.ProseMirror img.ProseMirror-separator {
+    display: inline !important;
+    border: none !important;
+    margin: 0 !important;
+  }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -631,6 +631,14 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     caret-color: var(--rmr-color-selection-caret);
     text-shadow: var(--rmr-color-selection-shadow);
   }
+
+  /* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */
+
+  .remirror-editor.ProseMirror img.ProseMirror-separator {
+    display: inline !important;
+    border: none !important;
+    margin: 0 !important;
+  }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
   }

--- a/packages/remirror__theme/src/core-theme.ts
+++ b/packages/remirror__theme/src/core-theme.ts
@@ -44,6 +44,13 @@ export const EDITOR = css`
       caret-color: ${getTheme((t) => t.color.selection.caret)};
       text-shadow: ${getTheme((t) => t.color.selection.shadow)};
     }
+
+    /* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */
+    img.ProseMirror-separator {
+      display: inline !important;
+      border: none !important;
+      margin: 0 !important;
+    }
   }
 
   &.ProseMirror-hideselection *::selection {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Migrate the patch from prosemirro-view https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
