### PR TITLE
docs: allow `docs/api` to not exist

### DIFF
--- a/website/sidebar.js
+++ b/website/sidebar.js
@@ -1,10 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 
-const API_DIR = path.join(__dirname, '../docs/api')
+const API_DIR = path.join(__dirname, '../docs/api');
 
 function getApiItems() {
-  if (!fs.existsSync(API_DIR)) {return []}
+  if (!fs.existsSync(API_DIR)) {
+    return [];
+  }
 
   const apiItems = [];
 

--- a/website/sidebar.js
+++ b/website/sidebar.js
@@ -1,7 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 
+const API_DIR = path.join(__dirname, '../docs/api')
+
 function getApiItems() {
+  if (!fs.existsSync(API_DIR)) {return []}
+
   const apiItems = [];
 
   /*
@@ -19,7 +23,7 @@ function getApiItems() {
     ]
   */
   const apiFiles = fs
-    .readdirSync(path.join(__dirname, '../docs/api'))
+    .readdirSync(API_DIR)
     .map((name) => `api/${name.replace(/\.mdx?$/, '')}`)
     .sort((a, b) => {
       if (a === 'api/index') {

--- a/website/sidebar.js
+++ b/website/sidebar.js
@@ -137,8 +137,4 @@ const docs = [
   },
 ];
 
-/** @type import('@docusaurus/plugin-content-docs/lib/types').SidebarItem[] */
-// const api = fs.readdirSync(path.join(__dirname, '../docs/api')).sort((a, b) => (a === 'index.md' ? -1 : 0)).map((name) => `api/${name.replace(/\.mdx?$/, '')}`);
-// console.log('api:',api)
-
 exports.docs = docs;


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This patch allows users to run the website locally without generated API markdown files.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 