### PR TITLE
feat: allow to pre-fill markdown editor

### DIFF
--- a/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
+++ b/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
@@ -37,12 +37,17 @@ export default { title: 'Editors / Markdown' };
 
 export interface MarkdownEditorProps {
   placeholder?: string;
+  initialContent?: string;
 }
 
 /**
  * The editor which is used to create the annotation. Supports formatting.
  */
-export const MarkdownEditor: FC<MarkdownEditorProps> = ({ placeholder, children }) => {
+export const MarkdownEditor: FC<MarkdownEditorProps> = ({
+  placeholder,
+  initialContent,
+  children,
+}) => {
   const extensions = useCallback(
     () => [
       new PlaceholderExtension({ placeholder }),
@@ -70,12 +75,15 @@ export const MarkdownEditor: FC<MarkdownEditorProps> = ({ placeholder, children 
     [placeholder],
   );
 
-  const { manager } = useRemirror({ extensions });
+  const { manager } = useRemirror({
+    extensions,
+    stringHandler: 'markdown',
+  });
 
   return (
     <AllStyledComponent>
       <ThemeProvider>
-        <Remirror manager={manager} autoFocus>
+        <Remirror manager={manager} autoFocus initialContent={initialContent}>
           <Toolbar items={toolbarItems} refocusEditor label='Top Toolbar' />
           <EditorComponent />
           {children}

--- a/packages/storybook-react/stories/react-editors/markdown-editor.stories.tsx
+++ b/packages/storybook-react/stories/react-editors/markdown-editor.stories.tsx
@@ -51,7 +51,7 @@ function MarkdownPreview() {
 
 export const Basic = () => {
   return (
-    <MarkdownEditor placeholder='Start typing...'>
+    <MarkdownEditor placeholder='Start typing...' initialContent={basicContent}>
       <MarkdownPreview />
     </MarkdownEditor>
   );


### PR DESCRIPTION
### Description

Enable to pre-fill content of markdown editor

Triggered by https://discord.com/channels/726035064831344711/745695521305526302/892537726346358818

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
