### PR TITLE
docs: fix a 404 storybook link

### DIFF
--- a/docs/react/static-html.md
+++ b/docs/react/static-html.md
@@ -29,6 +29,6 @@ On the upside, this approach leads to the identical rendering as in editable mod
 
 The react-render provides a more efficient way to visualize Remirror documents: It renders the document directly to HTML, by-passing the editor completely. This implies that the visualization can look differently from the editor and that you'll have to implement rendering for all your custom node types.
 
-See [storybook](https://remirror.vercel.app/?path=/story/react-renderer-static-html--basic) for example usage.
+See [storybook](https://remirror.vercel.app/?path=/story/editors-react-renderer-static-html--basic) for example usage.
 
 _Note: Today only the most widely Remirror node types are supported by the react-render. Please file a ticket (or even better PR) if you require further node types._


### PR DESCRIPTION
### Description

Fixing broken link in the documentation I found.

Previously:
https://remirror.vercel.app/?path=/story/react-renderer-static-html--basic

Fixed:
https://remirror.vercel.app/?path=/story/editors-react-renderer-static-html--basic

### Checklist


- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
