### PR TITLE
docs: fix create-manager doc typo

### DIFF
--- a/docs/getting-started/create-manager.md
+++ b/docs/getting-started/create-manager.md
@@ -65,7 +65,7 @@ const { manager, state } = useRemirror({
   // Set the initial content.
   content: '<p>I love <b>Remirror</b></p>',
 
-  // Place the cursor at the start of the document. This an also be set to
+  // Place the cursor at the start of the document. This can also be set to
   // `end`, `all` or a numbered position.
   selection: 'start',
 


### PR DESCRIPTION
### Description

Fix a typo in comment on create-manager code example

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots
<img width="714" alt="Screen Shot 2021-10-13 at 11 04 56 AM" src="https://user-images.githubusercontent.com/62940602/137060146-7e185d33-0793-43e6-9bf9-e37c1c5c5c59.png">


