### PR TITLE
chore: let renvoate to ignore y-prosemirror temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,10 @@
       {
         "groupName": "prosemirror packages",
         "matchPackagePatterns": [
-          ".*prosemirror.*"
+          "^@proprosemirror.*"
+        ],
+        "excludePackagePatterns": [
+          "y-prosemirror"
         ],
         "rangeStrategy": "bump",
         "stabilityDays": 0

--- a/package.json
+++ b/package.json
@@ -260,10 +260,8 @@
       {
         "groupName": "prosemirror packages",
         "matchPackagePatterns": [
-          "^@proprosemirror.*"
-        ],
-        "excludePackagePatterns": [
-          "y-prosemirror"
+          "@types/prosemirror.*",
+          "^prosemirror.*"
         ],
         "rangeStrategy": "bump",
         "stabilityDays": 0


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

The latest version of `y-prosemirror` seems to have some kind of ESM/CJS issues, which blocks #1396, so let me ignore it temporarily. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
