### PR TITLE
fix: remove rules depending on capture groups

### DIFF
--- a/.changeset/two-gifts-float.md
+++ b/.changeset/two-gifts-float.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-shortcuts': patch
+---
+
+fix: remove rules depending on capture groups

--- a/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
+++ b/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
@@ -7,14 +7,6 @@ const SHORTCUTS: Array<[RegExp, string]> = [
   [/--$/, '—'],
   // ellipsis
   [/\.{3}$/, '…'],
-  // openDoubleQuote
-  [/(?:^|[\s"'(<[{\u2018\u201C])(")$/, '“'],
-  // closeDoubleQuote
-  [/"$/, '”'],
-  // openSingleQuote
-  [/(?:^|[\s"'(<[{\u2018\u201C])(')$/, '‘'],
-  // closeSingleQuote
-  [/'$/, '’'],
   // leftArrow
   [/<-$/, '←'],
   // rightArrow
@@ -35,8 +27,6 @@ const SHORTCUTS: Array<[RegExp, string]> = [
   [/<<$/, '«'],
   // raquo
   [/>>$/, '»'],
-  // multiplication
-  [/\d+\s?([*x])\s?\d+$/, '×'],
   // superscriptTwo
   [/\^2$/, '²'],
   // superscriptThree

--- a/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
+++ b/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
@@ -51,11 +51,10 @@ export class ShortcutsExtension extends PlainExtension<ShortcutsOptions> {
   }
 
   /**
-   * Manage input rules for emoticons.
+   * Manage input rules for keyboard shortcuts
    */
   createInputRules(): InputRule[] {
     return SHORTCUTS.map(([regexp, replace]) => {
-      // Replace emoticons
       return plainInputRule({
         regexp,
         transformMatch: () => replace,


### PR DESCRIPTION
### Description

Remirror's input rules currently don't handle capture groups directly.

TODO: These rules could be brought back if we add logic to inject the provided matches into the replacement string.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
