### PR TITLE
feat: align left/right arrow style with other arrows

### DIFF
--- a/.changeset/sour-rockets-tan.md
+++ b/.changeset/sour-rockets-tan.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-shortcuts': patch
+---
+
+Align left/right arrow style with other arrows

--- a/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
+++ b/packages/remirror__extension-shortcuts/src/shortcuts-extension.ts
@@ -13,7 +13,7 @@ const SHORTCUTS: Array<[RegExp, string]> = [
   [/->$/, '→'],
   // left/right arrow
   // First "<-" gets replaced by left arrow; after typing ">", both get replaced by left/right arrow
-  [/←>$/, '⬌'],
+  [/←>$/, '↔'],
   // copyright
   [/\(c\)$/, '©'],
   // trademark


### PR DESCRIPTION
### Description

The shortcut used the 'LEFT RIGHT BLACK ARROW' (U+2B0C) whereas the left arrow and the right arrow are not the BLACK variant. For visual consistency, this commit changes the left/right arrow to the non-BLACK version 'LEFT RIGHT ARROW' (U+2194).

Raised by https://github.com/remirror/remirror/pull/1423#issuecomment-990765788

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![image](https://user-images.githubusercontent.com/9339055/145569410-db60764d-d746-43e2-87fb-3e3a29972440.png)
