### PR TITLE
fix(core-helpers): correct the error message for `ErrorConstant.REACT_PROVIDER_CONTEXT`

### DIFF
--- a/.changeset/stale-dolls-lay.md
+++ b/.changeset/stale-dolls-lay.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-helpers': patch
+---
+
+Correct the error message for `ErrorConstant.REACT_PROVIDER_CONTEXT`.

--- a/packages/remirror__core-helpers/src/core-errors.ts
+++ b/packages/remirror__core-helpers/src/core-errors.ts
@@ -54,7 +54,7 @@ if (process.env.NODE_ENV !== 'production') {
     [ErrorConstant.INVALID_SET_EXTENSION_OPTIONS]:
       'A call to `extension.setOptions` was made with invalid keys.',
     [ErrorConstant.REACT_PROVIDER_CONTEXT]:
-      '`useRemirror` was called outside of the `remirror` context. It can only be used within an active remirror context created by the `<Remirror />`.',
+      '`useRemirrorContext` was called outside of the `remirror` context. It can only be used within an active remirror context created by the `<Remirror />`.',
     [ErrorConstant.REACT_GET_ROOT_PROPS]:
       '`getRootProps` has been attached to the DOM more than once. It should only be attached to the dom once per editor.',
     [ErrorConstant.REACT_EDITOR_VIEW]: 'A problem occurred adding the editor view to the dom.',


### PR DESCRIPTION


### Description

This error will be raised in `useRemirrorContext` instead of `useRemirror`.
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 