### PR TITLE
docs: add example of font size extension initial content using JSON

### DIFF
--- a/docs/extensions/font-size-extension.mdx
+++ b/docs/extensions/font-size-extension.mdx
@@ -31,6 +31,38 @@ The extension is provided by the `@remirror/extension-font-size` package. There 
 
 <Basic />
 
+### JSON Content
+
+Initial content can be provided as JSON instead of HTML.
+Here is how you would provide the size mark.
+
+```tsx
+import {FontSizeExtension} from 'remirror/extensions';
+import {useRemirror} from '@remirror/react';
+
+const {manager, state} = useRemirror({
+
+  extensions: () => [
+    new FontSizeExtension()
+  ],
+
+  content: {
+    type: 'doc',
+    content: [{ type: 'paragraph',
+                content: [{ type: 'text',
+                            text: 'Hello ',
+                            marks: [{ type: 'fontSize',
+                                      attrs: { size: '20pt' }}]
+                           }]
+              }]
+  }
+
+});
+```
+
+Make sure you include the size unit in the mark because it can throw an error without a unit.
+
+
 ## API
 
 - [FontSizeExtension](../api/extension-font-size)

--- a/docs/extensions/font-size-extension.mdx
+++ b/docs/extensions/font-size-extension.mdx
@@ -33,35 +33,30 @@ The extension is provided by the `@remirror/extension-font-size` package. There 
 
 ### JSON Content
 
-Initial content can be provided as JSON instead of HTML.
-Here is how you would provide the size mark.
+Initial content can be provided as JSON instead of HTML. Here is how you would provide the size mark.
 
 ```tsx
-import {FontSizeExtension} from 'remirror/extensions';
-import {useRemirror} from '@remirror/react';
+import { FontSizeExtension } from 'remirror/extensions';
+import { useRemirror } from '@remirror/react';
 
-const {manager, state} = useRemirror({
-
-  extensions: () => [
-    new FontSizeExtension()
-  ],
+const { manager, state } = useRemirror({
+  extensions: () => [new FontSizeExtension()],
 
   content: {
     type: 'doc',
-    content: [{ type: 'paragraph',
-                content: [{ type: 'text',
-                            text: 'Hello ',
-                            marks: [{ type: 'fontSize',
-                                      attrs: { size: '20pt' }}]
-                           }]
-              }]
-  }
-
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          { type: 'text', text: 'Hello ', marks: [{ type: 'fontSize', attrs: { size: '20pt' } }] },
+        ],
+      },
+    ],
+  },
 });
 ```
 
 Make sure you include the size unit in the mark because it can throw an error without a unit.
-
 
 ## API
 


### PR DESCRIPTION
### Description

Docs example to avoid font size bug

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

tests failed on my machine with:
RangeError: /Users/steve/Documents/oss/remirror/packages/remirror__react-components/src/icons/all.ts: Maximum call stack size exceeded

but since this PR is a doc change only, I'm going to ignore that as it's probably due to my M1/node version etc.


