### PR TITLE
fix(extension-list): don't delete extra nodes when pressing enter

### DIFF
--- a/.changeset/stupid-windows-smoke.md
+++ b/.changeset/stupid-windows-smoke.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Fix an issue that causes the content below a list item is being deleted when deleting this list item by pressing Enter.

--- a/packages/remirror__extension-list/__tests__/list-keymap.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-keymap.spec.ts
@@ -161,6 +161,41 @@ describe('Enter', () => {
     editor.add(from).press('Enter');
     expect(editor.view.state.doc).toEqualProsemirrorNode(to);
   });
+
+  it('keeps the content below when deleting a list item', () => {
+    from = doc(
+      ul(
+        li(
+          p('Head'),
+          ul(
+            li(p('A1')), //
+            li(p('A2')), //
+            li(p('A3')), //
+            li(p('<cursor>')), //
+          ),
+          p('Tail'),
+        ),
+      ),
+    );
+    to = doc(
+      ul(
+        li(
+          p('Head'),
+          ul(
+            li(p('A1')), //
+            li(p('A2')), //
+            li(p('A3')), //
+          ),
+        ),
+        li(
+          p(''),
+          p('Tail'), //
+        ),
+      ),
+    );
+    editor.add(from).press('Enter');
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
 });
 
 describe('Tab and Shift-Tab', () => {

--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -139,9 +139,16 @@ export function splitListItem(
 
         wrap = wrap.append(Fragment.from(listItemType.createAndFill(null, content) || undefined));
 
+        const depthAfter =
+          $from.indexAfter(-1) < $from.node(-2).childCount
+            ? 1
+            : $from.indexAfter(-2) < $from.node(-3).childCount
+            ? 2
+            : 3;
+
         tr.replace(
           $from.before(keepItem ? undefined : -1),
-          $from.after(-3),
+          $from.after(-depthAfter),
           new Slice(wrap, keepItem ? 3 : 2, 2),
         );
         tr.setSelection(


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Fix an issue that causes the content below a list item is being deleted when deleting this list item by pressing Enter.



### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
https://user-images.githubusercontent.com/24715727/145380040-88d2e60f-6dda-4293-b04d-06d4827a146c.mp4
