### PR TITLE
feat(extension-list): improve list input rules

### DIFF
--- a/.changeset/hot-shirts-lick.md
+++ b/.changeset/hot-shirts-lick.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Allow input rules to convert task list to bullet list or ordered list.

--- a/.changeset/silver-papayas-kneel.md
+++ b/.changeset/silver-papayas-kneel.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': minor
+---
+
+Automagically join two lists with same node type when there are siblings.

--- a/.changeset/silver-papayas-kneel.md
+++ b/.changeset/silver-papayas-kneel.md
@@ -2,4 +2,4 @@
 '@remirror/extension-list': minor
 ---
 
-Automagically join two lists with same node type when there are siblings.
+Automagically join two lists with the same node type when there are siblings.

--- a/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-input-rules.spec.ts
@@ -55,7 +55,7 @@ describe('create a list', () => {
     expect(editor.doc).toEqualProsemirrorNode(doc(taskList(checkedItem(p('')))));
   });
 
-  it('creates a taskList in a bulletListItem', () => {
+  it('creates a task list in a bullet list', () => {
     editor.add(
       doc(
         bulletList(
@@ -73,7 +73,7 @@ describe('create a list', () => {
     );
   });
 
-  it('creates a taskList in an ordered ListItem', () => {
+  it('creates a task list in an ordered list', () => {
     editor.add(
       doc(
         orderedList({ order: 1 })(
@@ -86,6 +86,78 @@ describe('create a list', () => {
       doc(
         taskList(
           checkedItem(p('')), //
+        ),
+      ),
+    );
+  });
+
+  it('creates a bullet list in an ordered list', () => {
+    editor.add(
+      doc(
+        orderedList({ order: 1 })(
+          listItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('- ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(p('')), //
+        ),
+      ),
+    );
+  });
+
+  it('creates a bullet list in a task list', () => {
+    editor.add(
+      doc(
+        taskList(
+          checkedItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('- ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        bulletList(
+          listItem(p('')), //
+        ),
+      ),
+    );
+  });
+
+  it('creates an ordered list in a bullet list', () => {
+    editor.add(
+      doc(
+        bulletList(
+          listItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('1. ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        orderedList()(
+          listItem(p('')), //
+        ),
+      ),
+    );
+  });
+
+  it('creates an ordered list in a task list', () => {
+    editor.add(
+      doc(
+        taskList(
+          uncheckedItem(p('<cursor>')), //
+        ),
+      ),
+    );
+    editor.insertText('1. ');
+    expect(editor.doc).toEqualProsemirrorNode(
+      doc(
+        orderedList()(
+          listItem(p('')), //
         ),
       ),
     );
@@ -295,5 +367,242 @@ describe('create a list', () => {
     editor.add(doc(taskList(uncheckedItem(p('<cursor>')))));
     editor.insertText('[x] ');
     expect(editor.doc).toEqualProsemirrorNode(doc(taskList(uncheckedItem(p('[x] ')))));
+  });
+});
+
+describe('joins lists', () => {
+  const editor = renderEditor([
+    new BulletListExtension({}),
+    new ListItemExtension({}),
+    new OrderedListExtension(),
+    new TaskListExtension(),
+  ]);
+
+  const {
+    nodes: { bulletList, taskList, listItem, doc, p },
+    attributeNodes: { taskListItem, orderedList },
+  } = editor;
+
+  const uncheckedItem = taskListItem({ checked: false });
+  const checkedItem = taskListItem({ checked: true });
+
+  describe('input rules', () => {
+    it('bullet list => task list (join backward and forward)', () => {
+      editor.add(
+        doc(
+          taskList(
+            checkedItem(p('A')), //
+          ),
+          bulletList(
+            listItem(p('<cursor>B')), //
+          ),
+          taskList(
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('[x] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            checkedItem(p('A')), //
+            checkedItem(p('B')), //
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    it('bullet list => task list (join backward)', () => {
+      editor.add(
+        doc(
+          taskList(
+            checkedItem(p('A')), //
+          ),
+          bulletList(
+            listItem(p('<cursor>B')), //
+          ),
+        ),
+      );
+      editor.insertText('[x] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            checkedItem(p('A')), //
+            checkedItem(p('B')), //
+          ),
+        ),
+      );
+    });
+
+    it('bullet list => task list (join forward)', () => {
+      editor.add(
+        doc(
+          bulletList(
+            listItem(p('<cursor>B')), //
+          ),
+          taskList(
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('[x] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            checkedItem(p('B')), //
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    it('ordered list => task list (join backward and forward)', () => {
+      editor.add(
+        doc(
+          taskList(
+            uncheckedItem(p('A')), //
+          ),
+          orderedList()(
+            listItem(p('<cursor>B')), //
+          ),
+          taskList(
+            uncheckedItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('[ ] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            uncheckedItem(p('A')), //
+            uncheckedItem(p('B')), //
+            uncheckedItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    it('ordered list => task list (join backward)', () => {
+      editor.add(
+        doc(
+          taskList(
+            uncheckedItem(p('A')), //
+          ),
+          orderedList()(
+            listItem(p('<cursor>B')), //
+          ),
+        ),
+      );
+      editor.insertText('[ ] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            uncheckedItem(p('A')), //
+            uncheckedItem(p('B')), //
+          ),
+        ),
+      );
+    });
+
+    it('ordered list => task list (join forward)', () => {
+      editor.add(
+        doc(
+          orderedList()(
+            listItem(p('<cursor>B')), //
+          ),
+          taskList(
+            uncheckedItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('[ ] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            uncheckedItem(p('B')), //
+            uncheckedItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    it('paragraph => task list (join backward and forward)', () => {
+      editor.add(
+        doc(
+          taskList(
+            checkedItem(p('A')), //
+          ),
+          p('<cursor>B'), //
+          taskList(
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('[x] ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          taskList(
+            checkedItem(p('A')), //
+            checkedItem(p('B')), //
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    it('paragraph => bullet list (join backward)', () => {
+      editor.add(
+        doc(
+          bulletList(
+            listItem(p('A')), //
+          ),
+          p('<cursor>B'), //
+          taskList(
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('- ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          bulletList(
+            listItem(p('A')), //
+            listItem(p('B')), //
+          ),
+          taskList(
+            checkedItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    it('paragraph => ordered list (join forward)', () => {
+      editor.add(
+        doc(
+          bulletList(
+            listItem(p('A')), //
+          ),
+          p('<cursor>B'), //
+          orderedList()(
+            listItem(p('C')), //
+          ),
+        ),
+      );
+      editor.insertText('1. ');
+      expect(editor.doc).toEqualProsemirrorNode(
+        doc(
+          bulletList(
+            listItem(p('A')), //
+          ),
+          orderedList()(
+            listItem(p('B')), //
+            listItem(p('C')), //
+          ),
+        ),
+      );
+    });
+
+    //
   });
 });

--- a/packages/remirror__extension-list/src/bullet-list-extension.ts
+++ b/packages/remirror__extension-list/src/bullet-list-extension.ts
@@ -21,7 +21,7 @@ import { InputRule, wrappingInputRule } from '@remirror/pm/inputrules';
 import { NodeSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
-import { toggleList } from './list-commands';
+import { toggleList, wrapSingleItem } from './list-commands';
 import { ListItemExtension } from './list-item-extension';
 
 /**
@@ -118,7 +118,23 @@ export class BulletListExtension extends NodeExtension<BulletListOptions> {
   }
 
   createInputRules(): InputRule[] {
-    return [wrappingInputRule(/^\s*([*+-])\s$/, this.type)];
+    const regexp = /^\s*([*+-])\s$/;
+
+    return [
+      wrappingInputRule(regexp, this.type),
+
+      new InputRule(regexp, (state, _match, start, end) => {
+        const tr = state.tr;
+        tr.deleteRange(start, end);
+        const canUpdate = wrapSingleItem({ listType: this.type, state, tr });
+
+        if (!canUpdate) {
+          return null;
+        }
+
+        return tr;
+      }),
+    ];
   }
 }
 

--- a/packages/remirror__extension-list/src/index.ts
+++ b/packages/remirror__extension-list/src/index.ts
@@ -1,5 +1,10 @@
 export { BulletListExtension } from './bullet-list-extension';
-export { sharedLiftListItem, sharedSinkListItem, toggleList } from './list-commands';
+export {
+  sharedLiftListItem,
+  sharedSinkListItem,
+  toggleList,
+  wrapSingleItem,
+} from './list-commands';
 export { ListItemExtension } from './list-item-extension';
 export { ListItemSharedExtension } from './list-item-shared-extension';
 export { OrderedListExtension } from './ordered-list-extension';

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -16,6 +16,7 @@ import {
   ProsemirrorNode,
   Static,
 } from '@remirror/core';
+import { NodeType } from '@remirror/pm/model';
 import { NodeSelection } from '@remirror/pm/state';
 import { ExtensionListTheme } from '@remirror/theme';
 
@@ -132,8 +133,8 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
    * Lift the content inside a list item around the selection out of list
    */
   @command()
-  liftListItemOutOfList(): CommandFunction {
-    return liftListItemOutOfList(this.type);
+  liftListItemOutOfList(listItemType?: NodeType | undefined): CommandFunction {
+    return liftListItemOutOfList(listItemType ?? this.type);
   }
 }
 

--- a/packages/remirror__extension-list/src/list-item-shared-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-shared-extension.ts
@@ -1,9 +1,9 @@
-import { KeyBindings, PlainExtension } from '@remirror/core';
+import { CreateExtensionPlugin, KeyBindings, PlainExtension } from '@remirror/core';
 
-import { sharedLiftListItem, sharedSinkListItem } from './list-commands';
+import { maybeJoinList, sharedLiftListItem, sharedSinkListItem } from './list-commands';
 
 /**
- * Provides some shared keymaps used by both `listItem` and `taskListItem`
+ * Provides some shared thing used by both `listItem` and `taskListItem`
  */
 export class ListItemSharedExtension extends PlainExtension {
   get name() {
@@ -14,6 +14,16 @@ export class ListItemSharedExtension extends PlainExtension {
     return {
       Tab: sharedSinkListItem(this.store.extensions),
       'Shift-Tab': sharedLiftListItem(this.store.extensions),
+    };
+  }
+
+  createPlugin(): CreateExtensionPlugin {
+    return {
+      appendTransaction: (_transactions, _oldState, newState) => {
+        const tr = newState.tr;
+        const updated = maybeJoinList(tr);
+        return updated ? tr : null;
+      },
     };
   }
 }

--- a/packages/remirror__extension-list/src/list-utils.ts
+++ b/packages/remirror__extension-list/src/list-utils.ts
@@ -1,0 +1,10 @@
+import { ExtensionTag } from '@remirror/core';
+import { NodeType } from '@remirror/pm';
+
+export function isList(type: NodeType): boolean {
+  return !!type.spec.group?.includes(ExtensionTag.ListContainerNode);
+}
+
+export function isListItem(type: NodeType): boolean {
+  return !!type.spec.group?.includes(ExtensionTag.ListItemNode);
+}

--- a/packages/remirror__extension-list/src/ordered-list-extension.ts
+++ b/packages/remirror__extension-list/src/ordered-list-extension.ts
@@ -6,6 +6,7 @@ import {
   extension,
   ExtensionPriority,
   ExtensionTag,
+  findParentNodeOfType,
   isElementDomNode,
   keyBinding,
   KeyBindingProps,
@@ -17,7 +18,7 @@ import {
 import { ExtensionListMessages as Messages } from '@remirror/messages';
 import { InputRule, wrappingInputRule } from '@remirror/pm/inputrules';
 
-import { toggleList } from './list-commands';
+import { toggleList, wrapSingleItem } from './list-commands';
 import { ListItemExtension } from './list-item-extension';
 
 /**
@@ -90,13 +91,37 @@ export class OrderedListExtension extends NodeExtension {
   }
 
   createInputRules(): InputRule[] {
+    const regexp = /^(\d+)\.\s$/;
+
     return [
       wrappingInputRule(
-        /^(\d+)\.\s$/,
+        regexp,
         this.type,
         (match) => ({ order: +assertGet(match, 1) }),
         (match, node) => node.childCount + (node.attrs.order as number) === +assertGet(match, 1),
       ),
+
+      new InputRule(regexp, (state, match, start, end) => {
+        const tr = state.tr;
+        tr.deleteRange(start, end);
+        const canUpdate = wrapSingleItem({ listType: this.type, state, tr });
+
+        if (!canUpdate) {
+          return null;
+        }
+
+        const order = +assertGet(match, 1);
+
+        if (order !== 1) {
+          const found = findParentNodeOfType({ selection: tr.selection, types: this.type });
+
+          if (found) {
+            tr.setNodeMarkup(found.pos, undefined, { order });
+          }
+        }
+
+        return tr;
+      }),
     ];
   }
 }


### PR DESCRIPTION
### Description


- Automagically join two lists with the same node type when there are siblings.
- Allow input rules to convert task list to bullet list or ordered list. 


Closes #1249
    
### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

 
https://user-images.githubusercontent.com/24715727/136146036-49370428-813b-471a-98ae-4b58686705ed.mov
 
