### PR TITLE
fix(extension-list): don't let the browser handle the Tab key in a list

### DIFF
--- a/.changeset/witty-shirts-hammer.md
+++ b/.changeset/witty-shirts-hammer.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Don't let the browser handle the Tab key in a list.

--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -278,7 +278,9 @@ export function sharedSinkListItem(allExtensions: AnyExtension[]): CommandFuncti
       }
     }
 
-    return false;
+    // if current selection is inside at lease one list item node, then we
+    // always return true.
+    return listItemTypes.size > 0;
   };
 }
 
@@ -298,7 +300,9 @@ export function sharedLiftListItem(allExtensions: AnyExtension[]): CommandFuncti
       }
     }
 
-    return false;
+    // if current selection is inside at lease one list item node, then we
+    // always return true.
+    return listItemTypes.size > 0;
   };
 }
 


### PR DESCRIPTION
### Description

Closes #1258
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->



Before this patch:

https://user-images.githubusercontent.com/24715727/135931608-9edea0c3-4cb7-4c80-8f53-115e84a3cff4.mp4


After this patch:

https://user-images.githubusercontent.com/24715727/135931483-ef238b94-f16a-4e69-9709-bd64364faaad.mp4



