### PR TITLE
fix(prosemirror-resizable-view): don't discard node attributes when resizing

### DIFF
--- a/.changeset/cool-wolves-camp.md
+++ b/.changeset/cool-wolves-camp.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-resizable-view': patch
+---
+
+Don't discard node attributes when resizing.

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -196,8 +196,9 @@ export abstract class ResizableNodeView implements NodeView {
 
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
-      const transaction = view.state.tr.setNodeMarkup(getPos(), undefined, {
-        src: this.#node.attrs.src,
+      const pos = getPos();
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+        ...this.#node.attrs,
         width: this.dom.style.width,
         height: this.dom.style.height,
       });
@@ -205,7 +206,7 @@ export abstract class ResizableNodeView implements NodeView {
       this.#width = this.dom.style.width;
       this.#height = this.dom.style.height;
 
-      view.dispatch(transaction);
+      view.dispatch(tr);
     };
 
     document.addEventListener('mousemove', onMouseMove);


### PR DESCRIPTION


### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
