### PR TITLE
fix: removeFontSize respects user selection

### DIFF
--- a/.changeset/thick-zebras-admire.md
+++ b/.changeset/thick-zebras-admire.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-font-size': patch
+---
+
+fix: removeFontSize should respect user text selection

--- a/packages/remirror__extension-font-size/__tests__/font-size-extension.spec.ts
+++ b/packages/remirror__extension-font-size/__tests__/font-size-extension.spec.ts
@@ -1,5 +1,46 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
+import { object } from '@remirror/core';
 
 import { FontSizeExtension } from '../';
+import { FontSizeOptions } from '../src/font-size-types';
 
 extensionValidityTest(FontSizeExtension);
+
+function create(options: FontSizeOptions = object()) {
+  const extension = new FontSizeExtension(options);
+  return renderEditor([extension]);
+}
+
+describe('commands', () => {
+  it('removeFontSize removes only font size from selected text', () => {
+    const {
+      nodes: { p, doc },
+      add,
+      view,
+      commands,
+      chain,
+    } = create();
+
+    add(doc(p('<start>Big small<end>')));
+    commands.setFontSize('8px');
+    console.log(view.dom.innerHTML);
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+      <p>
+        <span style=" font-size:6pt">
+          Big small
+        </span>
+      </p>
+    `);
+
+    chain.selectText({ from: 0, to: 4 }).run();
+    commands.removeFontSize();
+    expect(view.dom.innerHTML).toMatchInlineSnapshot(`
+    <p>
+      Big
+      <span style=" font-size:6pt">
+        small
+      </span>
+    </p>
+  `);
+  });
+});

--- a/packages/remirror__extension-font-size/__tests__/font-size-extension.spec.ts
+++ b/packages/remirror__extension-font-size/__tests__/font-size-extension.spec.ts
@@ -22,7 +22,7 @@ describe('commands', () => {
     } = create();
 
     add(doc(p('<start>Big small<end>')));
-    commands.setFontSize('8px');
+    commands.setFontSize('6pt');
     console.log(view.dom.innerHTML);
     expect(view.dom.innerHTML).toMatchInlineSnapshot(`
       <p>

--- a/packages/remirror__extension-font-size/src/font-size-extension.ts
+++ b/packages/remirror__extension-font-size/src/font-size-extension.ts
@@ -176,7 +176,7 @@ export class FontSizeExtension extends MarkExtension<FontSizeOptions> {
    */
   @command()
   removeFontSize(options?: SizeCommandOptions): CommandFunction {
-    return this.store.commands.removeMark.original({ type: this.type, ...options, expand: true });
+    return this.store.commands.removeMark.original({ type: this.type, ...options });
   }
 
   /**


### PR DESCRIPTION
### Description

Before, removeFontSize would remove always the complete mark.

Fixes https://discord.com/channels/726035064831344711/745695521305526302/908690345464836126

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
