### PR TITLE
docs: how to set content from outside editor

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,7 +3,7 @@ hide_title: true
 title: Frequently asked questions
 ---
 
-import ReplaceContentPreserveHistory from '../website/extension-examples/react/replace-content-preserve-history'; import ReplaceContentAndClearHistory from '../website/extension-examples/react/replace-content-and-clear-history';
+import ReplaceContentPreserveHistory from '../website/extension-examples/react/replace-content-preserve-history'; import ReplaceContentAndClearHistory from '../website/extension-examples/react/replace-content-and-clear-history'; import ReplaceContentImperative from '../website/extension-examples/react/replace-content-imperative';
 
 # Frequently Asked Questions
 
@@ -44,3 +44,9 @@ Calling `setContent(...)` replaced the content and preserves the history:
 Calling `manager.view.updateState(...)` replaces the complete editor state, including the history:
 
 <ReplaceContentAndClearHistory />
+
+#### Outside editor context
+
+Use an imperative handle if you want to replace the content from outside the editor context:
+
+<ReplaceContentImperative />

--- a/packages/storybook-react/stories/react/controlled.stories.tsx
+++ b/packages/storybook-react/stories/react/controlled.stories.tsx
@@ -1,7 +1,13 @@
 import Editable from './editable';
 import ReplaceContentAndClearHistory from './replace-content-and-clear-history';
+import ReplaceContentImperative from './replace-content-imperative';
 import ReplaceContentPreserveHistory from './replace-content-preserve-history';
 
-export { Editable, ReplaceContentAndClearHistory, ReplaceContentPreserveHistory };
+export {
+  Editable,
+  ReplaceContentAndClearHistory,
+  ReplaceContentImperative,
+  ReplaceContentPreserveHistory,
+};
 
 export default { title: 'Editors / Controlled' };

--- a/packages/storybook-react/stories/react/replace-content-and-clear-history.tsx
+++ b/packages/storybook-react/stories/react/replace-content-and-clear-history.tsx
@@ -9,7 +9,7 @@ const DOC = {
       content: [
         {
           type: 'text',
-          text: 'New content',
+          text: `Undo via Ctrl+Z won't restore old content`,
         },
       ],
     },

--- a/packages/storybook-react/stories/react/replace-content-imperative.tsx
+++ b/packages/storybook-react/stories/react/replace-content-imperative.tsx
@@ -1,0 +1,54 @@
+import { forwardRef, Ref, useImperativeHandle, useRef } from 'react';
+import { Remirror, ThemeProvider, useRemirror, useRemirrorContext } from '@remirror/react';
+
+const DOC = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'New content',
+        },
+      ],
+    },
+  ],
+};
+
+export interface EditorRef {
+  setContent: (content: any) => void;
+}
+
+const ImperativeHandle = forwardRef((_: unknown, ref: Ref<EditorRef>) => {
+  const { setContent } = useRemirrorContext({
+    autoUpdate: true,
+  });
+
+  // Expose content handling to outside
+  useImperativeHandle(ref, () => ({ setContent }));
+
+  return <></>;
+});
+
+const ReplaceContentImperative = (): JSX.Element => {
+  const editorRef = useRef<EditorRef | null>(null);
+  const { manager, state } = useRemirror({
+    extensions: () => [],
+    content: '<p>[Replace] button is placed outside the editor (see code)</p>',
+    stringHandler: 'html',
+  });
+
+  return (
+    <>
+      <button onClick={() => editorRef.current!.setContent(DOC)}>Replace content</button>
+      <ThemeProvider>
+        <Remirror manager={manager} initialContent={state} autoRender='end'>
+          <ImperativeHandle ref={editorRef} />
+        </Remirror>
+      </ThemeProvider>
+    </>
+  );
+};
+
+export default ReplaceContentImperative;

--- a/packages/storybook-react/stories/react/replace-content-preserve-history.tsx
+++ b/packages/storybook-react/stories/react/replace-content-preserve-history.tsx
@@ -8,7 +8,7 @@ const DOC = {
       content: [
         {
           type: 'text',
-          text: 'New content',
+          text: 'Undo via Ctrl+Z will restore old content',
         },
       ],
     },

--- a/website/extension-examples/react/replace-content-imperative.tsx
+++ b/website/extension-examples/react/replace-content-imperative.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/react/replace-content-imperative.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/react/replace-content-imperative').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;
+  


### PR DESCRIPTION
### Description

Improve docs

Question raised by https://discord.com/channels/726035064831344711/745695521305526302/897800305910091837

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
