### PR TITLE
feat(extension-link): add a new extension option `extractHref`

### DIFF
--- a/.changeset/orange-ravens-marry.md
+++ b/.changeset/orange-ravens-marry.md
@@ -2,5 +2,5 @@
 '@remirror/extension-link': patch
 ---
 
-Add a new option `extractHref` to `ExtensionLink`. Users can use this option to customize the `href` attribute, for example `file://` and `tel`.
+Add a new option `extractHref` to `ExtensionLink`. Users can use this option to customize the `href` attribute, for example `file://` and `tel:`.
 

--- a/.changeset/orange-ravens-marry.md
+++ b/.changeset/orange-ravens-marry.md
@@ -3,4 +3,3 @@
 ---
 
 Add a new option `extractHref` to `ExtensionLink`. Users can use this option to customize the `href` attribute, for example `file://` and `tel:`.
-

--- a/.changeset/orange-ravens-marry.md
+++ b/.changeset/orange-ravens-marry.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-link': patch
+---
+
+Add a new option `extractHref` to `ExtensionLink`. Users can use this option to customize the `href` attribute, for example `file://` and `tel`.
+

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -10,7 +10,7 @@ import {
   NodeExtensionSpec,
   prosemirrorNodeToHtml,
 } from 'remirror';
-import { createCoreManager, LinkExtension, LinkOptions } from 'remirror/extensions';
+import { createCoreManager, extractHref, LinkExtension, LinkOptions } from 'remirror/extensions';
 
 extensionValidityTest(LinkExtension);
 
@@ -481,6 +481,7 @@ describe('autolinking', () => {
 
   beforeEach(() => {
     onUpdateLink = jest.fn(() => {});
+
     editor = create({ autoLink: true, onUpdateLink });
     ({
       attributeMarks: { link },
@@ -499,6 +500,44 @@ describe('autolinking', () => {
 
     expect(editor.doc).toEqualRemirrorDocument(
       doc(p(link({ auto: true, href: '//test.com' })('test.com'))),
+    );
+  });
+
+  it('can parse telphone by overriding extractHref', () => {
+    const phoneRegex = /(?:\+?(\d{1,3}))?[ (.-]*(\d{3})[ ).-]*(\d{3})[ .-]*(\d{4})(?: *x(\d+))?/;
+    const linkRegex =
+      /(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}\.?(?::\d{2,5})?(?:[#/?]\S*)?/i;
+
+    const composedRegex = new RegExp(
+      [phoneRegex, linkRegex].map((regex) => `(${regex.source})`).join('|'),
+      // 'i',
+    );
+
+    const extractLinkOrTel = (props: { url: string; defaultProtocol: string }): string => {
+      const isLink = linkRegex.exec(props.url);
+      return isLink ? extractHref(props) : `tel:${props.url}`;
+    };
+
+    const editor = create({
+      autoLink: true,
+      autoLinkRegex: composedRegex,
+      extractHref: extractLinkOrTel,
+    });
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>'))).insertText('test.com');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//test.com' })('test.com'))),
+    );
+
+    editor.add(doc(p('<cursor>'))).insertText('800-555-1234');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: 'tel:800-555-1234' })('800-555-1234'))),
     );
   });
 

--- a/packages/remirror__extension-link/src/index.ts
+++ b/packages/remirror__extension-link/src/index.ts
@@ -5,4 +5,4 @@ export type {
   LinkOptions,
   ShortcutHandlerProps,
 } from './link-extension';
-export { LinkExtension } from './link-extension';
+export { extractHref, LinkExtension } from './link-extension';

--- a/packages/storybook-react/stories/extension-link/link-extension.stories.tsx
+++ b/packages/storybook-react/stories/extension-link/link-extension.stories.tsx
@@ -1,6 +1,7 @@
 import Basic from './basic';
 import ClickHandler from './click-handler';
 import EditDialog from './edit-dialog';
+import WithTelephoneSupport from './with-telephone-support';
 
-export { Basic, ClickHandler, EditDialog };
+export { Basic, ClickHandler, EditDialog, WithTelephoneSupport };
 export default { title: 'Extensions / Link' };

--- a/packages/storybook-react/stories/extension-link/with-telephone-support.tsx
+++ b/packages/storybook-react/stories/extension-link/with-telephone-support.tsx
@@ -3,13 +3,12 @@ import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const phoneRegex = /(?:\+?(\d{1,3}))?[ (.-]*(\d{3})[ ).-]*(\d{3})[ .-]*(\d{4})(?: *x(\d+))?/;
 const linkRegex =
-  /(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}\.?(?::\d{2,5})?(?:[#/?]\S*)?/gi;
-
+  /(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}\.?(?::\d{2,5})?(?:[#/?]\S*)?/i;
 const composedRegex = new RegExp(
   [phoneRegex, linkRegex].map((regex) => `(${regex.source})`).join('|'),
 );
 
-function extractHref({
+function extractLinkOrTel({
   url,
   defaultProtocol,
 }: {
@@ -23,7 +22,11 @@ function extractHref({
 const WithTelephoneSupport = (): JSX.Element => {
   const { manager, state } = useRemirror({
     extensions: () => [
-      new LinkExtension({ autoLink: true, autoLinkRegex: composedRegex, extractHref }),
+      new LinkExtension({
+        autoLink: true,
+        autoLinkRegex: composedRegex,
+        extractHref: extractLinkOrTel,
+      }),
     ],
     content: `Type "800-555-1234" to insert a phone:&nbsp;`,
     stringHandler: 'html',

--- a/packages/storybook-react/stories/extension-link/with-telephone-support.tsx
+++ b/packages/storybook-react/stories/extension-link/with-telephone-support.tsx
@@ -1,0 +1,39 @@
+import { DefaultProtocol, extractHref as extractLink, LinkExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const phoneRegex = /(?:\+?(\d{1,3}))?[ (.-]*(\d{3})[ ).-]*(\d{3})[ .-]*(\d{4})(?: *x(\d+))?/;
+const linkRegex =
+  /(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}\.?(?::\d{2,5})?(?:[#/?]\S*)?/gi;
+
+const composedRegex = new RegExp(
+  [phoneRegex, linkRegex].map((regex) => `(${regex.source})`).join('|'),
+);
+
+function extractHref({
+  url,
+  defaultProtocol,
+}: {
+  url: string;
+  defaultProtocol: DefaultProtocol;
+}): string {
+  const isLink = linkRegex.test(url);
+  return isLink ? extractLink({ url, defaultProtocol }) : `tel:${url}`;
+}
+
+const WithTelephoneSupport = (): JSX.Element => {
+  const { manager, state } = useRemirror({
+    extensions: () => [
+      new LinkExtension({ autoLink: true, autoLinkRegex: composedRegex, extractHref }),
+    ],
+    content: `Type "800-555-1234" to insert a phone:&nbsp;`,
+    stringHandler: 'html',
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} initialContent={state} />
+    </ThemeProvider>
+  );
+};
+
+export default WithTelephoneSupport;

--- a/packages/storybook-react/stories/extension-link/with-telephone-support.tsx
+++ b/packages/storybook-react/stories/extension-link/with-telephone-support.tsx
@@ -1,11 +1,12 @@
 import { DefaultProtocol, extractHref as extractLink, LinkExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-const phoneRegex = /(?:\+?(\d{1,3}))?[ (.-]*(\d{3})[ ).-]*(\d{3})[ .-]*(\d{4})(?: *x(\d+))?/;
+const phoneRegex = /(?:\+?(\d{1,3}))?[(.-]*(\d{3})[).-]*(\d{3})[.-]*(\d{4})(?: *x(\d+))?/;
 const linkRegex =
-  /(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}\.?(?::\d{2,5})?(?:[#/?]\S*)?/i;
+  /(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}\.?(?::\d{2,5})?(?:[#/?]\S*)?/gi;
 const composedRegex = new RegExp(
   [phoneRegex, linkRegex].map((regex) => `(${regex.source})`).join('|'),
+  'gi',
 );
 
 function extractLinkOrTel({
@@ -15,6 +16,7 @@ function extractLinkOrTel({
   url: string;
   defaultProtocol: DefaultProtocol;
 }): string {
+  linkRegex.lastIndex = 0;
   const isLink = linkRegex.test(url);
   return isLink ? extractLink({ url, defaultProtocol }) : `tel:${url}`;
 }

--- a/website/extension-examples/extension-link/with-telephone-support.tsx
+++ b/website/extension-examples/extension-link/with-telephone-support.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-link/with-telephone-support.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-link/with-telephone-support').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;
+  


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Add a new option `extractHref` to `ExtensionLink`. Users can use this option to customize the `href` attribute, for example `file://` and `tel:`.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
