### PR TITLE
feat(resizable-view):  make handle more recognizable

### DIFF
--- a/.changeset/thin-planes-remain.md
+++ b/.changeset/thin-planes-remain.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-resizable-view': minor
+---
+
+make handle more recognizable

--- a/.changeset/thin-planes-remain.md
+++ b/.changeset/thin-planes-remain.md
@@ -2,4 +2,4 @@
 'prosemirror-resizable-view': minor
 ---
 
-make handle more recognizable
+Add a white border to the handle to make it more recognizable.

--- a/packages/prosemirror-resizable-view/src/corner-handle.ts
+++ b/packages/prosemirror-resizable-view/src/corner-handle.ts
@@ -1,0 +1,6 @@
+const leftCorner = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="22" height="22" fill="rgba(0, 0, 0, 0.65)" stroke="rgba(255, 255, 255, 0.5)" transform="rotate(90)" xmlns:v="https://vecta.io/nano"><path fill-rule="evenodd" d="M14 0a2 2 0 0 0-2 2v10H2a2 2 0 1 0 0 4h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/></svg>`;
+
+const rightCorner = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="22" height="22" fill="rgba(0, 0, 0, 0.65)" stroke="rgba(255, 255, 255, 0.5)" transform="matrix(0 1 1 0 0 0)" xmlns:v="https://vecta.io/nano"><path fill-rule="evenodd" d="M14 0a2 2 0 0 0-2 2v10H2a2 2 0 1 0 0 4h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/></svg>`;
+export const leftCornerHandle = encodeURIComponent(leftCorner);
+
+export const rightCornerHandle = encodeURIComponent(rightCorner);

--- a/packages/prosemirror-resizable-view/src/resizable-view-handle.ts
+++ b/packages/prosemirror-resizable-view/src/resizable-view-handle.ts
@@ -1,5 +1,7 @@
 import { setStyle } from '@remirror/core-utils';
 
+import { leftCornerHandle, rightCornerHandle } from './corner-handle';
+
 export enum ResizableHandleType {
   Right,
   Left,
@@ -52,7 +54,10 @@ export class ResizableHandle {
           width: ' 4px',
           height: '36px',
           maxHeight: '50%',
-          background: 'rgba(15, 15, 15, 0.5)',
+          boxSizing: 'content-box',
+          background: 'rgba(0, 0, 0, 0.65)',
+          border: '1px solid rgba(255, 255, 255, 0.5)',
+          borderRadius: '6px',
         });
 
         break;
@@ -69,7 +74,10 @@ export class ResizableHandle {
           width: ' 4px',
           height: '36px',
           maxHeight: '50%',
-          background: 'rgba(15, 15, 15, 0.5)',
+          boxSizing: 'content-box',
+          background: 'rgba(0, 0, 0, 0.65)',
+          border: '1px solid rgba(255, 255, 255, 0.5)',
+          borderRadius: '6px',
         });
 
         break;
@@ -82,17 +90,20 @@ export class ResizableHandle {
         });
 
         setStyle(this.#handle, {
-          width: ' 36px',
+          width: ' 42px',
           height: '4px',
+          boxSizing: 'content-box',
           maxWidth: '50%',
-          background: 'rgba(15, 15, 15, 0.5)',
+          background: 'rgba(0, 0, 0, 0.65)',
+          border: '1px solid rgba(255, 255, 255, 0.5)',
+          borderRadius: '6px',
         });
 
         break;
       case ResizableHandleType.BottomRight:
         setStyle(this.dom, {
-          right: '0px',
-          bottom: '0px',
+          right: '-1px',
+          bottom: '-2px',
           width: '30px',
           height: '30px',
           cursor: 'nwse-resize',
@@ -100,17 +111,17 @@ export class ResizableHandle {
         });
 
         setStyle(this.#handle, {
-          width: '18px',
-          height: '18px',
-          borderBottom: '4px solid rgba(15, 15, 15, 0.5)',
-          borderRight: '4px solid rgba(15, 15, 15, 0.5)',
+          height: '22px',
+          width: '22px',
+          backgroundRepeat: 'no-repeat',
+          backgroundImage: `url("data:image/svg+xml,${rightCornerHandle}") `,
         });
 
         break;
       case ResizableHandleType.BottomLeft:
         setStyle(this.dom, {
-          left: '0px',
-          bottom: '0px',
+          left: '-1px',
+          bottom: '-2px',
           width: '30px',
           height: '30px',
           cursor: 'nesw-resize',
@@ -118,10 +129,10 @@ export class ResizableHandle {
         });
 
         setStyle(this.#handle, {
-          width: '18px',
-          height: '18px',
-          borderBottom: '4px solid rgba(15, 15, 15, 0.5)',
-          borderLeft: '4px solid rgba(15, 15, 15, 0.5)',
+          height: '22px',
+          width: '22px',
+          backgroundRepeat: 'no-repeat',
+          backgroundImage: `url("data:image/svg+xml,${leftCornerHandle}") `,
         });
 
         break;


### PR DESCRIPTION
### Description

Previous resize handles might be a bit hard to recognized with a dark background.
So, I changed the corner resize handles to SVG and did some changes to the other handles,gave the resize handles a better recognizable look :)

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/16329365/132666913-5d8739dc-712f-4bf7-8028-4298fbf117eb.mov

