### PR TITLE
docs: fix typo in "command and helpers" documentation

### DIFF
--- a/docs/getting-started/commands-and-helpers.md
+++ b/docs/getting-started/commands-and-helpers.md
@@ -194,7 +194,7 @@ Here are a few useful helpers, but there are many more!
 
 ## Summing up
 
-Congratulations! You created a manager, rendered the editor UI, added a menu, and captured the document for persistancy.
+Congratulations! You created a manager, rendered the editor UI, added a menu, and captured the document for persistency.
 
 With that, you've all the basic tools to start [exploring Remirror](https://remirror.vercel.app).
 


### PR DESCRIPTION
### Description

Fixes a typo.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- ~[ ] My code follows the code style of this project and `pnpm fix` completed successfully.~ (doc typo)
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`. (no new code)
