### PR TITLE
fix(core): unchained commands should use a new transaction

### DIFF
--- a/.changeset/twelve-hotels-matter.md
+++ b/.changeset/twelve-hotels-matter.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Unchained commands should use a new transaction to prevent leaking of previous command steps

--- a/packages/remirror__core/__tests__/remirror-manager.spec.tsx
+++ b/packages/remirror__core/__tests__/remirror-manager.spec.tsx
@@ -17,7 +17,7 @@ import type {
   ProsemirrorAttributes,
 } from '@remirror/core-types';
 import { Schema } from '@remirror/pm/model';
-import { EditorState, Plugin } from '@remirror/pm/state';
+import { EditorState, Plugin, Transaction } from '@remirror/pm/state';
 import { EditorView } from '@remirror/pm/view';
 
 describe('Manager', () => {
@@ -95,14 +95,19 @@ describe('Manager', () => {
   it('supports commands', () => {
     const attributes = { a: 'a' };
     manager.store.commands.dummy(attributes);
+    const { state, dispatch } = manager.view;
 
     expect(mock).toHaveBeenCalledWith(attributes);
     expect(innerMock).toHaveBeenCalledWith({
-      state: manager.view.state,
-      dispatch: manager.view.dispatch,
+      state: state,
+      dispatch: dispatch,
       view: manager.view,
-      tr: manager.tr,
+      tr: expect.any(Transaction),
     });
+
+    const { tr } = innerMock.mock.calls[0][0];
+    // Check this transaction is empty
+    expect(tr.steps).toHaveLength(0);
   });
 
   it('supports helpers', () => {

--- a/packages/remirror__core/src/builtins/commands-extension.ts
+++ b/packages/remirror__core/src/builtins/commands-extension.ts
@@ -1133,7 +1133,7 @@ export class CommandsExtension extends PlainExtension<CommandOptions> {
         dispatch = view.dispatch;
       }
 
-      return command(...args)({ state, dispatch, view, tr: this.transaction });
+      return command(...args)({ state, dispatch, view, tr: state.tr });
     };
   }
 

--- a/packages/remirror__react-core/__tests__/controlled.spec.tsx
+++ b/packages/remirror__react-core/__tests__/controlled.spec.tsx
@@ -329,22 +329,8 @@ test('can run multiple commands', () => {
   };
 
   const Component = () => {
-    const [value, setValue] = useState<EditorState>(
-      manager.createState({
-        content: '',
-      }),
-    );
-
     return (
-      <Remirror
-        {...props}
-        state={value}
-        manager={manager}
-        onChange={(changeProps) => {
-          const { state } = changeProps;
-          setValue(state);
-        }}
-      >
+      <Remirror {...props} manager={manager}>
         <InnerComponent />
       </Remirror>
     );

--- a/packages/remirror__react-core/__tests__/core.spec.tsx
+++ b/packages/remirror__react-core/__tests__/core.spec.tsx
@@ -1,13 +1,11 @@
 import { axe } from 'jest-axe';
 import { RemirrorTestChain } from 'jest-remirror';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { renderToString } from 'react-dom/server';
-import { RemirrorEventListener } from 'remirror';
 import { hideConsoleError, rafMock } from 'testing';
 import { act, fireEvent, render, strictRender } from 'testing/react';
 import {
   createReactManager,
-  ReactExtensions,
   ReactFrameworkOutput,
   Remirror,
   useRemirror,
@@ -338,34 +336,13 @@ test('`focus` should be chainable', () => {
   };
 
   const Component = () => {
-    const [state, setState] = useState(() =>
-      manager.createState({
-        content: '<p>Content </p>',
-        selection: 'end',
-      }),
-    );
-
-    const onChange: RemirrorEventListener<ReactExtensions<never>> = useCallback(
-      ({ state, firstRender }) => {
-        if (firstRender) {
-          return;
-        }
-
-        act(() => {
-          setState(state);
-        });
-      },
-      [],
-    );
+    const state = manager.createState({
+      content: '<p>Content </p>',
+      selection: 'end',
+    });
 
     return (
-      <Remirror
-        autoFocus={true}
-        manager={manager}
-        onChange={onChange}
-        state={state}
-        autoRender='start'
-      >
+      <Remirror autoFocus={true} manager={manager} initialContent={state} autoRender='start'>
         <TrapContext />
       </Remirror>
     );

--- a/support/root/jest.config.js
+++ b/support/root/jest.config.js
@@ -70,7 +70,7 @@ module.exports = {
     '!packages/remirror__cli/**',
   ],
   coverageReporters: ['json', 'lcov', 'text-summary', 'clover'],
-  collectCoverage: true,
+  collectCoverage: !!process.env.CI,
   reporters,
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
   testRunner: 'jest-circus/runner',


### PR DESCRIPTION
### Description

Unchained commands should use a new transaction to prevent leaking of previous command steps

Fixes #1197

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
