### PR TITLE
chore(file): highlight file extension should use drop cursors

### DIFF
--- a/docs/extensions/drop-cursor-extension.mdx
+++ b/docs/extensions/drop-cursor-extension.mdx
@@ -5,6 +5,9 @@ title: 'DropCursorExtension'
 
 # `DropCursorExtension`
 
+import Basic from '../../website/extension-examples/extension-drop-cursor/basic';
+import Color from '../../website/extension-examples/extension-drop-cursor/color';
+
 ## Summary
 
 Shows a line indicator for where the drop target will be
@@ -24,6 +27,12 @@ import { DropCursorExtension } from 'remirror/extensions';
 To install it directly you can use
 
 The extension is provided by the `@remirror/extension-drop-cursor` package. There are two ways of pulling it into your project.
+
+### Examples
+
+<Basic />
+
+<Color />
 
 ## API
 

--- a/packages/remirror__extension-file/readme.md
+++ b/packages/remirror__extension-file/readme.md
@@ -1,1 +1,46 @@
 # @remirror/extension-file
+
+> Add files to your editor.
+
+[![Version][version]][npm] [![Weekly Downloads][downloads-badge]][npm] [![Bundled size][size-badge]][size] [![Typed Codebase][typescript]](#) [![MIT License][license]](#)
+
+[version]: https://flat.badgen.net/npm/v/@remirror/extension-file
+[npm]: https://npmjs.com/package/@remirror/extension-file
+[license]: https://flat.badgen.net/badge/license/MIT/purple
+[size]: https://bundlephobia.com/result?p=@remirror/extension-file
+[size-badge]: https://flat.badgen.net/bundlephobia/minzip/@remirror/extension-file
+[typescript]: https://flat.badgen.net/badge/icon/TypeScript?icon=typescript&label
+[downloads-badge]: https://badgen.net/npm/dw/@remirror/extension-file/red?icon=npm
+
+## Beta
+
+Note this extension is in beta, so its API may change without a bump to the major semver version.
+
+## Installation
+
+```bash
+yarn add @remirror/extension-file # yarn
+pnpm add @remirror/extension-file # pnpm
+npm install @remirror/extension-file # npm
+```
+
+This is **NOT** included by default when you install the recommended `remirror` package.
+
+To install it directly you can use
+
+```ts
+import { FileExtension } from '@remirror/extension-file';
+```
+
+The extension is provided by the `@remirror/extension-file` package.
+
+## Usage
+
+The following code creates an instance of this extension.
+
+```ts
+import { DropCursorExtension } from 'remirror/extensions';
+import { FileExtension } from '@remirror/extension-file';
+
+const extension = new FileExtension();
+```

--- a/packages/storybook-react/stories/extension-drop-cursor/basic.tsx
+++ b/packages/storybook-react/stories/extension-drop-cursor/basic.tsx
@@ -1,0 +1,32 @@
+import 'remirror/styles/all.css';
+
+import React from 'react';
+import { htmlToProsemirrorNode } from 'remirror';
+import { DropCursorExtension, ImageExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const extensions = () => [new ImageExtension(), new DropCursorExtension()];
+
+const Basic: React.FC = () => {
+  const { manager, state, onChange } = useRemirror({
+    extensions,
+    content:
+      '<p>Drag-and-drop an image file, or drag the image below to view a drop cursor.</p>' +
+      '<p><img src="https://dummyimage.com/200x80/479e0c/fafafa"></p>',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror
+        manager={manager}
+        autoFocus
+        onChange={onChange}
+        initialContent={state}
+        autoRender='end'
+      />
+    </ThemeProvider>
+  );
+};
+
+export default Basic;

--- a/packages/storybook-react/stories/extension-drop-cursor/color.tsx
+++ b/packages/storybook-react/stories/extension-drop-cursor/color.tsx
@@ -1,0 +1,32 @@
+import 'remirror/styles/all.css';
+
+import React from 'react';
+import { htmlToProsemirrorNode } from 'remirror';
+import { DropCursorExtension, ImageExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const extensions = () => [new ImageExtension(), new DropCursorExtension({ color: '#7963d2' })];
+
+const Color: React.FC = () => {
+  const { manager, state, onChange } = useRemirror({
+    extensions,
+    content:
+      '<p>Drag-and-drop an image file, or drag the image below to view a colored drop cursor.</p>' +
+      '<p><img src="https://dummyimage.com/200x80/479e0c/fafafa"></p>',
+    stringHandler: htmlToProsemirrorNode,
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror
+        manager={manager}
+        autoFocus
+        onChange={onChange}
+        initialContent={state}
+        autoRender='end'
+      />
+    </ThemeProvider>
+  );
+};
+
+export default Color;

--- a/packages/storybook-react/stories/extension-drop-cursor/drop-cursor.stories.tsx
+++ b/packages/storybook-react/stories/extension-drop-cursor/drop-cursor.stories.tsx
@@ -1,0 +1,5 @@
+import Basic from './basic';
+import Color from './color';
+
+export { Basic, Color };
+export default { title: 'Extensions / Drop Cursor' };

--- a/packages/storybook-react/stories/extension-file/basic.tsx
+++ b/packages/storybook-react/stories/extension-file/basic.tsx
@@ -1,11 +1,12 @@
 import 'remirror/styles/extension-file.css';
 
 import { useCallback } from 'react';
+import { DropCursorExtension } from 'remirror/extensions';
 import { FileExtension } from '@remirror/extension-file';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const Basic = (): JSX.Element => {
-  const extensions = useCallback(() => [new FileExtension({})], []);
+  const extensions = useCallback(() => [new FileExtension({}), new DropCursorExtension()], []);
   const { manager, state } = useRemirror({ extensions, content, stringHandler: 'html' });
 
   return (

--- a/packages/storybook-react/stories/extension-file/with-bashupload.tsx
+++ b/packages/storybook-react/stories/extension-file/with-bashupload.tsx
@@ -1,12 +1,16 @@
 import 'remirror/styles/extension-file.css';
 
 import { useCallback } from 'react';
+import { DropCursorExtension } from 'remirror/extensions';
 import { createBaseuploadFileUploader, FileExtension } from '@remirror/extension-file';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const WithBashupload = (): JSX.Element => {
   const extensions = useCallback(
-    () => [new FileExtension({ uploadFileHandler: createBaseuploadFileUploader })],
+    () => [
+      new FileExtension({ uploadFileHandler: createBaseuploadFileUploader }),
+      new DropCursorExtension(),
+    ],
     [],
   );
   const { manager, state } = useRemirror({ extensions, content, stringHandler: 'html' });

--- a/packages/storybook-react/stories/extension-file/with-object-url.tsx
+++ b/packages/storybook-react/stories/extension-file/with-object-url.tsx
@@ -1,12 +1,16 @@
 import 'remirror/styles/extension-file.css';
 
 import { useCallback } from 'react';
+import { DropCursorExtension } from 'remirror/extensions';
 import { createObjectUrlFileUploader, FileExtension } from '@remirror/extension-file';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const WithObjectUrl = (): JSX.Element => {
   const extensions = useCallback(
-    () => [new FileExtension({ uploadFileHandler: createObjectUrlFileUploader })],
+    () => [
+      new FileExtension({ uploadFileHandler: createObjectUrlFileUploader }),
+      new DropCursorExtension(),
+    ],
     [],
   );
   const { manager, state } = useRemirror({ extensions, content, stringHandler: 'html' });

--- a/packages/storybook-react/stories/extension-file/with-upload-file-button.tsx
+++ b/packages/storybook-react/stories/extension-file/with-upload-file-button.tsx
@@ -1,11 +1,12 @@
 import 'remirror/styles/extension-file.css';
 
 import React, { useCallback } from 'react';
+import { DropCursorExtension } from 'remirror/extensions';
 import { FileExtension } from '@remirror/extension-file';
 import { Remirror, ThemeProvider, useCommands, useRemirror } from '@remirror/react';
 
 const WithUploadFileButton = (): JSX.Element => {
-  const extensions = useCallback(() => [new FileExtension({})], []);
+  const extensions = useCallback(() => [new FileExtension({}), new DropCursorExtension()], []);
   const { manager, state } = useRemirror({ extensions, content, stringHandler: 'html' });
 
   return (

--- a/packages/storybook-react/stories/extension-file/with-upload-progress.tsx
+++ b/packages/storybook-react/stories/extension-file/with-upload-progress.tsx
@@ -1,12 +1,16 @@
 import 'remirror/styles/extension-file.css';
 
 import { useCallback } from 'react';
+import { DropCursorExtension } from 'remirror/extensions';
 import { createSlowFileUploader, FileExtension } from '@remirror/extension-file';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const WithUploadProgress = (): JSX.Element => {
   const extensions = useCallback(
-    () => [new FileExtension({ uploadFileHandler: createSlowFileUploader })],
+    () => [
+      new FileExtension({ uploadFileHandler: createSlowFileUploader }),
+      new DropCursorExtension(),
+    ],
     [],
   );
   const { manager, state } = useRemirror({ extensions, content, stringHandler: 'html' });

--- a/website/extension-examples/extension-drop-cursor/basic.tsx
+++ b/website/extension-examples/extension-drop-cursor/basic.tsx
@@ -8,7 +8,7 @@
 
 import CodeBlock from '@theme/CodeBlock';
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/react/replace-content-and-clear-history.tsx';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-drop-cursor/basic.tsx';
 
 import { StoryExample } from '../../src/components/story-example-component';
 
@@ -16,7 +16,7 @@ const ExampleComponent = (): JSX.Element => {
   const story = (
     <BrowserOnly>
       {() => {
-        const ComponentStory = require('../../../packages/storybook-react/stories/react/replace-content-and-clear-history').default
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-drop-cursor/basic').default
         return <ComponentStory/>
       }}
     </BrowserOnly>

--- a/website/extension-examples/extension-drop-cursor/color.tsx
+++ b/website/extension-examples/extension-drop-cursor/color.tsx
@@ -8,7 +8,7 @@
 
 import CodeBlock from '@theme/CodeBlock';
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/react/replace-content-and-clear-history.tsx';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-drop-cursor/color.tsx';
 
 import { StoryExample } from '../../src/components/story-example-component';
 
@@ -16,7 +16,7 @@ const ExampleComponent = (): JSX.Element => {
   const story = (
     <BrowserOnly>
       {() => {
-        const ComponentStory = require('../../../packages/storybook-react/stories/react/replace-content-and-clear-history').default
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-drop-cursor/color').default
         return <ComponentStory/>
       }}
     </BrowserOnly>

--- a/website/extension-examples/react/editable.tsx
+++ b/website/extension-examples/react/editable.tsx
@@ -27,3 +27,4 @@ const ExampleComponent = (): JSX.Element => {
 };
 
 export default ExampleComponent;
+  

--- a/website/extension-examples/react/replace-content-preserve-history.tsx
+++ b/website/extension-examples/react/replace-content-preserve-history.tsx
@@ -27,3 +27,4 @@ const ExampleComponent = (): JSX.Element => {
 };
 
 export default ExampleComponent;
+  


### PR DESCRIPTION
### Description

Update docs/storybook to highlight that file extension should be used with drop cursor extension.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

