### PR TITLE
fix: make extension-shortcuts package public

### DIFF
--- a/packages/remirror__extension-shortcuts/package.json
+++ b/packages/remirror__extension-shortcuts/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@remirror/extension-shortcuts",
   "version": "1.0.2",
-  "private": true,
   "description": "Replace characters with keyboard shortcuts",
   "keywords": [
     "remirror",


### PR DESCRIPTION
### Description

This broke before the build: https://discord.com/channels/726035064831344711/745695557976195072/910219378744754277

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
