### PR TITLE
fix: remove react dependency from wysiwyg-preset

### DIFF
--- a/.changeset/calm-olives-repair.md
+++ b/.changeset/calm-olives-repair.md
@@ -1,0 +1,5 @@
+---
+'@remirror/preset-wysiwyg': minor
+---
+
+Remove react dependency from wysiwyg-preset: An earlier commit upgraded the tables from simple to fancy tables. As a side effect, this had introduced a dependency from wysiwyg to the react-part of remirror. This change removes this dependency again.

--- a/packages/remirror__preset-wysiwyg/__tests__/tsconfig.json
+++ b/packages/remirror__preset-wysiwyg/__tests__/tsconfig.json
@@ -80,16 +80,10 @@
       "path": "../../remirror__extension-list/src"
     },
     {
-      "path": "../../remirror__extension-react-tables/src"
-    },
-    {
       "path": "../../remirror__extension-search/src"
     },
     {
       "path": "../../remirror__extension-strike/src"
-    },
-    {
-      "path": "../../remirror__extension-tables/src"
     },
     {
       "path": "../../remirror__extension-trailing-node/src"

--- a/packages/remirror__preset-wysiwyg/package.json
+++ b/packages/remirror__preset-wysiwyg/package.json
@@ -57,10 +57,8 @@
     "@remirror/extension-italic": "^1.0.3",
     "@remirror/extension-link": "^1.0.3",
     "@remirror/extension-list": "^1.0.10",
-    "@remirror/extension-react-tables": "^1.0.8",
     "@remirror/extension-search": "^1.0.3",
     "@remirror/extension-strike": "^1.0.3",
-    "@remirror/extension-tables": "^1.0.4",
     "@remirror/extension-trailing-node": "^1.0.3",
     "@remirror/extension-underline": "^1.0.3",
     "@remirror/preset-core": "^1.0.5"

--- a/packages/remirror__preset-wysiwyg/src/tsconfig.json
+++ b/packages/remirror__preset-wysiwyg/src/tsconfig.json
@@ -65,16 +65,10 @@
       "path": "../../remirror__extension-list/src"
     },
     {
-      "path": "../../remirror__extension-react-tables/src"
-    },
-    {
       "path": "../../remirror__extension-search/src"
     },
     {
       "path": "../../remirror__extension-strike/src"
-    },
-    {
-      "path": "../../remirror__extension-tables/src"
     },
     {
       "path": "../../remirror__extension-trailing-node/src"

--- a/packages/remirror__preset-wysiwyg/src/wysiwyg-preset.ts
+++ b/packages/remirror__preset-wysiwyg/src/wysiwyg-preset.ts
@@ -18,10 +18,8 @@ import {
   OrderedListExtension,
   TaskListExtension,
 } from '@remirror/extension-list';
-import { TableExtension } from '@remirror/extension-react-tables';
 import { SearchExtension, SearchOptions } from '@remirror/extension-search';
 import { StrikeExtension } from '@remirror/extension-strike';
-import { TableOptions } from '@remirror/extension-tables';
 import { TrailingNodeExtension, TrailingNodeOptions } from '@remirror/extension-trailing-node';
 import { UnderlineExtension } from '@remirror/extension-underline';
 
@@ -33,8 +31,7 @@ export interface WysiwygOptions
     HeadingOptions,
     LinkOptions,
     SearchOptions,
-    TrailingNodeOptions,
-    TableOptions {}
+    TrailingNodeOptions {}
 
 const DEFAULT_OPTIONS = {
   ...BidiExtension.defaultOptions,
@@ -44,7 +41,6 @@ const DEFAULT_OPTIONS = {
   ...SearchExtension.defaultOptions,
   ...TrailingNodeExtension.defaultOptions,
   ...HeadingExtension.defaultOptions,
-  ...TableExtension.defaultOptions,
 };
 
 /**
@@ -63,7 +59,6 @@ export function wysiwygPreset(options: GetStaticAndDynamic<WysiwygOptions> = {})
   const underlineExtension = new UnderlineExtension();
   const blockquoteExtension = new BlockquoteExtension();
   const codeExtension = new CodeExtension();
-  const tableExtension = new TableExtension();
   const iframeExtension = new IframeExtension();
   const bulletListExtension = new BulletListExtension();
   const orderedListExtension = new OrderedListExtension();
@@ -139,7 +134,6 @@ export function wysiwygPreset(options: GetStaticAndDynamic<WysiwygOptions> = {})
     blockquoteExtension,
     codeBlockExtension,
     headingExtension,
-    tableExtension,
     iframeExtension,
     bulletListExtension,
     orderedListExtension,
@@ -169,7 +163,6 @@ export type WysiwygPreset =
   | UnderlineExtension
   | BlockquoteExtension
   | CodeExtension
-  | TableExtension
   | LinkExtension
   | BidiExtension
   | BoldExtension

--- a/packages/remirror__react-editors/__e2e__/tsconfig.json
+++ b/packages/remirror__react-editors/__e2e__/tsconfig.json
@@ -33,6 +33,9 @@
       "path": "../../remirror__core-helpers/src"
     },
     {
+      "path": "../../remirror__extension-react-tables/src"
+    },
+    {
       "path": "../../remirror__pm/src"
     },
     {

--- a/packages/remirror__react-editors/package.json
+++ b/packages/remirror__react-editors/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@remirror/core-helpers": "^1.0.1",
+    "@remirror/extension-react-tables": "^1.0.8",
     "@remirror/pm": "^1.0.2",
     "@remirror/react": "^1.0.8",
     "@remirror/styles": "^1.1.2",

--- a/packages/remirror__react-editors/src/social/social-editor.tsx
+++ b/packages/remirror__react-editors/src/social/social-editor.tsx
@@ -8,6 +8,7 @@ import {
   wysiwygPreset,
 } from 'remirror/extensions';
 import data from 'svgmoji/emoji.json';
+import { TableExtension } from '@remirror/extension-react-tables';
 import {
   EditorComponent,
   EmojiPopupComponent,
@@ -67,6 +68,7 @@ export const SocialEditor: FC<SocialEditorProps> = ({ placeholder, ...props }) =
   const extensions = useCallback(
     () => [
       new PlaceholderExtension({ placeholder }),
+      new TableExtension(),
       new MentionAtomExtension({
         matchers: [
           { name: 'at', char: '@', appendText: ' ' },

--- a/packages/remirror__react-editors/src/tsconfig.json
+++ b/packages/remirror__react-editors/src/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../../remirror__core-helpers/src"
     },
     {
+      "path": "../../remirror__extension-react-tables/src"
+    },
+    {
       "path": "../../remirror__pm/src"
     },
     {

--- a/packages/remirror__react-editors/src/wysiwyg/wysiwyg-editor.tsx
+++ b/packages/remirror__react-editors/src/wysiwyg/wysiwyg-editor.tsx
@@ -1,5 +1,6 @@
 import { FC, useCallback } from 'react';
 import { PlaceholderExtension, wysiwygPreset } from 'remirror/extensions';
+import { TableExtension } from '@remirror/extension-react-tables';
 import {
   EditorComponent,
   Remirror,
@@ -18,7 +19,7 @@ export interface WysiwygEditorProps {
 
 export const WysiwygEditor: FC<WysiwygEditorProps> = ({ placeholder, ...props }) => {
   const extensions = useCallback(
-    () => [new PlaceholderExtension({ placeholder }), ...wysiwygPreset()],
+    () => [new PlaceholderExtension({ placeholder }), new TableExtension(), ...wysiwygPreset()],
     [placeholder],
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1937,10 +1937,8 @@ importers:
       '@remirror/extension-italic': ^1.0.3
       '@remirror/extension-link': ^1.0.3
       '@remirror/extension-list': ^1.0.10
-      '@remirror/extension-react-tables': ^1.0.8
       '@remirror/extension-search': ^1.0.3
       '@remirror/extension-strike': ^1.0.3
-      '@remirror/extension-tables': ^1.0.4
       '@remirror/extension-trailing-node': ^1.0.3
       '@remirror/extension-underline': ^1.0.3
       '@remirror/pm': ^1.0.2
@@ -1963,10 +1961,8 @@ importers:
       '@remirror/extension-italic': link:../remirror__extension-italic
       '@remirror/extension-link': link:../remirror__extension-link
       '@remirror/extension-list': link:../remirror__extension-list
-      '@remirror/extension-react-tables': link:../remirror__extension-react-tables
       '@remirror/extension-search': link:../remirror__extension-search
       '@remirror/extension-strike': link:../remirror__extension-strike
-      '@remirror/extension-tables': link:../remirror__extension-tables
       '@remirror/extension-trailing-node': link:../remirror__extension-trailing-node
       '@remirror/extension-underline': link:../remirror__extension-underline
       '@remirror/preset-core': link:../remirror__preset-core
@@ -2139,6 +2135,7 @@ importers:
       '@babel/runtime': ^7.13.10
       '@emotion/css': ^11.1.3
       '@remirror/core-helpers': ^1.0.1
+      '@remirror/extension-react-tables': ^1.0.8
       '@remirror/pm': ^1.0.2
       '@remirror/react': ^1.0.8
       '@remirror/styles': ^1.1.2
@@ -2155,6 +2152,7 @@ importers:
     dependencies:
       '@babel/runtime': 7.15.3
       '@remirror/core-helpers': link:../remirror__core-helpers
+      '@remirror/extension-react-tables': link:../remirror__extension-react-tables
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
       '@remirror/styles': link:../remirror__styles

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -753,10 +753,8 @@
       "@remirror/extension-italic",
       "@remirror/extension-link",
       "@remirror/extension-list",
-      "@remirror/extension-react-tables",
       "@remirror/extension-search",
       "@remirror/extension-strike",
-      "@remirror/extension-tables",
       "@remirror/extension-trailing-node",
       "@remirror/extension-underline",
       "@remirror/preset-core"


### PR DESCRIPTION
### Description

Commit https://github.com/remirror/remirror/commit/9b8f7662775fa8228b43c327d497ccbf30c0c730 had introduced a dependency from wysiwyg to the react-part of remirror. This removes this dependency again.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
