### PR TITLE
docs: fix markdown 404 storybook link

### DIFF
--- a/docs/extensions/markdown-extension.mdx
+++ b/docs/extensions/markdown-extension.mdx
@@ -86,7 +86,7 @@ The extension is provided by the `@remirror/extension-markdown` package. There a
 
 ### Examples
 
-See [storybook](https://remirror.vercel.app/?path=/story/markdown-editor--basic) for examples.
+See [storybook](https://remirror.vercel.app/?path=/story/editors-markdown--basic) for examples.
 
 ## API
 


### PR DESCRIPTION
### Description

Fixing a broken Storybook link in the documentation for the Markdown extension.

Was previously linking here:
https://remirror.vercel.app/?path=/story/markdown-editor--basic

Is corrected to link here:
https://remirror.vercel.app/?path=/story/editors-markdown--basic

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [X] I have updated the documentation where necessary.
