### PR TITLE
chore: update funding.yml

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -3,5 +3,4 @@ github:
   - remirror
   - whawker
   - ocavue
-  - benjie
   - ronnyroeller


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Copy from GitHub Support:

> Our engineering team have established the cause of the issue you're experiencing - Apparently, there's a limit on how many links you can include per funding.yml file.
> 
> The limit is 1 sponsorable org and 4 sponsorable users.
> 
> We're not quite sure why this limit was imposed or whether it's something we're able to increase, but we're continuing to investigate on those points.
> 
> I'll get back in touch once I hear more - Thanks for your patience.

So let keep funding.yml fit GitHub's requirement.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 