### PR TITLE
feat(extension-annotation): add flag to filter out getAnnotationsAt edge matches

### DIFF
--- a/.changeset/big-terms-clean.md
+++ b/.changeset/big-terms-clean.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': minor
+---
+
+Add a flag to filter out edge matches from `getAnnotationAt` helper

--- a/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
+++ b/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
@@ -311,102 +311,149 @@ describe('styling', () => {
 });
 
 describe('helpers', () => {
-  it('#getAnnotations', () => {
-    const {
-      add,
-      helpers,
-      nodes: { p, doc },
-      commands,
-    } = create();
+  describe('#getAnnotations', () => {
+    it('default', () => {
+      const {
+        add,
+        helpers,
+        nodes: { p, doc },
+        commands,
+      } = create();
 
-    add(doc(p('<start>Hello<end>')));
-    commands.addAnnotation({ id: '1' });
+      add(doc(p('<start>Hello<end>')));
+      commands.addAnnotation({ id: '1' });
 
-    expect(helpers.getAnnotations()).toEqual([
-      {
-        id: '1',
-        from: 1,
-        to: 6,
-        text: 'Hello',
-      },
-    ]);
-  });
-
-  it('#getAnnotations gracefully handles misplaced annotations', () => {
-    const {
-      add,
-      helpers,
-      nodes: { p, doc },
-      commands,
-    } = create();
-
-    add(doc(p('Hello')));
-    commands.setAnnotations([
-      {
-        id: '1',
-        from: 100,
-        to: 110,
-      },
-    ]);
-
-    expect(helpers.getAnnotations()[0]?.text).toBeUndefined();
-  });
-
-  it('#getAnnotations concats multi-block content with configured blockseparator', () => {
-    const {
-      add,
-      helpers,
-      nodes: { p, doc },
-      commands,
-    } = create({
-      blockSeparator: '<NEWLINE>',
+      expect(helpers.getAnnotations()).toEqual([
+        {
+          id: '1',
+          from: 1,
+          to: 6,
+          text: 'Hello',
+        },
+      ]);
     });
 
-    add(doc(p('Hello'), p('World')));
-    commands.setAnnotations([
-      {
-        id: '1',
-        from: 1,
-        to: 13,
-      },
-    ]);
+    it('gracefully handles misplaced annotations', () => {
+      const {
+        add,
+        helpers,
+        nodes: { p, doc },
+        commands,
+      } = create();
 
-    expect(helpers.getAnnotations()[0]?.text).toEqual('Hello<NEWLINE>World');
+      add(doc(p('Hello')));
+      commands.setAnnotations([
+        {
+          id: '1',
+          from: 100,
+          to: 110,
+        },
+      ]);
+
+      expect(helpers.getAnnotations()[0]?.text).toBeUndefined();
+    });
+
+    it('concats multi-block content with configured blockseparator', () => {
+      const {
+        add,
+        helpers,
+        nodes: { p, doc },
+        commands,
+      } = create({
+        blockSeparator: '<NEWLINE>',
+      });
+
+      add(doc(p('Hello'), p('World')));
+      commands.setAnnotations([
+        {
+          id: '1',
+          from: 1,
+          to: 13,
+        },
+      ]);
+
+      expect(helpers.getAnnotations()[0]?.text).toEqual('Hello<NEWLINE>World');
+    });
   });
 
-  it('#getAnnotationsAt', () => {
-    const {
+  describe('#getAnnotationsAt', () => {
+    let {
       add,
       helpers,
       nodes: { p, doc },
       commands,
     } = create();
 
-    add(doc(p('An <start>important<end> note')));
-    commands.addAnnotation({ id: '1' });
+    beforeEach(() => {
+      ({
+        add,
+        helpers,
+        nodes: { p, doc },
+        commands,
+      } = create());
+      add(doc(p('An <start>important<end> note')));
+      commands.addAnnotation({ id: '1' });
+    });
 
-    expect(helpers.getAnnotationsAt(5)).toEqual([
-      {
-        id: '1',
-        from: 4,
-        to: 13,
-        text: 'important',
-      },
-    ]);
-  });
+    it('default', () => {
+      expect(helpers.getAnnotationsAt()).toEqual([
+        {
+          id: '1',
+          from: 4,
+          to: 13,
+          text: 'important',
+        },
+      ]);
+    });
 
-  it('#getAnnotationsAt (unannotated)', () => {
-    const {
-      add,
-      helpers,
-      nodes: { p, doc },
-      commands,
-    } = create();
+    it('pos', () => {
+      expect(helpers.getAnnotationsAt(5)).toEqual([
+        {
+          id: '1',
+          from: 4,
+          to: 13,
+          text: 'important',
+        },
+      ]);
+    });
 
-    add(doc(p('An <start>important<end> note')));
-    commands.addAnnotation({ id: '1' });
+    it('edge pos', () => {
+      expect(helpers.getAnnotationsAt(13)).toEqual([
+        {
+          id: '1',
+          from: 4,
+          to: 13,
+          text: 'important',
+        },
+      ]);
+    });
 
-    expect(helpers.getAnnotationsAt(2)).toEqual([]);
+    it('no annotation', () => {
+      expect(helpers.getAnnotationsAt(2)).toEqual([]);
+    });
+
+    it('default, includeEdges = false', () => {
+      expect(helpers.getAnnotationsAt(undefined, false)).toEqual([]);
+    });
+
+    it('pos, includeEdges = false', () => {
+      expect(helpers.getAnnotationsAt(5, false)).toEqual([
+        {
+          id: '1',
+          from: 4,
+          to: 13,
+          text: 'important',
+        },
+      ]);
+    });
+
+    it('edge pos, includeEdges = false', () => {
+      expect(helpers.getAnnotationsAt(13, false)).toEqual([]);
+    });
+
+    it('no annotation, includeEdges = false', () => {
+      expect(helpers.getAnnotationsAt(2, false)).toEqual([]);
+    });
   });
 });
 

--- a/packages/remirror__extension-annotation/src/annotation-extension.ts
+++ b/packages/remirror__extension-annotation/src/annotation-extension.ts
@@ -234,6 +234,7 @@ export class AnnotationExtension<Type extends Annotation = Annotation> extends P
 
   /**
    * @param pos - the position in the root document to find annotations.
+   * @param includeEdges - whether to match annotations that start or end exactly on the given pos
    *
    * @returns all annotations at a specific position in the editor.
    *
@@ -241,7 +242,7 @@ export class AnnotationExtension<Type extends Annotation = Annotation> extends P
    * [[`AnnotationExtension`]] added to your editor.
    */
   @helper()
-  getAnnotationsAt(pos?: PrimitiveSelection): Helper<Type[]> {
+  getAnnotationsAt(pos?: PrimitiveSelection, includeEdges = true): Helper<Type[]> {
     const annotations: Type[] = [];
     const { doc, selection } = this.store.getState();
     const state: AnnotationState<Type> = this.getPluginState();
@@ -254,7 +255,11 @@ export class AnnotationExtension<Type extends Annotation = Annotation> extends P
         within(annotation.from, from, to) ||
         within(annotation.to, from, to)
       ) {
-        annotations.push(this.enrichText(annotation));
+        if (includeEdges) {
+          annotations.push(this.enrichText(annotation));
+        } else if (annotation.from !== from && annotation.to !== to) {
+          annotations.push(this.enrichText(annotation));
+        }
       }
     }
 


### PR DESCRIPTION
### Description

Add the ability to filter out edge matches from `getAnnotationsAt` helper.

I.e. if an annotation exists from position 4 to 9, `getAnnotationAt(4)` will match it, `getAnnotationAt(4, false)` will **not**

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
