### PR TITLE
fix: task list was not available in SocialEditor

### DIFF
--- a/.changeset/eight-bears-relate.md
+++ b/.changeset/eight-bears-relate.md
@@ -1,0 +1,5 @@
+---
+'@remirror/preset-wysiwyg': patch
+---
+
+fix: task list wasn't available in wysiwyg editors

--- a/packages/remirror__preset-wysiwyg/src/wysiwyg-preset.ts
+++ b/packages/remirror__preset-wysiwyg/src/wysiwyg-preset.ts
@@ -16,7 +16,7 @@ import { LinkExtension, LinkOptions } from '@remirror/extension-link';
 import {
   BulletListExtension,
   OrderedListExtension,
-  TaskListItemExtension,
+  TaskListExtension,
 } from '@remirror/extension-list';
 import { TableExtension } from '@remirror/extension-react-tables';
 import { SearchExtension, SearchOptions } from '@remirror/extension-search';
@@ -67,7 +67,7 @@ export function wysiwygPreset(options: GetStaticAndDynamic<WysiwygOptions> = {})
   const iframeExtension = new IframeExtension();
   const bulletListExtension = new BulletListExtension();
   const orderedListExtension = new OrderedListExtension();
-  const taskListExtension = new TaskListItemExtension({});
+  const taskListExtension = new TaskListExtension({});
 
   const { selectTextOnClick } = options;
   const linkExtension = new LinkExtension({ autoLink: true, selectTextOnClick });
@@ -181,4 +181,4 @@ export type WysiwygPreset =
   | IframeExtension
   | BulletListExtension
   | OrderedListExtension
-  | TaskListItemExtension;
+  | TaskListExtension;


### PR DESCRIPTION
### Description

The wrong extension was added in the wysiwygPreset

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
