### PR TITLE
fix(extension-font-size): fix a runtime error when getting font size

### DIFF
--- a/.changeset/slimy-dolphins-peel.md
+++ b/.changeset/slimy-dolphins-peel.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-font-size': patch
+---
+
+Fix a runtime error when getting font size before the editor view is initialized.

--- a/packages/remirror__extension-font-size/src/font-size-extension.ts
+++ b/packages/remirror__extension-font-size/src/font-size-extension.ts
@@ -122,7 +122,7 @@ export class FontSizeExtension extends MarkExtension<FontSizeOptions> {
   private getFontSize(size: string) {
     const { unit, roundingMultiple, max, min } = this.options;
     const value = clamp({
-      value: round(convertPixelsToDomUnit(size, unit, this.store.view.dom), roundingMultiple),
+      value: round(convertPixelsToDomUnit(size, unit, this.store.view?.dom), roundingMultiple),
       max,
       min,
     });


### PR DESCRIPTION
### Description

Close #1455 

When the manager's phase is smaller than [ManagerPhase.EditorView](https://github.com/remirror/remirror/blob/862a0c8ec4e90c2108abe8c2f50cdcb562ffa713/packages/remirror__core-constants/src/core-constants.ts#L403), `this.store.view` is `undefined`.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
