### PR TITLE
fix: make HorizontalRule compatible with Shortcuts

### DIFF
--- a/.changeset/cool-olives-know.md
+++ b/.changeset/cool-olives-know.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-horizontal-rule': patch
+---
+
+fix: make HorizontalRule compatible with Shortcuts

--- a/packages/remirror__extension-horizontal-rule/src/horizontal-rule-extension.ts
+++ b/packages/remirror__extension-horizontal-rule/src/horizontal-rule-extension.ts
@@ -96,7 +96,9 @@ export class HorizontalRuleExtension extends NodeExtension<HorizontalRuleOptions
   createInputRules(): InputRule[] {
     return [
       nodeInputRule({
-        regexp: /^(?:---|___\s|\*\*\*\s)$/,
+        // Allow dash + hyphen to cater for ShortcutsExtension, which replaces first
+        // two hyphens with a dash, i.e. "---" becomes "<dash>-"
+        regexp: /^(?:---|—-|___\s|\*\*\*\s)$/,
         type: this.type,
         beforeDispatch: ({ tr }) => {
           // Update to using a text selection.


### PR DESCRIPTION
### Description

The ShortcutExtension picks up "--" and replaces it with a dash. This means that the HorizontalRuleExtension never sees "---" because it was already replaced to "<dash>-".

To avoid this, the HorizontalRuleExtension replaces now also "<dash>-".

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
