### PR TITLE
fix(core-helpers): always reset regexp lastIndex before matching

### DIFF
--- a/.changeset/tasty-gifts-remember.md
+++ b/.changeset/tasty-gifts-remember.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-helpers': patch
+---
+
+Always reset regexp lastIndex before matching.

--- a/packages/remirror__core-helpers/src/core-helpers.ts
+++ b/packages/remirror__core-helpers/src/core-helpers.ts
@@ -513,6 +513,8 @@ export function findMatches(
   regexp: RegExp,
   runWhile: (match: RegExpExecArray | null) => boolean = (match) => !!match,
 ): RegExpExecArray[] {
+  regexp.lastIndex = 0;
+
   const results: RegExpExecArray[] = [];
   const flags = regexp.flags;
   let match: RegExpExecArray | null;


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

 
https://user-images.githubusercontent.com/24715727/140272834-997056e3-03f3-4469-a5b5-a51a4cf2c1cf.mp4

 
