### PR TITLE
fix(extension-list): fix the cursor position when pressing backspace

### DIFF
--- a/.changeset/wicked-trains-scream.md
+++ b/.changeset/wicked-trains-scream.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-list': patch
+---
+
+Fix a bug that causes the cursor to jump to the end of the first node when pressing backspace at the beginning of a list and this list is the second child of the document.
+

--- a/.changeset/wicked-trains-scream.md
+++ b/.changeset/wicked-trains-scream.md
@@ -3,4 +3,3 @@
 ---
 
 Fix a bug that causes the cursor to jump to the end of the first node when pressing backspace at the beginning of a list and this list is the second child of the document.
-

--- a/packages/remirror__extension-list/__tests__/list-keymap.spec.ts
+++ b/packages/remirror__extension-list/__tests__/list-keymap.spec.ts
@@ -1160,4 +1160,20 @@ describe('Backspace', () => {
     editor.add(from).press('Backspace');
     expect(editor.view.state.doc).toEqualProsemirrorNode(to);
   });
+
+  // This test case covers the issue from https://github.com/remirror/remirror/pull/1461
+  it('presses backspace before a list item when the list is the second child of the doc', () => {
+    from = doc(
+      p('text'),
+      ol(
+        li(p('<cursor>')), //
+      ),
+    );
+    editor.add(from).press('Backspace').insertText('!');
+    to = doc(
+      p('text'),
+      p('!'), //
+    );
+    expect(editor.view.state.doc).toEqualProsemirrorNode(to);
+  });
 });

--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -720,11 +720,16 @@ export function listBackspace({ view }: CommandFunctionProps): boolean {
       return false;
     }
 
+    // Handle the backspace key in a three-levels list correctly:
+    // * A
+    //   * <cursor>B
+    //     * C
     const itemIndex = $cursor.index(range.depth); // current node is the n-th node in item
     const listIndex = $cursor.index(range.depth - 1); // current item is the n-th item in list
-    const rootIndex = $cursor.index(range.depth - 2); // current list is the n-th list in root
+    const rootIndex = $cursor.index(range.depth - 2); // current list is the n-th list in its parent
+    const isNestedList = range.depth - 2 >= 1 && isListItemNode($cursor.node(range.depth - 2));
 
-    if (itemIndex === 0 && listIndex === 0 && rootIndex <= 1) {
+    if (itemIndex === 0 && listIndex === 0 && rootIndex <= 1 && isNestedList) {
       liftListItem(range.parent.type)(view.state, view.dispatch);
     }
   }


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Fix a cursor bug when pressing backspace before a list item. Check the screenshots below for details. 
 
### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->

Before this patch:



https://user-images.githubusercontent.com/24715727/148402939-4b61a0c2-2892-4258-88fc-c9c38afa8631.mp4



After this patch: 

https://user-images.githubusercontent.com/24715727/148403024-14e33b63-a0d3-4a5e-953f-b4b76c7141df.mp4


