### PR TITLE
docs: include the note that the `history` extension conflicts with `yjs`

### DIFF
--- a/docs/extensions/yjs-extension.mdx
+++ b/docs/extensions/yjs-extension.mdx
@@ -23,9 +23,16 @@ You can use the imports in the following way.
 import { YjsExtension } from 'remirror/extensions';
 ```
 
-To install it directly you can use
+The `yjs` extension provides support for "undo"/"redo" commands, which conflicts with the default `history` extension. You should therefore disable the `history` extension when using the `yjs` extension in the core preset configuration:
 
-The extension is provided by the `@remirror/extension-yjs` package. There are two ways of pulling it into your project.
+```ts
+const { manager } = useRemirror({
+  extensions: () => [new YjsExtension({ getProvider })],
+  core: {
+    excludeExtensions: ['history'],
+  },
+});
+```
 
 ### Examples
 

--- a/packages/storybook-react/stories/extension-yjs/basic.tsx
+++ b/packages/storybook-react/stories/extension-yjs/basic.tsx
@@ -16,7 +16,7 @@ const extensions = () => [
 ];
 
 const Basic = (): JSX.Element => {
-  const { manager } = useRemirror({ extensions });
+  const { manager } = useRemirror({ extensions, core: { excludeExtensions: ['history'] } });
 
   return (
     <ThemeProvider>


### PR DESCRIPTION
### Description

The `yjs` and `history` extensions conflict, for example by both providing a `undo` command: In a yjs-enabled remirror instance with the `history` extension not excluded from the core preset the `undo` command will actually be provided the `history` extension, which isn't aware of the specific Yjs transactions -- and for instance will allow to "undo" the initial content of the editor.

This is mentioned in the JS docs for the `excludeExtensions` setting: https://github.com/remirror/remirror/blob/64593d99c3d88efe2b46a990b873e0ef107d01dd/packages/remirror__preset-core/src/core-preset.ts#L25-L26

This PR brings that important tidbit into a place that a user might actually see: The Yjs extension documentation :)

While there: Drop some weird half-sentences in the same document. I don't know where the writer wanted to go there, but the basic example seems to be good enough to show how to use the extension and get going.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] ~New code is unit tested and all current tests pass when running `pnpm test`.~ No new code.
