### PR TITLE
fix(link): prevent text loss when drag and dropping text containing links

### DIFF
--- a/.changeset/pink-snails-behave.md
+++ b/.changeset/pink-snails-behave.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-link': patch
+---
+
+fix: prevent text loss when drag and dropping text containing links

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -384,8 +384,6 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
           href: getMatchString(url),
           auto: !isReplacement,
         }),
-        // Only replace the selection for non whitespace selections
-        replaceSelection: (replacedText) => !!replacedText.trim(),
       },
     ];
   }


### PR DESCRIPTION
### Description

Drag and dropping text containing links would loss the text _after_ the link

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

#### Before

https://user-images.githubusercontent.com/2003804/146214958-1c362b9a-42be-415c-a049-6f2a2f5f1f80.mov

#### After

https://user-images.githubusercontent.com/2003804/146215494-24dab1b2-2f62-4a3e-88fc-1b30ae416c27.mov



