### PR TITLE
feat(theme): avoid using Proxy to generate theme variables

### DIFF
--- a/.changeset/rude-foxes-drop.md
+++ b/.changeset/rude-foxes-drop.md
@@ -1,0 +1,22 @@
+---
+'@remirror/theme': minor
+'@remirror/extension-react-tables': patch
+'@remirror/extension-text-color': patch
+'storybook-react': patch
+---
+
+Deprecate `getTheme` and `getThemeProps` in favour of new methods `getThemeVar` and `getThemeVarName`.
+
+This removes a code path that used an ES6 Proxy, which cannot be polyfilled.
+
+```
+getTheme((t) => t.color.primary.text) => `var(--rmr-color-primary-text)`
+
+getThemeProps((t) => t.color.primary.text) => `--rmr-color-primary-text`
+```
+
+```
+getThemeVar('color', 'primary', 'text') => `var(--rmr-color-primary-text)`
+
+getThemeVarName('color', 'primary', 'text') => `--rmr-color-primary-text`
+```

--- a/packages/remirror__extension-react-tables/src/table-plugins.ts
+++ b/packages/remirror__extension-react-tables/src/table-plugins.ts
@@ -7,12 +7,12 @@ import {
 } from '@remirror/core';
 import { Plugin, PluginKey, Transaction } from '@remirror/pm/state';
 import { Decoration, DecorationSet } from '@remirror/pm/view';
-import { ExtensionTablesTheme, getTheme } from '@remirror/theme';
+import { ExtensionTablesTheme, getThemeVar } from '@remirror/theme';
 
 import { InsertButtonAttrs } from './components/table-insert-button';
 
-const preselectBorderColor = getTheme((t) => t.color.table.preselect.border);
-const preselectControllerBackgroundColor = getTheme((t) => t.color.table.preselect.controller);
+const preselectBorderColor = getThemeVar('color', 'table', 'preselect', 'border');
+const preselectControllerBackgroundColor = getThemeVar('color', 'table', 'preselect', 'controller');
 
 export function getTableStyle(attrs: ControllerStateValues): string {
   const preselectClass = css`

--- a/packages/remirror__extension-text-color/src/text-color-utils.ts
+++ b/packages/remirror__extension-text-color/src/text-color-utils.ts
@@ -1,7 +1,7 @@
 import { range } from '@remirror/core';
 import { I18n, MessageDescriptor } from '@remirror/i18n';
 import { ExtensionTextColorMessages as Messages } from '@remirror/messages';
-import { getTheme } from '@remirror/theme';
+import { getThemeVar } from '@remirror/theme';
 
 import {
   ColorPalette,
@@ -31,7 +31,7 @@ function createHuePalette(props: CreateHuePaletteProps): HuePalette {
   const label = t(labelDescriptor);
   const hues = hueRange.map((hue) => ({
     label: t(hueDescriptor, { hue }),
-    color: getTheme((theme) => theme.hue[name][hue]),
+    color: getThemeVar('hue', name, hue),
   })) as ColorWithLabelTuple;
 
   return { label, hues };

--- a/packages/remirror__theme/src/components-theme.ts
+++ b/packages/remirror__theme/src/components-theme.ts
@@ -1,24 +1,24 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
-const foreground = getTheme((t) => t.color.foreground);
-const text = getTheme((t) => t.color.text);
-const background = getTheme((t) => t.color.background);
-const backdrop = getTheme((t) => t.color.backdrop);
-const border = getTheme((t) => t.color.border);
-const shadow1 = getTheme((t) => t.color.shadow1);
-const borderHover = getTheme((t) => t.color.hover.border);
-const borderActive = getTheme((t) => t.color.active.border);
-const primary = getTheme((t) => t.color.primary);
-const primaryText = getTheme((t) => t.color.primaryText);
-const primaryHover = getTheme((t) => t.color.hover.primary);
-const primaryHoverText = getTheme((t) => t.color.hover.primaryText);
-const primaryActive = getTheme((t) => t.color.active.primary);
-const primaryActiveText = getTheme((t) => t.color.active.primaryText);
+const foreground = getThemeVar('color', 'foreground');
+const text = getThemeVar('color', 'text');
+const background = getThemeVar('color', 'background');
+const backdrop = getThemeVar('color', 'backdrop');
+const border = getThemeVar('color', 'border');
+const shadow1 = getThemeVar('color', 'shadow1');
+const borderHover = getThemeVar('color', 'hover', 'border');
+const borderActive = getThemeVar('color', 'active', 'border');
+const primary = getThemeVar('color', 'primary');
+const primaryText = getThemeVar('color', 'primaryText');
+const primaryHover = getThemeVar('color', 'hover', 'primary');
+const primaryHoverText = getThemeVar('color', 'hover', 'primaryText');
+const primaryActive = getThemeVar('color', 'active', 'primary');
+const primaryActiveText = getThemeVar('color', 'active', 'primaryText');
 
 export const EDITOR_WRAPPER = css`
-  padding-top: ${getTheme((t) => t.space[3])};
+  padding-top: ${getThemeVar('space', 3)};
 `;
 
 export const BUTTON_ACTIVE = css`
@@ -34,7 +34,7 @@ export const BUTTON = css`
   user-select: none;
   padding: 0.375em 0.75em;
   line-height: 1.5;
-  border-radius: ${getTheme((t) => t.radius.border)};
+  border-radius: ${getThemeVar('radius', 'border')};
   text-decoration: none;
   border: 1px solid ${border};
   cursor: pointer;
@@ -93,7 +93,7 @@ export const DIALOG = css`
   top: 28px;
   left: 50%;
   transform: translateX(-50%);
-  border-radius: ${getTheme((t) => t.radius.border)};
+  border-radius: ${getThemeVar('radius', 'border')};
   padding: 1em;
   max-height: calc(100vh - 56px);
   outline: 0;
@@ -142,7 +142,7 @@ export const FORM_GROUP = css`
   display: block;
   color: ${text};
   border: 1px solid ${border};
-  border-radius: ${getTheme((t) => t.radius.border)};
+  border-radius: ${getThemeVar('radius', 'border')};
   padding: 0.5rem 1rem 1rem;
   & > * {
     display: block;
@@ -176,15 +176,15 @@ export const GROUP = css`
 export const INPUT = css`
   display: block;
   width: 100%;
-  border-radius: ${getTheme((t) => t.radius.border)};
+  border-radius: ${getThemeVar('radius', 'border')};
   padding: 0.5em 0.75em;
   font-size: 100%;
-  border: 1px solid ${getTheme((t) => t.hue.gray[2])};
-  color: ${getTheme((t) => t.hue.gray[5])};
+  border: 1px solid ${getThemeVar('hue', 'gray', 2)};
+  color: ${getThemeVar('hue', 'gray', 5)};
   margin: 0 !important;
 
   &:focus {
-    border-color: ${getTheme((t) => t.hue.gray[3])};
+    border-color: ${getThemeVar('hue', 'gray', 3)};
   }
 `;
 
@@ -198,9 +198,9 @@ export const MENU_PANE = css`
   display: flex;
   justify-content: center;
   align-items: flex-start;
-  padding-top: ${getTheme((t) => t.space[1])};
-  padding-bottom: ${getTheme((t) => t.space[1])};
-  padding-right: ${getTheme((t) => t.space[2])};
+  padding-top: ${getThemeVar('space', 1)};
+  padding-bottom: ${getThemeVar('space', 1)};
+  padding-right: ${getThemeVar('space', 2)};
 `;
 
 export const MENU_PANE_ACTIVE = css`
@@ -209,19 +209,19 @@ export const MENU_PANE_ACTIVE = css`
 `;
 
 export const MENU_DROPDOWN_LABEL = css`
-  padding: 0 ${getTheme((t) => t.space[2])};
+  padding: 0 ${getThemeVar('space', 2)};
 `;
 
 export const MENU_PANE_ICON = css`
   position: absolute;
   left: 8px;
   width: 20px;
-  color: ${getTheme((t) => t.hue.gray[7])};
+  color: ${getThemeVar('hue', 'gray', 7)};
 
   button:hover &,
   button:active &,
   [aria-checked='true'] & {
-    color: ${getTheme((t) => t.hue.gray[1])};
+    color: ${getThemeVar('hue', 'gray', 1)};
   }
 `;
 
@@ -229,34 +229,34 @@ export const MENU_PANE_LABEL = css`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  padding-right: ${getTheme((t) => t.space[3])};
+  padding-right: ${getThemeVar('space', 3)};
 `;
 
 export const MENU_PANE_SHORTCUT = css`
   align-self: flex-end;
-  color: ${getTheme((t) => t.hue.gray[6])};
+  color: ${getThemeVar('hue', 'gray', 6)};
 
   button:hover &,
   button:active &,
   [aria-checked='true'] & {
-    color: ${getTheme((t) => t.hue.gray[1])};
+    color: ${getThemeVar('hue', 'gray', 1)};
   }
 `;
 
 export const MENU_BUTTON_LEFT = css`
   [role='menu'] > & {
-    left: ${getTheme((t) => t.space[2])};
+    left: ${getThemeVar('space', 2)};
   }
 ` as 'remirror-menu-button-left';
 export const MENU_BUTTON_RIGHT = css`
   [role='menu'] > & {
-    right: ${getTheme((t) => t.space[2])};
+    right: ${getThemeVar('space', 2)};
   }
 ` as 'remirror-menu-button-right';
 
 export const MENU_BUTTON_NESTED_LEFT = css`
   svg {
-    margin-right: ${getTheme((t) => t.space[2])};
+    margin-right: ${getThemeVar('space', 2)};
   }
 ` as 'remirror-menu-button-nested-left';
 
@@ -266,7 +266,7 @@ export const MENU_BUTTON_NESTED_RIGHT = css`
   }
 
   svg {
-    margin-left: ${getTheme((t) => t.space[2])};
+    margin-left: ${getThemeVar('space', 2)};
   }
 ` as 'remirror-menu-button-nested-right';
 
@@ -342,11 +342,11 @@ export const MENU_ITEM = css`
 `;
 
 export const MENU_ITEM_ROW = css`
-  padding: 0 ${getTheme((t) => t.space[2])};
+  padding: 0 ${getThemeVar('space', 2)};
 `;
 
 export const MENU_ITEM_COLUMN = css`
-  padding: 0 ${getTheme((t) => t.space[4])};
+  padding: 0 ${getThemeVar('space', 4)};
 `;
 
 export const MENU_ITEM_CHECKBOX = css`
@@ -388,7 +388,7 @@ export const MENU_GROUP = css`
 ` as 'remirror-menu-group';
 
 export const FLOATING_POPOVER = css`
-  /* padding: ${getTheme((t) => t.space[2])}; */
+  /* padding: ${getThemeVar('space', 2)}; */
   padding: 0;
   border: none;
   max-height: calc(100vh - 56px);
@@ -420,7 +420,7 @@ export const ANIMATED_POPOVER = css`
 export const ROLE = css`
   box-sizing: border-box;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  font-family: ${getTheme((t) => t.fontFamily.default)};
+  font-family: ${getThemeVar('fontFamily', 'default')};
   color: ${text};
   background-color: ${background};
   /* border: 1px solid ${border}; */
@@ -445,7 +445,7 @@ export const TAB = css`
   background-color: transparent;
   border: 1px solid transparent;
   border-width: 1px 1px 0 1px;
-  border-radius: ${getTheme((t) => t.radius.border)} ${getTheme((t) => t.radius.border)} 0 0;
+  border-radius: ${getThemeVar('radius', 'border')} ${getThemeVar('radius', 'border')} 0 0;
   font-size: 100%;
   padding: 0.5em 1em;
   margin: 0 0 -1px 0;
@@ -478,7 +478,7 @@ export const TABBABLE = css`
     /* transition: box-shadow 0.15s ease-in-out; */
     outline: 0;
     &:focus {
-      box-shadow: ${getTheme((t) => t.color.outline)} 0px 0px 0px 0.2em;
+      box-shadow: ${getThemeVar('color', 'outline')} 0px 0px 0px 0.2em;
       position: relative;
       z-index: 2;
     }
@@ -512,11 +512,11 @@ export const TOOLBAR = css`
 `;
 
 export const TOOLTIP = css`
-  background-color: ${getTheme((t) => t.color.faded)};
+  background-color: ${getThemeVar('color', 'faded')};
   color: white;
   font-size: 0.8em;
   padding: 0.5rem;
-  border-radius: ${getTheme((t) => t.radius.border)};
+  border-radius: ${getThemeVar('radius', 'border')};
   z-index: 999;
 
   [data-arrow] {
@@ -525,16 +525,16 @@ export const TOOLTIP = css`
       fill: transparent;
     }
     & .fill {
-      fill: ${getTheme((t) => t.hue.gray[8])};
+      fill: ${getThemeVar('hue', 'gray', 8)};
     }
   }
 `;
 
 export const TABLE_SIZE_EDITOR = css`
-  background: ${getTheme((t) => t.color.background)};
-  box-shadow: ${getTheme((t) => t.color.shadow1)};
-  font-family: ${getTheme((t) => t.fontFamily.default)};
-  font-size: ${getTheme((t) => t.fontSize[1])};
+  background: ${getThemeVar('color', 'background')};
+  box-shadow: ${getThemeVar('color', 'shadow1')};
+  font-family: ${getThemeVar('fontFamily', 'default')};
+  font-size: ${getThemeVar('fontSize', 1)};
 `;
 
 export const TABLE_SIZE_EDITOR_BODY = css`
@@ -552,27 +552,27 @@ export const TABLE_SIZE_EDITOR_BODY = css`
 `;
 
 export const TABLE_SIZE_EDITOR_CELL = css`
-  border: ${getTheme((t) => t.color.border)};
+  border: ${getThemeVar('color', 'border')};
   position: absolute;
   z-index: 2;
 `;
 
 export const TABLE_SIZE_EDITOR_CELL_SELECTED = css`
-  background: ${getTheme((t) => t.color.selection.background)};
-  border-color: ${getTheme((t) => t.color.border)};
+  background: ${getThemeVar('color', 'selection', 'background')};
+  border-color: ${getThemeVar('color', 'border')};
 `;
 
 export const TABLE_SIZE_EDITOR_FOOTER = css`
-  padding-bottom: ${getTheme((t) => t.space['1'])};
+  padding-bottom: ${getThemeVar('space', 1)};
   text-align: center;
 `;
 
 export const COLOR_PICKER = css`
-  background: ${getTheme((t) => t.color.background)};
-  box-shadow: ${getTheme((t) => t.boxShadow[1])};
-  font-family: ${getTheme((t) => t.fontFamily.default)};
-  font-size: ${getTheme((t) => t.fontSize[1])};
-  padding: ${getTheme((t) => t.space[2])} ${getTheme((t) => t.space[3])};
+  background: ${getThemeVar('color', 'background')};
+  box-shadow: ${getThemeVar('boxShadow', 1)};
+  font-family: ${getThemeVar('fontFamily', 'default')};
+  font-size: ${getThemeVar('fontSize', 1)};
+  padding: ${getThemeVar('space', 2)} ${getThemeVar('space', 3)};
 `;
 export const COLOR_PICKER_CELL = css``;
 export const COLOR_PICKER_CELL_SELECTED = css``;

--- a/packages/remirror__theme/src/core-theme.ts
+++ b/packages/remirror__theme/src/core-theme.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
 /**
  * This is compiled into the class name `remirror-editor` and the css is
@@ -39,10 +39,10 @@ export const EDITOR = css`
 
     ::selection,
     .selection {
-      background: ${getTheme((t) => t.color.selection.background)};
-      color: ${getTheme((t) => t.color.selection.text)};
-      caret-color: ${getTheme((t) => t.color.selection.caret)};
-      text-shadow: ${getTheme((t) => t.color.selection.shadow)};
+      background: ${getThemeVar('color', 'selection', 'background')};
+      color: ${getThemeVar('color', 'selection', 'text')};
+      caret-color: ${getThemeVar('color', 'selection', 'caret')};
+      text-shadow: ${getThemeVar('color', 'selection', 'shadow')};
     }
 
     /* Protect against generic img rules. See also https://github.com/ProseMirror/prosemirror-view/commit/aaa50d592074c8063fc2ef77907ab6d0373822fb */

--- a/packages/remirror__theme/src/extension-blockquote-theme.ts
+++ b/packages/remirror__theme/src/extension-blockquote-theme.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
 /**
  * This is compiled into the class name `remirror-editor` and the css is
@@ -10,7 +10,7 @@ import { getTheme } from './utils';
 export const EDITOR = css`
   &.ProseMirror {
     blockquote {
-      border-left: 3px solid ${getTheme((t) => t.hue.gray[3])};
+      border-left: 3px solid ${getThemeVar('hue', 'gray', 3)};
       margin-left: 0;
       margin-right: 0;
       padding-left: 10px;

--- a/packages/remirror__theme/src/extension-emoji-theme.ts
+++ b/packages/remirror__theme/src/extension-emoji-theme.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
 export const EMOJI_IMAGE = css`
   object-fit: contain;
@@ -24,11 +24,11 @@ export const EMOJI_POPUP_ITEM = css`
 `;
 
 export const EMOJI_POPUP_HOVERED = css`
-  background-color: ${getTheme((t) => t.hue.gray[2])};
+  background-color: ${getThemeVar('hue', 'gray', 2)};
 `;
 
 export const EMOJI_POPUP_HIGHLIGHT = css`
-  background-color: ${getTheme((t) => t.hue.gray[3])};
+  background-color: ${getThemeVar('hue', 'gray', 3)};
 `;
 
 export const EMOJI_POPUP_WRAPPER = css`

--- a/packages/remirror__theme/src/extension-list-theme.ts
+++ b/packages/remirror__theme/src/extension-list-theme.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
 export const LIST_ITEM_WITH_CUSTOM_MARKER = 'remirror-list-item-with-custom-mark';
 export const UL_LIST_CONTENT = 'remirror-ul-list-content';
@@ -44,7 +44,7 @@ export const COLLAPSIBLE_LIST_ITEM_CLOSED = css`
   }
 
   & .remirror-collapsible-list-item-button {
-    background-color: ${getTheme((t) => t.hue.gray[6])};
+    background-color: ${getThemeVar('hue', 'gray', 6)};
   }
 ` as 'remirror-collapsible-list-item-closed';
 
@@ -57,15 +57,15 @@ export const COLLAPSIBLE_LIST_ITEM_BUTTON = css`
   vertical-align: middle;
 
   transition: background-color 0.25s ease;
-  background-color: ${getTheme((t) => t.color.border)};
+  background-color: ${getThemeVar('color', 'border')};
 
   &:hover {
-    background-color: ${getTheme((t) => t.color.primary)};
+    background-color: ${getThemeVar('color', 'primary')};
   }
 
   &.disabled,
   &.disabled:hover {
-    background-color: ${getTheme((t) => t.color.border)};
+    background-color: ${getThemeVar('color', 'border')};
     cursor: default;
   }
 ` as 'remirror-collapsible-list-item-button';
@@ -79,11 +79,11 @@ export const LIST_SPINE = css`
   cursor: pointer;
 
   transition: border-left-color 0.25s ease;
-  border-left-color: ${getTheme((t) => t.color.border)};
+  border-left-color: ${getThemeVar('color', 'border')};
   border-left-style: solid;
   border-left-width: 1px;
 
   &:hover {
-    border-left-color: ${getTheme((t) => t.color.primary)};
+    border-left-color: ${getThemeVar('color', 'primary')};
   }
 ` as 'remirror-list-spine';

--- a/packages/remirror__theme/src/extension-mention-atom-theme.ts
+++ b/packages/remirror__theme/src/extension-mention-atom-theme.ts
@@ -1,16 +1,16 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
 export const MENTION_ATOM = css`
-  background: ${getTheme((t) => t.hue.gray[2])};
+  background: ${getThemeVar('hue', 'gray', 2)};
   font-weight: bold;
   font-size: 0.9em;
   font-style: normal;
-  border-radius: ${getTheme((t) => t.radius.border)};
+  border-radius: ${getThemeVar('radius', 'border')};
   padding: 0.2rem 0.5rem;
   white-space: nowrap;
-  color: ${getTheme((t) => t.color.primary)};
+  color: ${getThemeVar('color', 'primary')};
 ` as 'remirror-mention-atom';
 
 export const SUGGEST_ATOM = css`
@@ -28,11 +28,11 @@ export const MENTION_ATOM_POPUP_ITEM = css`
 `;
 
 export const MENTION_ATOM_POPUP_HOVERED = css`
-  background-color: ${getTheme((t) => t.hue.gray[2])};
+  background-color: ${getThemeVar('hue', 'gray', 2)};
 `;
 
 export const MENTION_ATOM_POPUP_HIGHLIGHT = css`
-  background-color: ${getTheme((t) => t.hue.gray[3])};
+  background-color: ${getThemeVar('hue', 'gray', 3)};
 `;
 
 export const MENTION_ATOM_POPUP_WRAPPER = css`

--- a/packages/remirror__theme/src/extension-tables-theme.ts
+++ b/packages/remirror__theme/src/extension-tables-theme.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { getTheme } from './utils';
+import { getThemeVar } from './utils';
 
 const controllerSize = 12;
 const markRadius = 2;
@@ -31,7 +31,7 @@ export const EDITOR = css`
       position: relative;
       border-width: 1px;
       border-style: solid;
-      border-color: ${getTheme((t) => t.color.table.default.border)};
+      border-color: ${getThemeVar('color', 'table', 'default', 'border')};
     }
 
     .column-resize-handle {
@@ -41,7 +41,7 @@ export const EDITOR = css`
       bottom: 0;
       width: 4px;
       z-index: 40;
-      background-color: ${getTheme((t) => t.hue.blue[7])};
+      background-color: ${getThemeVar('hue', 'blue', 7)};
       pointer-events: none;
     }
 
@@ -67,8 +67,8 @@ export const EDITOR = css`
     */
     th.${SELECTED_CELL}, td.${SELECTED_CELL} {
       border-style: double;
-      border-color: ${getTheme((t) => t.color.table.selected.border)};
-      background-color: ${getTheme((t) => t.color.table.selected.cell)};
+      border-color: ${getThemeVar('color', 'table', 'selected', 'border')};
+      background-color: ${getThemeVar('color', 'table', 'selected', 'cell')};
     }
   }
 ` as 'remirror-editor';
@@ -125,7 +125,7 @@ const CSSSegements = (() => {
     height: 0px;
     border-radius: 50%;
     border-style: solid;
-    border-color: ${getTheme((t) => t.color.table.mark)};
+    border-color: ${getThemeVar('color', 'table', 'mark')};
     border-width: ${markRadius}px;
   `;
 
@@ -332,14 +332,14 @@ export const TABLE_TBODY_WITH_CONTROLLERS = css`
   /* Styles for default */
   & {
     th.${TABLE_CONTROLLER} {
-      background-color: ${getTheme((t) => t.color.table.default.controller)};
+      background-color: ${getThemeVar('color', 'table', 'default', 'controller')};
     }
   }
 
   /* Styles for selected */
   & {
     th.${SELECTED_CELL}.${TABLE_CONTROLLER} {
-      background-color: ${getTheme((t) => t.color.table.selected.controller)};
+      background-color: ${getThemeVar('color', 'table', 'selected', 'controller')};
     }
   }
 ` as 'remirror-table-tbody-with-controllers';
@@ -348,11 +348,11 @@ export const TABLE_SHOW_PREDELETE = css`
   /* Styles for predelete */
   & {
     th.${SELECTED_CELL}.${SELECTED_CELL}.${TABLE_CONTROLLER} {
-      background-color: ${getTheme((t) => t.color.table.predelete.controller)};
+      background-color: ${getThemeVar('color', 'table', 'predelete', 'controller')};
     }
     th.${SELECTED_CELL}.${SELECTED_CELL}, td.${SELECTED_CELL}.${SELECTED_CELL} {
-      border-color: ${getTheme((t) => t.color.table.predelete.border)};
-      background-color: ${getTheme((t) => t.color.table.predelete.cell)};
+      border-color: ${getThemeVar('color', 'table', 'predelete', 'border')};
+      background-color: ${getThemeVar('color', 'table', 'predelete', 'cell')};
     }
   }
 ` as 'remirror-table-show-predelete';

--- a/packages/remirror__theme/src/index.ts
+++ b/packages/remirror__theme/src/index.ts
@@ -22,4 +22,11 @@ export type {
   Hue,
   RemirrorThemeType,
 } from './utils';
-export { createThemeVariables, defaultRemirrorTheme, getTheme, getThemeProps } from './utils';
+export {
+  createThemeVariables,
+  defaultRemirrorTheme,
+  getTheme,
+  getThemeProps,
+  getThemeVar,
+  getThemeVarName,
+} from './utils';

--- a/packages/remirror__theme/src/theme.ts
+++ b/packages/remirror__theme/src/theme.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { createThemeVariables, defaultRemirrorTheme, getTheme } from './utils';
+import { createThemeVariables, defaultRemirrorTheme, getThemeVar } from './utils';
 
 /**
  * Create the theme variables from the provided theme.
@@ -21,9 +21,9 @@ export const THEME = css`
 
   ${createThemeVariables(defaultRemirrorTheme).css}
 
-  font-family: ${getTheme((t) => t.fontFamily.default)};
-  line-height: ${getTheme((t) => t.lineHeight.default)};
-  font-weight: ${getTheme((t) => t.fontWeight.default)};
+  font-family: ${getThemeVar('fontFamily', 'default')};
+  line-height: ${getThemeVar('lineHeight', 'default')};
+  font-weight: ${getThemeVar('fontWeight', 'default')};
 
   h1,
   h2,
@@ -31,46 +31,46 @@ export const THEME = css`
   h4,
   h5,
   h6 {
-    color: ${getTheme((t) => t.color.text)};
-    font-family: ${getTheme((t) => t.fontFamily.heading)};
-    line-height: ${getTheme((t) => t.lineHeight.heading)};
-    font-weight: ${getTheme((t) => t.fontWeight.heading)};
+    color: ${getThemeVar('color', 'text')};
+    font-family: ${getThemeVar('fontFamily', 'heading')};
+    line-height: ${getThemeVar('lineHeight', 'heading')};
+    font-weight: ${getThemeVar('fontWeight', 'heading')};
   }
 
   h1 {
-    font-size: ${getTheme((t) => t.fontSize[5])};
+    font-size: ${getThemeVar('fontSize', 5)};
   }
 
   h2 {
-    font-size: ${getTheme((t) => t.fontSize[4])};
+    font-size: ${getThemeVar('fontSize', 4)};
   }
 
   h3 {
-    font-size: ${getTheme((t) => t.fontSize[3])};
+    font-size: ${getThemeVar('fontSize', 3)};
   }
 
   h4 {
-    font-size: ${getTheme((t) => t.fontSize[2])};
+    font-size: ${getThemeVar('fontSize', 2)};
   }
 
   h5 {
-    font-size: ${getTheme((t) => t.fontSize[1])};
+    font-size: ${getThemeVar('fontSize', 1)};
   }
 
   h6 {
-    font-size: ${getTheme((t) => t.fontSize[0])};
+    font-size: ${getThemeVar('fontSize', 0)};
   }
 
   .ProseMirror {
-    min-height: ${getTheme((t) => t.space[6])};
-    box-shadow: ${getTheme((t) => t.color.border)} 0px 0px 0px 0.1em;
-    padding: ${getTheme((t) => t.space[3])};
-    border-radius: ${getTheme((t) => t.radius.border)};
+    min-height: ${getThemeVar('space', 6)};
+    box-shadow: ${getThemeVar('color', 'border')} 0px 0px 0px 0.1em;
+    padding: ${getThemeVar('space', 3)};
+    border-radius: ${getThemeVar('radius', 'border')};
     outline: none;
 
     &:active,
     &:focus {
-      box-shadow: ${getTheme((t) => t.color.outline)} 0px 0px 0px 0.2em;
+      box-shadow: ${getThemeVar('color', 'outline')} 0px 0px 0px 0.2em;
     }
 
     p,
@@ -83,7 +83,7 @@ export const THEME = css`
     h6,
     span {
       margin: 0;
-      /* margin-bottom: ${getTheme((t) => t.space[2])}; */
+      /* margin-bottom: ${getThemeVar('space', 2)}; */
     }
   }
 `;

--- a/packages/remirror__theme/src/utils.ts
+++ b/packages/remirror__theme/src/utils.ts
@@ -114,9 +114,43 @@ function keyCapturingProxy<Type extends object>(getter: (obj: Type) => string): 
  * import { getTheme } from '@remirror/theme';
  * getTheme((t) => t.color.primary.text) => `var(--rmr-color-primary-text)`
  * ```
+ *
+ * @deprecated use getThemeVar instead
  */
 export function getTheme(getter: (theme: DeepString<Remirror.Theme>) => string): string {
   return getVar(keyCapturingProxy(getter));
+}
+
+/**
+ * Get the theme custom property wrapped in a `var`.
+ *
+ * ```ts
+ * import { getThemeVar } from '@remirror/theme';
+ * getThemeVar('color', 'primary', 'text') => `var(--rmr-color-primary-text)`
+ * ```
+ */
+export function getThemeVar<TKey1 extends keyof Remirror.Theme>(t1: TKey1): string;
+
+export function getThemeVar<
+  TKey1 extends keyof Remirror.Theme,
+  TKey2 extends keyof Remirror.Theme[TKey1],
+>(t1: TKey1, t2: TKey2): string;
+
+export function getThemeVar<
+  TKey1 extends keyof Remirror.Theme,
+  TKey2 extends keyof Remirror.Theme[TKey1],
+  TKey3 extends keyof Remirror.Theme[TKey1][TKey2],
+>(t1: TKey1, t2: TKey2, t3: TKey3): string;
+
+export function getThemeVar<
+  TKey1 extends keyof Remirror.Theme,
+  TKey2 extends keyof Remirror.Theme[TKey1],
+  TKey3 extends keyof Remirror.Theme[TKey1][TKey2],
+  TKey4 extends keyof Remirror.Theme[TKey1][TKey2][TKey3],
+>(t1: TKey1, t2: TKey2, t3: TKey3, t4: TKey4): string;
+
+export function getThemeVar(...args: Array<string | number>): string {
+  return getVar(args.map((p) => p.toString()));
 }
 
 /**
@@ -126,10 +160,45 @@ export function getTheme(getter: (theme: DeepString<Remirror.Theme>) => string):
  * import {getThemeProps} from '@remirror/theme';
  * getThemeProps((t) => t.color.primary.text) => `--rmr-color-primary-text`
  * ```
+ *
+ * @deprecated use getThemeVarName instead
  */
 export function getThemeProps(getter: (theme: DeepString<Remirror.Theme>) => string): string {
   return getCustomPropertyName(keyCapturingProxy(getter));
 }
+
+/**
+ * Get the theme custom property wrapped in a `var`.
+ *
+ * ```ts
+ * import { getThemeVarName } from '@remirror/theme';
+ * getThemeVarName('color', 'primary', 'text') => `--rmr-color-primary-text`
+ * ```
+ */
+export function getThemeVarName<TKey1 extends keyof Remirror.Theme>(t1: TKey1): string;
+
+export function getThemeVarName<
+  TKey1 extends keyof Remirror.Theme,
+  TKey2 extends keyof Remirror.Theme[TKey1],
+>(t1: TKey1, t2: TKey2): string;
+
+export function getThemeVarName<
+  TKey1 extends keyof Remirror.Theme,
+  TKey2 extends keyof Remirror.Theme[TKey1],
+  TKey3 extends keyof Remirror.Theme[TKey1][TKey2],
+>(t1: TKey1, t2: TKey2, t3: TKey3): string;
+
+export function getThemeVarName<
+  TKey1 extends keyof Remirror.Theme,
+  TKey2 extends keyof Remirror.Theme[TKey1],
+  TKey3 extends keyof Remirror.Theme[TKey1][TKey2],
+  TKey4 extends keyof Remirror.Theme[TKey1][TKey2][TKey3],
+>(t1: TKey1, t2: TKey2, t3: TKey3, t4: TKey4): string;
+
+export function getThemeVarName(...args: Array<string | number>): string {
+  return getCustomPropertyName(args.map((p) => p.toString()));
+}
+
 // defaultRemirrorThemeHue is copied from https://github.com/yeun/open-color/blob/v1.7.0/open-color.json
 const defaultRemirrorThemeHue: Remirror.ThemeHue = {
   gray: [

--- a/packages/storybook-react/stories/react-editors/markdown-editor.stories.tsx
+++ b/packages/storybook-react/stories/react-editors/markdown-editor.stories.tsx
@@ -5,7 +5,7 @@ import { createContextState } from 'create-context-state';
 import jsx from 'refractor/lang/jsx';
 import md from 'refractor/lang/markdown';
 import typescript from 'refractor/lang/typescript';
-import { ExtensionPriority, getTheme } from 'remirror';
+import { ExtensionPriority, getThemeVar } from 'remirror';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -107,7 +107,7 @@ const MarkdownTextEditor = () => {
 
             pre {
               height: 100%;
-              padding: ${getTheme((t) => t.space[3])};
+              padding: ${getThemeVar('space', 3)};
               margin: 0;
             }
           }
@@ -137,14 +137,14 @@ const VisualEditor = () => {
             p,
             h3,
             h4 {
-              margin-top: ${getTheme((t) => t.space[2])};
-              margin-bottom: ${getTheme((t) => t.space[2])};
+              margin-top: ${getThemeVar('space', 2)};
+              margin-bottom: ${getThemeVar('space', 2)};
             }
 
             h1,
             h2 {
-              margin-bottom: ${getTheme((t) => t.space[3])};
-              margin-top: ${getTheme((t) => t.space[3])};
+              margin-bottom: ${getThemeVar('space', 3)};
+              margin-top: ${getThemeVar('space', 3)};
             }
           }
         `,


### PR DESCRIPTION
### Description

`Proxy` cannot be (completely) polyfilled - meaning Remirror cannot be used on IE11, even with polyfills applied.

Whilst Remirror does not support IE11, I think we should not be actively blocking its usage.

### Notes

This PR deprecates `getTheme` and `getThemeProps` in favour of `getThemeVar` and `getThemeVarName` that avoid using a Proxy, whilst preserving Typescript hints.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
