### PR TITLE
fix(resizable-view): fix resizable view height on a small viewpoint

### DIFF
--- a/.changeset/nice-planets-eat.md
+++ b/.changeset/nice-planets-eat.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-resizable-view': patch
+---
+
+Fix an issue where the resizable view is too tall on a small viewpoint.

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -127,12 +127,12 @@ export abstract class ResizableNodeView implements NodeView {
     if (initialSize) {
       setStyle(outer, {
         width: normalizeSize(initialSize.width),
-        height: normalizeSize(initialSize.height),
+        aspectRatio: `${initialSize.width} / ${initialSize.height}`,
       });
     } else {
       setStyle(outer, {
         width: normalizeSize(node.attrs.width),
-        height: normalizeSize(node.attrs.height),
+        aspectRatio: `${node.attrs.width} / ${node.attrs.height}`,
       });
     }
 
@@ -225,7 +225,10 @@ export abstract class ResizableNodeView implements NodeView {
 
       if (newHeight) {
         this.#height = Math.round(newHeight);
-        this.dom.style.height = `${this.#height}px`;
+      }
+
+      if (newWidth || newHeight) {
+        this.dom.style.aspectRatio = `${this.#width} / ${this.#height}`;
       }
     });
 

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -139,9 +139,18 @@ export abstract class ResizableNodeView implements NodeView {
     setStyle(outer, {
       maxWidth: '100%',
       minWidth: `${MIN_WIDTH}px`,
+
+      // By default, inline-block has "vertical-align: baseline", which makes
+      // the outer wrapper slightly taller than the resizable view, which will
+      // causes layout shift. So we need to set `vertical-align` to avoid this.
+      verticalAlign: 'bottom',
       display: 'inline-block',
-      lineHeight: '0', // necessary so the bottom right handle is aligned nicely
-      transition: 'width 0.15s ease-out, height 0.15s ease-out', // make sure transition time is larger then mousemove event's throttle time
+
+      // necessary so the bottom right handle is aligned nicely
+      lineHeight: '0',
+
+      // make sure transition time is larger then mousemove event's throttle time
+      transition: 'width 0.15s ease-out, height 0.15s ease-out',
     });
 
     return outer;

--- a/packages/storybook-react/package.json
+++ b/packages/storybook-react/package.json
@@ -46,6 +46,7 @@
     "@remirror/react": "^1.0.13",
     "@remirror/react-editors": "^0.1.23",
     "@remirror/styles": "^1.1.2",
+    "@storybook/addon-controls": "^6.3.12",
     "@storybook/addons": "^6.3.4",
     "@storybook/cli": "^6.3.4",
     "@storybook/components": "^6.3.4",

--- a/packages/storybook-react/src/storybook-react-main.ts
+++ b/packages/storybook-react/src/storybook-react-main.ts
@@ -11,7 +11,7 @@ export const stories = glob.sync(baseDir('packages/storybook-react/stories/**/*.
   ignore: ['**/node_modules'],
 });
 
-export const addons = [];
+export const addons = ['@storybook/addon-controls'];
 
 // Make the introduction the first story.
 stories.sort((a, b) => {

--- a/packages/storybook-react/stories/extension-image/basic.tsx
+++ b/packages/storybook-react/stories/extension-image/basic.tsx
@@ -1,18 +1,43 @@
 import 'remirror/styles/all.css';
 
-import React from 'react';
-import { htmlToProsemirrorNode } from 'remirror';
 import { ImageExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const extensions = () => [new ImageExtension()];
 
-const Basic: React.FC = () => {
+const Basic = ({ delaySeconds = 1 }: { delaySeconds: number }): JSX.Element => {
+  const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
+  const proxySrc = `https://deelay.me/${delaySeconds * 1000}/${imageSrc}`;
+
   const { manager, state, onChange } = useRemirror({
     extensions,
-    content:
-      '<p>You can see a green image below.</p><img src="https://dummyimage.com/200x80/479e0c/fafafa">',
-    stringHandler: htmlToProsemirrorNode,
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                height: 160,
+                width: 400,
+                src: proxySrc,
+              },
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'You can see a green image below.',
+            },
+          ],
+        },
+      ],
+    },
   });
 
   return (

--- a/packages/storybook-react/stories/extension-image/image.stories.tsx
+++ b/packages/storybook-react/stories/extension-image/image.stories.tsx
@@ -1,5 +1,20 @@
-import Basic from './basic';
-import Resizable from './resizable';
+import type { Story } from '@storybook/react';
+
+import BasicComponent from './basic';
+import ResizableCompoment from './resizable';
+
+const Basic: Story<{ delaySeconds: number }> = BasicComponent.bind({});
+Basic.args = {
+  delaySeconds: 1,
+};
+Basic.storyName = 'Basic';
+
+const Resizable: Story<{ delaySeconds: number }> = ResizableCompoment.bind({});
+Resizable.args = {
+  delaySeconds: 1,
+};
+Resizable.storyName = 'Resizable';
 
 export { Basic, Resizable };
+
 export default { title: 'Extensions / Image' };

--- a/packages/storybook-react/stories/extension-image/resizable.tsx
+++ b/packages/storybook-react/stories/extension-image/resizable.tsx
@@ -1,7 +1,6 @@
 import 'remirror/styles/all.css';
 
 import React from 'react';
-import { htmlToProsemirrorNode } from 'remirror';
 import { ImageExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
@@ -10,10 +9,40 @@ const extensions = () => [new ImageExtension({ enableResizing: true })];
 const Resizable: React.FC = () => {
   const { manager, state, onChange } = useRemirror({
     extensions,
-    content:
-      '<p>You can see a resizable image below. Move your mouse over the image and drag the resizing handler to resize it.</p>' +
-      '<p style="display:flex; align-items: center; justify-content: center;"><img src="https://dummyimage.com/200x80/479e0c/fafafa"></div>',
-    stringHandler: htmlToProsemirrorNode,
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'You can see a resizable image below. Move your mouse over the image and drag the resizing handler to resize it.',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                alt: '',
+                crop: null,
+                height: 160,
+                width: 400,
+                rotate: null,
+                src: 'https://deelay.me/10000/https://dummyimage.com/2000x800/479e0c/fafafa',
+                title: '',
+                fileName: null,
+                resizable: false,
+              },
+            },
+          ],
+        },
+        { type: 'paragraph', content: [{ type: 'text', text: 'aa' }] },
+      ],
+    },
   });
 
   return (

--- a/packages/storybook-react/stories/extension-image/resizable.tsx
+++ b/packages/storybook-react/stories/extension-image/resizable.tsx
@@ -1,12 +1,14 @@
 import 'remirror/styles/all.css';
 
-import React from 'react';
 import { ImageExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const extensions = () => [new ImageExtension({ enableResizing: true })];
 
-const Resizable: React.FC = () => {
+const Resizable = ({ delaySeconds = 1 }: { delaySeconds: number }): JSX.Element => {
+  const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
+  const proxySrc = `https://deelay.me/${delaySeconds * 1000}/${imageSrc}`;
+
   const { manager, state, onChange } = useRemirror({
     extensions,
     content: {
@@ -16,8 +18,12 @@ const Resizable: React.FC = () => {
           type: 'paragraph',
           content: [
             {
-              type: 'text',
-              text: 'You can see a resizable image below. Move your mouse over the image and drag the resizing handler to resize it.',
+              type: 'image',
+              attrs: {
+                height: 160,
+                width: 400,
+                src: proxySrc,
+              },
             },
           ],
         },
@@ -25,22 +31,11 @@ const Resizable: React.FC = () => {
           type: 'paragraph',
           content: [
             {
-              type: 'image',
-              attrs: {
-                alt: '',
-                crop: null,
-                height: 160,
-                width: 400,
-                rotate: null,
-                src: 'https://deelay.me/10000/https://dummyimage.com/2000x800/479e0c/fafafa',
-                title: '',
-                fileName: null,
-                resizable: false,
-              },
+              type: 'text',
+              text: 'You can see a resizable image above. Move your mouse over the image and drag the resizing handler to resize it.',
             },
           ],
         },
-        { type: 'paragraph', content: [{ type: 'text', text: 'aa' }] },
       ],
     },
   });

--- a/packages/storybook-react/stories/extension-image/resizable.tsx
+++ b/packages/storybook-react/stories/extension-image/resizable.tsx
@@ -11,7 +11,7 @@ const Resizable: React.FC = () => {
   const { manager, state, onChange } = useRemirror({
     extensions,
     content:
-      '<p>You can see a resizable image below. Move you mouse over the image and drag the resizing handler to resize it.</p>' +
+      '<p>You can see a resizable image below. Move your mouse over the image and drag the resizing handler to resize it.</p>' +
       '<p style="display:flex; align-items: center; justify-content: center;"><img src="https://dummyimage.com/200x80/479e0c/fafafa"></div>',
     stringHandler: htmlToProsemirrorNode,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2313,6 +2313,7 @@ importers:
       '@remirror/react': ^1.0.13
       '@remirror/react-editors': ^0.1.23
       '@remirror/styles': ^1.1.2
+      '@storybook/addon-controls': ^6.3.12
       '@storybook/addons': ^6.3.4
       '@storybook/cli': ^6.3.4
       '@storybook/components': ^6.3.4
@@ -2360,6 +2361,7 @@ importers:
       '@remirror/react': link:../remirror__react
       '@remirror/react-editors': link:../remirror__react-editors
       '@remirror/styles': link:../remirror__styles
+      '@storybook/addon-controls': 6.3.12_14fc3c4d570feae7d722fbbd1b906730
       '@storybook/addons': 6.3.12_react-dom@17.0.2+react@17.0.2
       '@storybook/cli': 6.3.12_jest@27.3.1
       '@storybook/components': 6.3.12_14fc3c4d570feae7d722fbbd1b906730
@@ -7686,6 +7688,31 @@ packages:
       highcharts: 9.3.0
     dev: false
 
+  /@storybook/addon-controls/6.3.12_14fc3c4d570feae7d722fbbd1b906730:
+    resolution: {integrity: sha512-WO/PbygE4sDg3BbstJ49q0uM3Xu5Nw4lnHR5N4hXSvRAulZt1d1nhphRTHjfX+CW+uBcfzkq9bksm6nKuwmOyw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.3.12_react-dom@17.0.2+react@17.0.2
+      '@storybook/api': 6.3.12_react-dom@17.0.2+react@17.0.2
+      '@storybook/client-api': 6.3.12_react-dom@17.0.2+react@17.0.2
+      '@storybook/components': 6.3.12_14fc3c4d570feae7d722fbbd1b906730
+      '@storybook/node-logger': 6.3.12
+      '@storybook/theming': 6.3.12_react-dom@17.0.2+react@17.0.2
+      core-js: 3.19.0
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@storybook/addons/6.3.12_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-UgoMyr7Qr0FS3ezt8u6hMEcHgyynQS9ucr5mAwZky3wpXRPFyUTmMto9r4BBUdqyUvTUj/LRKIcmLBfj+/l0Fg==}
     peerDependencies:
@@ -10850,7 +10877,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.4_debug@4.3.2
+      follow-redirects: 1.14.4
     transitivePeerDependencies:
       - debug
 
@@ -15555,6 +15582,15 @@ packages:
       tabbable: 4.0.0
       xtend: 4.0.2
     dev: false
+
+  /follow-redirects/1.14.4:
+    resolution: {integrity: sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   /follow-redirects/1.14.4_debug@4.3.2:
     resolution: {integrity: sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==}
@@ -27421,7 +27457,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
 
   /widest-line/2.0.1:
     resolution: {integrity: sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==}


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->


https://user-images.githubusercontent.com/24715727/140254172-0f933aff-1a5a-45be-b796-49e5842f0fa5.mov

Safari (both mac and iOS) doesn't support `aspect-ratio` until the very latest version: 
![image](https://user-images.githubusercontent.com/24715727/140255224-08496fa4-a298-49d2-9345-cfe16c038f0b.png)



### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 