### PR TITLE
fix(extension-list): merge patch from the upstream

### DIFF
--- a/.changeset/twenty-jobs-love.md
+++ b/.changeset/twenty-jobs-love.md
@@ -1,0 +1,9 @@
+---
+'@remirror/extension-list': patch
+---
+
+Merge a patch from the upstream prosemirror-schema-list: https://github.com/ProseMirror/prosemirror-schema-list/commit/38867345f6d97d6793655ed77c16f1a7b18f6846
+
+Make sure liftListItem doesn't crash when multiple items can't be merged.
+
+Fix a crash in `liftListItem` that happens when list items that can't be merged are lifted together.

--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -439,11 +439,7 @@ export function liftListItemOutOfList(itemType: NodeType): CommandFunction {
 function getItemRange(itemType: NodeType, selection: Selection) {
   const { $from, $to } = selection;
 
-  const range = $from.blockRange(
-    $to,
-    // @ts-expect-error this line of code is copied from `prosemirror-schema-list`
-    (node) => node.childCount >= 1 && node.firstChild.type.name === itemType.name,
-  );
+  const range = $from.blockRange($to, (node) => node.firstChild?.type === itemType);
 
   return range;
 }


### PR DESCRIPTION
Merge the upstream patch 
https://github.com/ProseMirror/prosemirror-schema-list/commit/38867345f6d97d6793655ed77c16f1a7b18f6846

 Notice that the `tr` in `liftOutOfList` may not be a _clean_ transaction, so we need to remove all previous steps when calculate mapping.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
