### PR TITLE
fix(events): fix type of copy and paste event handlers

### DIFF
--- a/.changeset/fuzzy-tomatoes-help.md
+++ b/.changeset/fuzzy-tomatoes-help.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': patch
+---
+
+Fix types of copy and paste event handlers

--- a/packages/remirror__extension-events/src/events-extension.ts
+++ b/packages/remirror__extension-events/src/events-extension.ts
@@ -205,6 +205,8 @@ export type HoverEventHandler = (props: HoverEventHandlerProps) => boolean | und
     hover: { earlyReturnValue: true },
     contextmenu: { earlyReturnValue: true },
     scroll: { earlyReturnValue: true },
+    copy: { earlyReturnValue: true },
+    paste: { earlyReturnValue: true },
   },
   defaultPriority: ExtensionPriority.High,
 })

--- a/packages/remirror__extension-events/src/events-extension.ts
+++ b/packages/remirror__extension-events/src/events-extension.ts
@@ -54,14 +54,14 @@ export interface EventsOptions {
    *
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
-  copy?: Handler<ScrollEventHandler>;
+  copy?: Handler<ClipboardEventHandler>;
 
   /**
    * Listens to `paste` events on the editor.
    *
    * Return `true` to prevent any other prosemirror listeners from firing.
    */
-  paste?: Handler<ScrollEventHandler>;
+  paste?: Handler<ClipboardEventHandler>;
 
   /**
    * Listens for mousedown events on the editor.
@@ -152,6 +152,7 @@ export interface EventsOptions {
 
 export type FocusEventHandler = (event: FocusEvent) => boolean | undefined | void;
 export type ScrollEventHandler = (event: Event) => boolean | undefined | void;
+export type ClipboardEventHandler = (event: ClipboardEvent) => boolean | undefined | void;
 export type MouseEventHandler = (event: MouseEvent) => boolean | undefined | void;
 export type TextInputHandler = (props: {
   from: number;


### PR DESCRIPTION
### Description

Copy and paste events are clipboard events, not scroll events.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
