### PR TITLE
feat: add shortcuts support

### DIFF
--- a/.changeset/happy-pets-hang.md
+++ b/.changeset/happy-pets-hang.md
@@ -1,0 +1,6 @@
+---
+'remirror': patch
+'@remirror/preset-wysiwyg': patch
+---
+
+Add keyboard shortcuts

--- a/.changeset/many-buttons-eat.md
+++ b/.changeset/many-buttons-eat.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-shortcuts': patch
+---
+
+Add support for keyboard shortcuts

--- a/docs/extensions/shortcuts-extension.mdx
+++ b/docs/extensions/shortcuts-extension.mdx
@@ -1,0 +1,30 @@
+---
+hide_title: true
+title: 'ShortcutsExtension'
+---
+
+# `ShortcutsExtension`
+
+## Summary
+
+Adds shortcut support to the editor, e.g. replaces `(c)` by `©`.
+
+## Usage
+
+### Installation
+
+This extension is installed for you when you install the main `remirror` package.
+
+You can use the imports in the following way.
+
+```ts
+import { ShortcutsExtension } from 'remirror/extensions';
+```
+
+To install it directly you can use
+
+The extension is provided by the `@remirror/extension-shortcuts` package. There are two ways of pulling it into your project.
+
+## API
+
+- [ShortcutsExtension](../api/extension-shortcuts)

--- a/packages/remirror/package.json
+++ b/packages/remirror/package.json
@@ -113,6 +113,7 @@
     "@remirror/extension-placeholder": "^1.0.11",
     "@remirror/extension-positioner": "^1.1.9",
     "@remirror/extension-search": "^1.0.10",
+    "@remirror/extension-shortcuts": "^1.0.1",
     "@remirror/extension-strike": "^1.0.10",
     "@remirror/extension-sub": "^1.0.10",
     "@remirror/extension-sup": "^1.0.10",

--- a/packages/remirror/src/extensions.ts
+++ b/packages/remirror/src/extensions.ts
@@ -35,6 +35,7 @@ export * from '@remirror/extension-paragraph';
 export * from '@remirror/extension-placeholder';
 export * from '@remirror/extension-positioner';
 export * from '@remirror/extension-search';
+export * from '@remirror/extension-shortcuts';
 export * from '@remirror/extension-strike';
 export * from '@remirror/extension-sub';
 export * from '@remirror/extension-sup';

--- a/packages/remirror/src/tsconfig.json
+++ b/packages/remirror/src/tsconfig.json
@@ -143,6 +143,9 @@
       "path": "../../remirror__extension-search/src"
     },
     {
+      "path": "../../remirror__extension-shortcuts/src"
+    },
+    {
       "path": "../../remirror__extension-strike/src"
     },
     {

--- a/packages/remirror__extension-shortcuts/CHANGELOG.md
+++ b/packages/remirror__extension-shortcuts/CHANGELOG.md
@@ -1,0 +1,23 @@
+# @remirror/extension-shortcuts
+
+## 1.0.1
+
+> 2021-07-17
+
+### Patch Changes
+
+- [#1002](https://github.com/remirror/remirror/pull/1002) [`b3ea6f10d`](https://github.com/remirror/remirror/commit/b3ea6f10d4917f933971236be936731f75a69a70) Thanks [@ifiokjr](https://github.com/ifiokjr)! - Use carets `^` for versioning of `remirror` packages.
+
+- Updated dependencies [[`b3ea6f10d`](https://github.com/remirror/remirror/commit/b3ea6f10d4917f933971236be936731f75a69a70)]:
+  - @remirror/core@1.0.1
+  - @remirror/pm@1.0.1
+
+## 1.0.0
+
+> 2021-07-17
+
+### Patch Changes
+
+- Updated dependencies [[`8202b65ef`](https://github.com/remirror/remirror/commit/8202b65efbce5a8338c45fd34b3efb676b7e54e7), [`adfb12a4c`](https://github.com/remirror/remirror/commit/adfb12a4cee7031eec4baa10830b0fc0134ebdc8), [`7f3569729`](https://github.com/remirror/remirror/commit/7f3569729c0d843b7745a490feda383b31aa2b7e), [`270edd91b`](https://github.com/remirror/remirror/commit/270edd91ba6badf9468721e35fa0ddc6a21c6dd2), [`b4dfcad36`](https://github.com/remirror/remirror/commit/b4dfcad364a0b41d321fbd26a97377f2b6d4047c), [`e9b10fa5a`](https://github.com/remirror/remirror/commit/e9b10fa5a50dd3e342b75b0a852627db99f22dc2), [`6ab7d2224`](https://github.com/remirror/remirror/commit/6ab7d2224d16ba821d8510e0498aaa9c420922c4), [`270edd91b`](https://github.com/remirror/remirror/commit/270edd91ba6badf9468721e35fa0ddc6a21c6dd2), [`270edd91b`](https://github.com/remirror/remirror/commit/270edd91ba6badf9468721e35fa0ddc6a21c6dd2), [`7024de573`](https://github.com/remirror/remirror/commit/7024de5738a968f2914a999e570d723899815611), [`03d0ae485`](https://github.com/remirror/remirror/commit/03d0ae485079a166a223b902ea72cbe62504b0f0)]:
+  - @remirror/core@1.0.0
+  - @remirror/pm@1.0.0

--- a/packages/remirror__extension-shortcuts/__tests__/shortcuts-extension.spec.ts
+++ b/packages/remirror__extension-shortcuts/__tests__/shortcuts-extension.spec.ts
@@ -1,0 +1,28 @@
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
+import { object } from '@remirror/core';
+
+import { ShortcutsExtension, ShortcutsOptions } from '../';
+
+extensionValidityTest(ShortcutsExtension);
+
+function create(options: ShortcutsOptions = object()) {
+  const extension = new ShortcutsExtension(options);
+  const editor = renderEditor([extension]);
+
+  return { ...editor, editor };
+}
+
+describe('inputRules', () => {
+  it('replaces sequence with shortcut', () => {
+    const {
+      nodes: { p, doc },
+      add,
+    } = create();
+
+    add(doc(p('<cursor>')))
+      .insertText('->')
+      .callback((content) => {
+        expect(content.state.doc).toEqualRemirrorDocument(doc(p('→')));
+      });
+  });
+});

--- a/packages/remirror__extension-shortcuts/__tests__/tsconfig.json
+++ b/packages/remirror__extension-shortcuts/__tests__/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > '__tests__'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "jest",
+      "jest-extended",
+      "jest-axe",
+      "@testing-library/jest-dom",
+      "snapshot-diff",
+      "node"
+    ],
+    "declaration": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove"
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../testing/src"
+    },
+    {
+      "path": "../../remirror/src"
+    },
+    {
+      "path": "../../remirror__core/src"
+    }
+  ]
+}

--- a/packages/remirror__extension-shortcuts/package.json
+++ b/packages/remirror__extension-shortcuts/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@remirror/extension-shortcuts",
+  "version": "1.0.1",
+  "private": true,
+  "description": "Replace characters with keyboard shortcuts",
+  "keywords": [
+    "remirror",
+    "extension"
+  ],
+  "homepage": "https://github.com/remirror/remirror/tree/HEAD/packages/remirror__extension-shortcuts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/remirror/remirror.git",
+    "directory": "packages/remirror__extension-shortcuts"
+  },
+  "license": "MIT",
+  "contributors": [
+    "Ronny Roeller <ronny@nextapp.co>"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/remirror-extension-shortcuts.esm.js",
+      "require": "./dist/remirror-extension-shortcuts.cjs.js",
+      "browser": "./dist/remirror-extension-shortcuts.browser.esm.js",
+      "types": "./dist/remirror-extension-shortcuts.cjs.d.ts",
+      "default": "./dist/remirror-extension-shortcuts.esm.js"
+    },
+    "./package.json": "./package.json",
+    "./types/*": "./dist/declarations/src/*.d.ts"
+  },
+  "main": "dist/remirror-extension-shortcuts.cjs.js",
+  "module": "dist/remirror-extension-shortcuts.esm.js",
+  "browser": {
+    "./dist/remirror-extension-shortcuts.cjs.js": "./dist/remirror-extension-shortcuts.browser.cjs.js",
+    "./dist/remirror-extension-shortcuts.esm.js": "./dist/remirror-extension-shortcuts.browser.esm.js"
+  },
+  "types": "dist/remirror-extension-shortcuts.cjs.d.ts",
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@babel/runtime": "^7.13.10",
+    "@remirror/core": "^1.3.0"
+  },
+  "devDependencies": {
+    "@remirror/pm": "^1.0.6"
+  },
+  "peerDependencies": {
+    "@remirror/pm": "^1.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "@remirror": {
+    "sizeLimit": "5 KB"
+  }
+}

--- a/packages/remirror__extension-shortcuts/readme.md
+++ b/packages/remirror__extension-shortcuts/readme.md
@@ -1,0 +1,36 @@
+# @remirror/extension-shortcuts
+
+> **Replace characters with keyboard shortcuts**
+
+[![Version][version]][npm] [![Weekly Downloads][downloads-badge]][npm] [![Bundled size][size-badge]][size] [![Typed Codebase][typescript]](#) [![MIT License][license]](#)
+
+[version]: https://flat.badgen.net/npm/v/@remirror/extension-shortcuts
+[npm]: https://npmjs.com/package/@remirror/extension-shortcuts
+[license]: https://flat.badgen.net/badge/license/MIT/purple
+[size]: https://bundlephobia.com/result?p=@remirror/extension-shortcuts
+[size-badge]: https://flat.badgen.net/bundlephobia/minzip/@remirror/extension-shortcuts
+[typescript]: https://flat.badgen.net/badge/icon/TypeScript?icon=typescript&label
+[downloads-badge]: https://badgen.net/npm/dw/@remirror/extension-shortcuts/red?icon=npm
+
+## Installation
+
+```bash
+# yarn
+yarn add @remirror/extension-shortcuts
+
+# pnpm
+pnpm add @remirror/extension-shortcuts
+
+# npm
+npm install @remirror/extension-shortcuts
+```
+
+## Usage
+
+The following code creates an instance of this extension.
+
+```ts
+import { ShortcutsExtension } from '@remirror/extension-shortcuts';
+
+const extension = new ShortcutsExtension();
+```

--- a/packages/remirror__extension-shortcuts/src/index.ts
+++ b/packages/remirror__extension-shortcuts/src/index.ts
@@ -1,0 +1,1 @@
+export * from './shortcuts-extension';

--- a/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
+++ b/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
@@ -6,13 +6,13 @@ const SHORTCUTS: Array<[RegExp, string]> = [
   // Dash
   [/--$/, '—'],
   // ellipsis
-  [/\.\.\.$/, '…'],
+  [/\.{3}$/, '…'],
   // openDoubleQuote
-  [/(?:^|[\s{[(<'"\u2018\u201C])(")$/, '“'],
+  [/(?:^|[\s"'(<[{\u2018\u201C])(")$/, '“'],
   // closeDoubleQuote
   [/"$/, '”'],
   // openSingleQuote
-  [/(?:^|[\s{[(<'"\u2018\u201C])(')$/, '‘'],
+  [/(?:^|[\s"'(<[{\u2018\u201C])(')$/, '‘'],
   // closeSingleQuote
   [/'$/, '’'],
   // leftArrow

--- a/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
+++ b/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
@@ -1,0 +1,83 @@
+import { extension, InputRule, PlainExtension, plainInputRule } from '@remirror/core';
+
+export interface ShortcutsOptions {}
+
+const SHORTCUTS: Array<[RegExp, string]> = [
+  // Dash
+  [/--$/, '—'],
+  // ellipsis
+  [/\.\.\.$/, '…'],
+  // openDoubleQuote
+  [/(?:^|[\s{[(<'"\u2018\u201C])(")$/, '“'],
+  // closeDoubleQuote
+  [/"$/, '”'],
+  // openSingleQuote
+  [/(?:^|[\s{[(<'"\u2018\u201C])(')$/, '‘'],
+  // closeSingleQuote
+  [/'$/, '’'],
+  // leftArrow
+  [/<-$/, '←'],
+  // rightArrow
+  [/->$/, '→'],
+  // copyright
+  [/\(c\)$/, '©'],
+  // trademark
+  [/\(tm\)$/, '™'],
+  // registeredTrademark
+  [/\(r\)$/, '®'],
+  // oneHalf
+  [/1\/2$/, '½'],
+  // plusMinus
+  [/\+\/-$/, '±'],
+  // notEqual
+  [/!=$/, '≠'],
+  // laquo
+  [/<<$/, '«'],
+  // raquo
+  [/>>$/, '»'],
+  // multiplication
+  [/\d+\s?([*x])\s?\d+$/, '×'],
+  // superscriptTwo
+  [/\^2$/, '²'],
+  // superscriptThree
+  [/\^3$/, '³'],
+  // oneQuarter
+  [/1\/4$/, '¼'],
+  // threeQuarters
+  [/3\/4$/, '¾'],
+];
+
+/**
+ * Replace characters with keyboard shortcuts
+ *
+ * Inspired by Tiptap's extension-typography
+ */
+@extension<ShortcutsOptions>({
+  defaultOptions: {},
+})
+export class ShortcutsExtension extends PlainExtension<ShortcutsOptions> {
+  get name() {
+    return 'shortcuts' as const;
+  }
+
+  /**
+   * Manage input rules for emoticons.
+   */
+  createInputRules(): InputRule[] {
+    return SHORTCUTS.map(([regexp, replace]) => {
+      // Replace emoticons
+      return plainInputRule({
+        regexp,
+        transformMatch: () => replace,
+      });
+    });
+  }
+}
+
+declare global {
+  namespace Remirror {
+    interface AllExtensions {
+      template: ShortcutsExtension;
+    }
+  }
+}

--- a/packages/remirror__extension-shortcuts/src/tsconfig.json
+++ b/packages/remirror__extension-shortcuts/src/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > 'src'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [],
+    "declaration": true,
+    "noEmit": false,
+    "composite": true,
+    "emitDeclarationOnly": true,
+    "outDir": "../dist-types"
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../../remirror__core/src"
+    }
+  ]
+}

--- a/packages/remirror__preset-wysiwyg/__tests__/tsconfig.json
+++ b/packages/remirror__preset-wysiwyg/__tests__/tsconfig.json
@@ -83,6 +83,9 @@
       "path": "../../remirror__extension-search/src"
     },
     {
+      "path": "../../remirror__extension-shortcuts/src"
+    },
+    {
       "path": "../../remirror__extension-strike/src"
     },
     {

--- a/packages/remirror__preset-wysiwyg/package.json
+++ b/packages/remirror__preset-wysiwyg/package.json
@@ -58,6 +58,7 @@
     "@remirror/extension-link": "^1.1.7",
     "@remirror/extension-list": "^1.2.4",
     "@remirror/extension-search": "^1.0.10",
+    "@remirror/extension-shortcuts": "^1.0.1",
     "@remirror/extension-strike": "^1.0.10",
     "@remirror/extension-trailing-node": "^1.0.10",
     "@remirror/extension-underline": "^1.0.10",

--- a/packages/remirror__preset-wysiwyg/src/tsconfig.json
+++ b/packages/remirror__preset-wysiwyg/src/tsconfig.json
@@ -68,6 +68,9 @@
       "path": "../../remirror__extension-search/src"
     },
     {
+      "path": "../../remirror__extension-shortcuts/src"
+    },
+    {
       "path": "../../remirror__extension-strike/src"
     },
     {

--- a/packages/remirror__preset-wysiwyg/src/wysiwyg-preset.ts
+++ b/packages/remirror__preset-wysiwyg/src/wysiwyg-preset.ts
@@ -19,6 +19,7 @@ import {
   TaskListExtension,
 } from '@remirror/extension-list';
 import { SearchExtension, SearchOptions } from '@remirror/extension-search';
+import { ShortcutsExtension } from '@remirror/extension-shortcuts';
 import { StrikeExtension } from '@remirror/extension-strike';
 import { TrailingNodeExtension, TrailingNodeOptions } from '@remirror/extension-trailing-node';
 import { UnderlineExtension } from '@remirror/extension-underline';
@@ -63,6 +64,7 @@ export function wysiwygPreset(options: GetStaticAndDynamic<WysiwygOptions> = {})
   const bulletListExtension = new BulletListExtension();
   const orderedListExtension = new OrderedListExtension();
   const taskListExtension = new TaskListExtension({});
+  const shortcutsExtension = new ShortcutsExtension();
 
   const { selectTextOnClick } = options;
   const linkExtension = new LinkExtension({ autoLink: true, selectTextOnClick });
@@ -125,6 +127,7 @@ export function wysiwygPreset(options: GetStaticAndDynamic<WysiwygOptions> = {})
     dropCursorExtension,
     gapCursorExtension,
     searchExtension,
+    shortcutsExtension,
     trailingNodeExtension,
 
     // Nodes
@@ -174,4 +177,5 @@ export type WysiwygPreset =
   | IframeExtension
   | BulletListExtension
   | OrderedListExtension
-  | TaskListExtension;
+  | TaskListExtension
+  | ShortcutsExtension;

--- a/packages/storybook-react/stories/extension-shortcuts/basic.tsx
+++ b/packages/storybook-react/stories/extension-shortcuts/basic.tsx
@@ -1,0 +1,27 @@
+import 'remirror/styles/all.css';
+
+import { PlaceholderExtension, ShortcutsExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const extensions = () => [
+  new PlaceholderExtension({ placeholder: `Type (c) for copyright sign` }),
+  new ShortcutsExtension(),
+];
+
+const Basic = (): JSX.Element => {
+  const { manager, state, onChange } = useRemirror({ extensions });
+
+  return (
+    <ThemeProvider>
+      <Remirror
+        manager={manager}
+        autoFocus
+        onChange={onChange}
+        initialContent={state}
+        autoRender='end'
+      />
+    </ThemeProvider>
+  );
+};
+
+export default Basic;

--- a/packages/storybook-react/stories/extension-shortcuts/shortcuts.stories.tsx
+++ b/packages/storybook-react/stories/extension-shortcuts/shortcuts.stories.tsx
@@ -1,0 +1,5 @@
+import Basic from './basic';
+
+export default { title: 'Extensions / Shortcuts' };
+
+export { Basic };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,7 @@ importers:
       '@remirror/extension-placeholder': ^1.0.11
       '@remirror/extension-positioner': ^1.1.9
       '@remirror/extension-search': ^1.0.10
+      '@remirror/extension-shortcuts': ^1.0.1
       '@remirror/extension-strike': ^1.0.10
       '@remirror/extension-sub': ^1.0.10
       '@remirror/extension-sup': ^1.0.10
@@ -594,6 +595,7 @@ importers:
       '@remirror/extension-placeholder': link:../remirror__extension-placeholder
       '@remirror/extension-positioner': link:../remirror__extension-positioner
       '@remirror/extension-search': link:../remirror__extension-search
+      '@remirror/extension-shortcuts': link:../remirror__extension-shortcuts
       '@remirror/extension-strike': link:../remirror__extension-strike
       '@remirror/extension-sub': link:../remirror__extension-sub
       '@remirror/extension-sup': link:../remirror__extension-sup
@@ -1534,6 +1536,17 @@ importers:
       '@remirror/core': link:../remirror__core
       '@remirror/messages': link:../remirror__messages
       escape-string-regexp: 4.0.0
+    devDependencies:
+      '@remirror/pm': link:../remirror__pm
+
+  packages/remirror__extension-shortcuts:
+    specifiers:
+      '@babel/runtime': ^7.13.10
+      '@remirror/core': ^1.3.0
+      '@remirror/pm': ^1.0.6
+    dependencies:
+      '@babel/runtime': 7.15.4
+      '@remirror/core': link:../remirror__core
     devDependencies:
       '@remirror/pm': link:../remirror__pm
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1935,6 +1935,7 @@ importers:
       '@remirror/extension-link': ^1.1.7
       '@remirror/extension-list': ^1.2.4
       '@remirror/extension-search': ^1.0.10
+      '@remirror/extension-shortcuts': ^1.0.1
       '@remirror/extension-strike': ^1.0.10
       '@remirror/extension-trailing-node': ^1.0.10
       '@remirror/extension-underline': ^1.0.10
@@ -1959,6 +1960,7 @@ importers:
       '@remirror/extension-link': link:../remirror__extension-link
       '@remirror/extension-list': link:../remirror__extension-list
       '@remirror/extension-search': link:../remirror__extension-search
+      '@remirror/extension-shortcuts': link:../remirror__extension-shortcuts
       '@remirror/extension-strike': link:../remirror__extension-strike
       '@remirror/extension-trailing-node': link:../remirror__extension-trailing-node
       '@remirror/extension-underline': link:../remirror__extension-underline

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -762,6 +762,7 @@
       "@remirror/extension-link",
       "@remirror/extension-list",
       "@remirror/extension-search",
+      "@remirror/extension-shortcuts",
       "@remirror/extension-strike",
       "@remirror/extension-trailing-node",
       "@remirror/extension-underline",

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -549,6 +549,14 @@
     "gzip": true
   },
   {
+    "name": "@remirror/extension-shortcuts",
+    "limit": "5 KB",
+    "path": "packages/remirror__extension-shortcuts/dist/remirror-extension-shortcuts.browser.esm.js",
+    "ignore": ["@remirror/pm", "@remirror/core"],
+    "running": false,
+    "gzip": true
+  },
+  {
     "name": "@remirror/extension-strike",
     "limit": "5 KB",
     "path": "packages/remirror__extension-strike/dist/remirror-extension-strike.browser.esm.js",

--- a/support/root/tsconfig.json
+++ b/support/root/tsconfig.json
@@ -351,6 +351,12 @@
       "path": "packages/remirror__extension-search/src"
     },
     {
+      "path": "packages/remirror__extension-shortcuts/__tests__"
+    },
+    {
+      "path": "packages/remirror__extension-shortcuts/src"
+    },
+    {
       "path": "packages/remirror__extension-strike/__tests__"
     },
     {

--- a/website/extension-examples/extension-shortcuts/basic.tsx
+++ b/website/extension-examples/extension-shortcuts/basic.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-shortcuts/basic.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-shortcuts/basic').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;
+  


### PR DESCRIPTION
### Description

Keyboard shortcuts replaces e.g. characters `(c)` by `©`.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
