### PR TITLE
feat(extension-codemirror6): add `Backspace` keybinding to CodeMirrorExtension

### DIFF
--- a/.changeset/clean-weeks-draw.md
+++ b/.changeset/clean-weeks-draw.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-code-block': patch
+---
+
+Correct a document error about `CodeBlockExtension`'s option `toggleName`. Its default value should be `'paragraph'` instead of `undefined`.

--- a/.changeset/fifty-keys-cheat.md
+++ b/.changeset/fifty-keys-cheat.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-codemirror6': minor
+---
+
+Add a new keybinging `Backspace` to the `codeMirror` node.
+
+Add a new option `toggleName` to `CodeMirrorExtension`, which is the name of the node that the codeMirror block should toggle back and forth from when pressing `Backspace`.

--- a/.changeset/mean-lies-explode.md
+++ b/.changeset/mean-lies-explode.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-code-block': patch
+---
+
+Fix a potential issue that might cause invalid text selection when pressing `Backspace` instead a code block node.

--- a/packages/remirror__extension-code-block/src/code-block-extension.ts
+++ b/packages/remirror__extension-code-block/src/code-block-extension.ts
@@ -367,12 +367,12 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
       }
     } else if (start > 2) {
       // Jump to the previous node.
-      tr.setSelection(TextSelection.create(tr.doc, start - 2));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(start - 2), -1));
     } else {
       // There is no content before the codeBlock so simply create a new
       // block and jump into it.
       tr.insert(0, toggleNode.create());
-      tr.setSelection(TextSelection.create(tr.doc, 1));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(1), -1));
     }
 
     if (dispatch) {

--- a/packages/remirror__extension-code-block/src/code-block-extension.ts
+++ b/packages/remirror__extension-code-block/src/code-block-extension.ts
@@ -367,12 +367,12 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
       }
     } else if (start > 2) {
       // Jump to the previous node.
-      tr.setSelection(TextSelection.near(tr.doc.resolve(start - 2), -1));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(start - 2)));
     } else {
       // There is no content before the codeBlock so simply create a new
       // block and jump into it.
       tr.insert(0, toggleNode.create());
-      tr.setSelection(TextSelection.near(tr.doc.resolve(1), -1));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(1)));
     }
 
     if (dispatch) {

--- a/packages/remirror__extension-code-block/src/code-block-types.ts
+++ b/packages/remirror__extension-code-block/src/code-block-types.ts
@@ -1,5 +1,5 @@
 import type { RefractorSyntax } from 'refractor/core';
-import type { AcceptUndefined, ProsemirrorAttributes, Static, StringKey } from '@remirror/core';
+import type { ProsemirrorAttributes, Static, StringKey } from '@remirror/core';
 import { ExtensionCodeBlockTheme } from '@remirror/theme';
 
 /**
@@ -82,11 +82,9 @@ export interface CodeBlockOptions {
   /**
    * The name of the node that the code block should toggle back and forth from.
    *
-   * Leave `undefined` to use the `defaultBlockNode` for the editor.
-   *
-   * @default undefined
+   * @default 'paragraph'
    */
-  toggleName?: AcceptUndefined<string>;
+  toggleName?: string;
 
   /**
    * Class to use in decorations of plain `text` nodes.

--- a/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
@@ -1,8 +1,10 @@
 import type { LanguageDescription, LanguageSupport } from '@codemirror/language';
 import {
   ApplySchemaAttributes,
+  assertGet,
   EditorView,
   extension,
+  findParentNodeOfType,
   GetAttributes,
   InputRule,
   isElementDomNode,
@@ -16,6 +18,8 @@ import {
   NodeViewMethod,
   PrioritizedKeyBindings,
   ProsemirrorNode,
+  removeNodeAtPosition,
+  replaceNodeAtPosition,
 } from '@remirror/core';
 import { TextSelection } from '@remirror/pm/state';
 
@@ -27,6 +31,7 @@ import { arrowHandler } from './codemirror-utils';
   defaultOptions: {
     extensions: null,
     languages: null,
+    toggleName: 'paragraph',
   },
 })
 export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOptions> {
@@ -106,6 +111,48 @@ export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOption
         getAttributes: getAttributes,
       }),
     ];
+  }
+
+  @keyBinding({ shortcut: 'Backspace' })
+  backspaceKey({ dispatch, tr, state }: KeyBindingProps): boolean {
+    // If the selection is not empty, return false and let other extension
+    // (ie: BaseKeymapExtension) to do the deleting operation.
+    if (!tr.selection.empty) {
+      return false;
+    }
+
+    // Check that this is the correct node.
+    const parent = findParentNodeOfType({ types: this.type, selection: tr.selection });
+
+    if (parent?.start !== tr.selection.from) {
+      return false;
+    }
+
+    const { pos, node, start } = parent;
+    const toggleNode = assertGet(state.schema.nodes, this.options.toggleName);
+
+    if (node.textContent.trim() === '') {
+      // eslint-disable-next-line unicorn/consistent-destructuring
+      if (tr.doc.lastChild === node && tr.doc.firstChild === node) {
+        replaceNodeAtPosition({ pos, tr, content: toggleNode.create() });
+      } else {
+        removeNodeAtPosition({ pos, tr });
+      }
+    } else if (start > 2) {
+      // Jump to the previous node.
+      tr.setSelection(TextSelection.near(tr.doc.resolve(start - 2), -1));
+    } else {
+      // There is no content before the codeBlock so simply create a new
+      // block and jump into it.
+      tr.insert(0, toggleNode.create());
+      tr.setSelection(TextSelection.near(tr.doc.resolve(1), -1));
+    }
+
+    if (dispatch) {
+      dispatch(tr);
+    }
+
+    return true;
   }
 
   @keyBinding({ shortcut: 'Enter' })

--- a/packages/remirror__extension-codemirror6/src/codemirror-node-view.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-node-view.ts
@@ -12,12 +12,7 @@ import {
   keymap,
 } from '@codemirror/view';
 import { isPromise } from '@remirror/core';
-import type {
-  EditorSchema,
-  EditorView as EditorView,
-  NodeView,
-  ProsemirrorNode,
-} from '@remirror/pm';
+import type { EditorSchema, EditorView, NodeView, ProsemirrorNode } from '@remirror/pm';
 import { exitCode } from '@remirror/pm/commands';
 import { Selection, TextSelection } from '@remirror/pm/state';
 

--- a/packages/remirror__extension-codemirror6/src/codemirror-types.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-types.ts
@@ -1,5 +1,6 @@
 import type { LanguageDescription } from '@codemirror/language';
 import { Extension as CodeMirrorExtension } from '@codemirror/state';
+import { AcceptUndefined } from '@remirror/core';
 
 export interface CodeMirrorExtensionOptions {
   /**
@@ -27,4 +28,11 @@ export interface CodeMirrorExtensionOptions {
    * @default null
    */
   languages?: LanguageDescription[] | null;
+
+  /**
+   * The name of the node that the codeMirror block should toggle back and forth from.
+   *
+   * @default "paragraph"
+   */
+  toggleName?: string;
 }

--- a/packages/remirror__extension-codemirror6/src/codemirror-types.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-types.ts
@@ -1,6 +1,5 @@
 import type { LanguageDescription } from '@codemirror/language';
 import { Extension as CodeMirrorExtension } from '@codemirror/state';
-import { AcceptUndefined } from '@remirror/core';
 
 export interface CodeMirrorExtensionOptions {
   /**

--- a/packages/storybook-react/stories/extension-codemirror6/basic.tsx
+++ b/packages/storybook-react/stories/extension-codemirror6/basic.tsx
@@ -1,13 +1,10 @@
-import { basicSetup } from '@codemirror/basic-setup';
 import { languages } from '@codemirror/language-data';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { ProsemirrorDevTools } from '@remirror/dev';
 import { CodeMirrorExtension } from '@remirror/extension-codemirror6';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-const extensions = () => [
-  new CodeMirrorExtension({ languages, extensions: [basicSetup, oneDark] }),
-];
+const extensions = () => [new CodeMirrorExtension({ languages, extensions: [oneDark] })];
 
 const jsCode = `function sayHello {
   console.log('Hello world, JavaScript!')

--- a/packages/storybook-react/stories/extension-codemirror6/codemirror6.stories.tsx
+++ b/packages/storybook-react/stories/extension-codemirror6/codemirror6.stories.tsx
@@ -1,3 +1,5 @@
+import './styles.css';
+
 import Basic from './basic';
 import WithCustomExtension from './with-custom-extension';
 

--- a/packages/storybook-react/stories/extension-codemirror6/styles.css
+++ b/packages/storybook-react/stories/extension-codemirror6/styles.css
@@ -1,0 +1,4 @@
+.cm-editor {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}

--- a/packages/storybook-react/stories/extension-codemirror6/with-custom-extension.tsx
+++ b/packages/storybook-react/stories/extension-codemirror6/with-custom-extension.tsx
@@ -1,4 +1,3 @@
-import { basicSetup } from '@codemirror/basic-setup';
 import { EditorView as CodeMirrorEditorView } from '@codemirror/view';
 import { CodeMirrorExtension } from '@remirror/extension-codemirror6';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
@@ -29,7 +28,7 @@ const myTheme = CodeMirrorEditorView.theme(
   { dark: false },
 );
 
-const extensions = () => [new CodeMirrorExtension({ extensions: [basicSetup, myTheme] })];
+const extensions = () => [new CodeMirrorExtension({ extensions: [myTheme] })];
 
 const content = `<pre><code>Custom CodeMirror color theme</code></pre>`;
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR mainly adds `Backspace` keybinding to `CodeMirrorExtension` as well as some other bug fixes. Check the changeset files for details.





### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/24715727/147765386-d6cde1bb-1e4d-438b-8bd4-dc06d3f4048a.mp4




<!-- Delete this section if not applicable -->
