### PR TITLE
docs: fix typo in documentation code example

### DIFF
--- a/packages/remirror__react-hooks/src/use-multi-positioner.ts
+++ b/packages/remirror__react-hooks/src/use-multi-positioner.ts
@@ -36,7 +36,7 @@ export interface UseMultiPositionerReturn extends PositionerPosition {
  * is useful for tracking the positions of multiple items in the editor.
  *
  * ```ts
- * import { Positioner } from 'remirror/extensions
+ * import { Positioner } from 'remirror/extensions';
  * import { useMultiPositioner } from '@remirror/react';
  *
  * const positioner = Positioner.create({


### PR DESCRIPTION
### Description

Fix typo in documentation code example

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project ~and `pnpm fix` completed successfully.~
- [x] I have updated the documentation where necessary.
- [x] ~New code is unit tested and all current tests pass when running `pnpm test`.~
