### PR TITLE
fix(extension-list): don't create a node selection within the `toggleCheckboxChecked` command

### DIFF
--- a/.changeset/six-readers-hug.md
+++ b/.changeset/six-readers-hug.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Don't create a node selection within the `toggleCheckboxChecked` command.

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -17,7 +17,7 @@ import {
 } from '@remirror/core';
 import { InputRule } from '@remirror/pm/inputrules';
 import { ResolvedPos } from '@remirror/pm/model';
-import { EditorState, NodeSelection, TextSelection } from '@remirror/pm/state';
+import { EditorState, TextSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
 import { splitListItem } from './list-commands';

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -16,6 +16,7 @@ import {
   ProsemirrorAttributes,
 } from '@remirror/core';
 import { InputRule } from '@remirror/pm/inputrules';
+import { ResolvedPos } from '@remirror/pm/model';
 import { EditorState, NodeSelection, TextSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
@@ -123,13 +124,18 @@ export class TaskListItemExtension extends NodeExtension {
    * @param checked - the `checked` attribute. If it's a boolean value, then it
    * will be set as an attribute. If it's undefined, then the `checked` attribuate
    * will be toggled.
+   *
+   * @param selection - a resolved position within the task list item you want to
+   * toggle. It it's not passed, the lower bound of the current selection's will
+   * be used.
    */
   @command()
-  toggleCheckboxChecked(checked?: boolean): CommandFunction {
+  toggleCheckboxChecked(checked?: boolean, $pos?: ResolvedPos): CommandFunction {
     return ({ tr, dispatch }) => {
-      const { selection } = tr;
-
-      const found = findParentNodeOfType({ selection, types: this.type });
+      const found = findParentNodeOfType({
+        selection: $pos ?? tr.selection.$from,
+        types: this.type,
+      });
 
       if (!found) {
         return false;

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -90,9 +90,8 @@ export class TaskListItemExtension extends NodeExtension {
       checkbox.contentEditable = 'false';
       checkbox.addEventListener('click', () => {
         const pos = (getPos as () => number)();
-        const selection = NodeSelection.create(view.state.doc, pos);
-        view.dispatch(view.state.tr.setSelection(selection));
-        this.store.commands.toggleCheckboxChecked();
+        const $pos = view.state.doc.resolve(pos);
+        this.store.commands.toggleCheckboxChecked({ $pos });
         return true;
       });
 
@@ -130,7 +129,19 @@ export class TaskListItemExtension extends NodeExtension {
    * be used.
    */
   @command()
-  toggleCheckboxChecked(checked?: boolean, $pos?: ResolvedPos): CommandFunction {
+  toggleCheckboxChecked(
+    props?: { checked?: boolean; $pos?: ResolvedPos } | boolean,
+  ): CommandFunction {
+    let checked: boolean | undefined;
+    let $pos: ResolvedPos | undefined;
+
+    if (typeof props === 'boolean') {
+      checked = props;
+    } else if (props) {
+      checked = props.checked;
+      $pos = props.$pos;
+    }
+
     return ({ tr, dispatch }) => {
       const found = findParentNodeOfType({
         selection: $pos ?? tr.selection.$from,


### PR DESCRIPTION
 
### Description

we don't need a node selection anymore after #1183
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
