### PR TITLE
fix: use the `firstUpdate` local variable

### DIFF
--- a/packages/remirror__core/src/manager/remirror-manager.ts
+++ b/packages/remirror__core/src/manager/remirror-manager.ts
@@ -677,7 +677,7 @@ export class RemirrorManager<Extension extends AnyExtension> {
     this.#extensionStore.currentState = props.state;
     this.#extensionStore.previousState = props.previousState;
 
-    if (this.#firstStateUpdate) {
+    if (firstUpdate) {
       this.#phase = ManagerPhase.Runtime;
       this.#firstStateUpdate = false;
     }


### PR DESCRIPTION
### Description

Accessing private members is ever so slightly slower, but more importantly when stepping
through this code it is very confusing to first see `firstUpdate` getting computed and then
completely ignored in the line below that.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`. (no "new" code)
