### PR TITLE
fix(extension-file): deleting files via keyboard should trigger onDeleteFile handler

### DIFF
--- a/.changeset/big-planets-cross.md
+++ b/.changeset/big-planets-cross.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': minor
+---
+
+Add new method `hasHandlers` to extensions.

--- a/.changeset/quiet-swans-collect.md
+++ b/.changeset/quiet-swans-collect.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-file': patch
+---
+
+Deleting a file using keyboard shortcuts should trigger `onDeleteFile` handler

--- a/.changeset/quiet-swans-collect.md
+++ b/.changeset/quiet-swans-collect.md
@@ -2,4 +2,4 @@
 '@remirror/extension-file': patch
 ---
 
-Deleting a file using keyboard shortcuts should trigger `onDeleteFile` handler
+Deleting a file using keyboard shortcuts should trigger `onDeleteFile` handler.

--- a/packages/remirror__core/src/extension/base-class.ts
+++ b/packages/remirror__core/src/extension/base-class.ts
@@ -426,6 +426,32 @@ export abstract class BaseClass<
       ));
   }
 
+  /**
+   * Determines if handlers exist for the given key.
+   *
+   * Checking the existence of a handler property directly gives wrong results.
+   * `this.options.onHandlerName` is always truthy because it is a reference to
+   * the wrapper function that calls each handler.
+   *
+   * ```ts
+   *
+   * // GOOD ✅
+   * if (!this.hasHandlers('onHandlerName')) {
+   *   return;
+   * }
+   *
+   * // BAD ❌
+   * if (!this.options.onHandlerName) {
+   *   return;
+   * }
+   * ```
+   *
+   * @param key The handler to test
+   */
+  hasHandlers<Key extends keyof GetHandler<Options>>(key: Key): boolean {
+    return (this._mappedHandlers[key] ?? []).length > 0;
+  }
+
   private sortHandlers<Key extends keyof GetHandler<Options>>(key: Key) {
     this._mappedHandlers[key] = sort(
       this._mappedHandlers[key],

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -10,6 +10,9 @@ import {
   findUploadPlaceholderPayload,
   getTextSelection,
   Handler,
+  isNodeSelection,
+  keyBinding,
+  KeyBindingProps,
   NodeExtension,
   NodeExtensionSpec,
   NodeSpecOverride,
@@ -217,6 +220,32 @@ export class FileExtension extends NodeExtension<FileOptions> {
 
       return false;
     };
+  }
+
+  @keyBinding({ shortcut: 'Backspace' })
+  backspaceKey(props: KeyBindingProps): boolean {
+    const { tr } = props;
+
+    // If the selection is not a node selection result false and let other
+    // extension (ie: BaseKeymapExtension) do the deleting operation.
+    if (!isNodeSelection(tr.selection)) {
+      return false;
+    }
+
+    return this.deleteFile(tr.selection.from)(props);
+  }
+
+  @keyBinding({ shortcut: 'Delete' })
+  deleteKey(props: KeyBindingProps): boolean {
+    const { tr } = props;
+
+    // If the selection is not a node selection result false and let other
+    // extension (ie: BaseKeymapExtension) do the deleting operation.
+    if (!isNodeSelection(tr.selection)) {
+      return false;
+    }
+
+    return this.deleteFile(tr.selection.from)(props);
   }
 
   private uploadFile(file: File, pos?: number | undefined): void {

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -223,11 +223,11 @@ export class FileExtension extends NodeExtension<FileOptions> {
   }
 
   @keyBinding({ shortcut: ['Backspace', 'Delete'] })
-  backspaceKey(props: KeyBindingProps): boolean {
+  backspaceShortcut(props: KeyBindingProps): boolean {
     const { tr, state } = props;
     const { from, to, empty } = tr.selection;
 
-    if (!this.options.onDeleteFile || empty) {
+    if (!this.hasHandlers('onDeleteFile') || empty) {
       return false;
     }
 

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -10,7 +10,6 @@ import {
   findUploadPlaceholderPayload,
   getTextSelection,
   Handler,
-  isNodeSelection,
   keyBinding,
   KeyBindingProps,
   NodeExtension,

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -222,21 +222,12 @@ export class FileExtension extends NodeExtension<FileOptions> {
     };
   }
 
-  @keyBinding({ shortcut: 'Backspace' })
+  @keyBinding({ shortcut: ['Backspace', 'Delete'] })
   backspaceKey(props: KeyBindingProps): boolean {
-    return this.removeKeyPress(props);
-  }
-
-  @keyBinding({ shortcut: 'Delete' })
-  deleteKey(props: KeyBindingProps): boolean {
-    return this.removeKeyPress(props);
-  }
-
-  private removeKeyPress(props: KeyBindingProps): boolean {
     const { tr, state } = props;
     const { from, to, empty } = tr.selection;
 
-    if (empty) {
+    if (!this.options.onDeleteFile || empty) {
       return false;
     }
 


### PR DESCRIPTION
### Description

The handler was only triggered when using the `deleteFile` command, this fix triggers the handler when the keyboard is used too.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

