### PR TITLE
docs: include controls for adding/removing annotations in the yjs extension story

### DIFF
--- a/packages/storybook-react/stories/extension-yjs/basic.tsx
+++ b/packages/storybook-react/stories/extension-yjs/basic.tsx
@@ -3,7 +3,14 @@ import 'remirror/styles/all.css';
 import { AnnotationExtension, PlaceholderExtension, YjsExtension } from 'remirror/extensions';
 import { WebrtcProvider } from 'y-webrtc';
 import * as Y from 'yjs';
-import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+import {
+  Remirror,
+  ThemeProvider,
+  useCommands,
+  useCurrentSelection,
+  useHelpers,
+  useRemirror,
+} from '@remirror/react';
 
 const ydoc = new Y.Doc();
 // clients connected to the same room-name share document updates
@@ -15,12 +22,44 @@ const extensions = () => [
   new YjsExtension({ getProvider: () => provider }),
 ];
 
+const Menu = () => {
+  const { removeAnnotations, addAnnotation } = useCommands();
+  const { getAnnotationsAt, selectionHasAnnotation } = useHelpers();
+  const selection = useCurrentSelection();
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          addAnnotation({ id: `${Date.now()}` });
+          focus();
+        }}
+        disabled={selection.empty}
+      >
+        Add annotation
+      </button>
+      <button
+        onClick={() => {
+          const annotations = getAnnotationsAt(selection.from);
+          removeAnnotations(annotations.map(({ id }) => id));
+          focus();
+        }}
+        disabled={!selectionHasAnnotation()}
+      >
+        Remove annotation(s)
+      </button>
+    </>
+  );
+};
+
 const Basic = (): JSX.Element => {
   const { manager } = useRemirror({ extensions, core: { excludeExtensions: ['history'] } });
 
   return (
     <ThemeProvider>
-      <Remirror manager={manager} autoFocus autoRender='end' />
+      <Remirror manager={manager} autoFocus autoRender='end'>
+        <Menu />
+      </Remirror>
     </ThemeProvider>
   );
 };

--- a/packages/storybook-react/stories/extension-yjs/basic.tsx
+++ b/packages/storybook-react/stories/extension-yjs/basic.tsx
@@ -23,7 +23,7 @@ const extensions = () => [
 ];
 
 const Menu = () => {
-  const { removeAnnotations, addAnnotation } = useCommands();
+  const { removeAnnotations, addAnnotation, redrawAnnotations } = useCommands();
   const { getAnnotationsAt, selectionHasAnnotation } = useHelpers();
   const selection = useCurrentSelection();
 
@@ -47,6 +47,14 @@ const Menu = () => {
         disabled={!selectionHasAnnotation()}
       >
         Remove annotation(s)
+      </button>
+      <button
+        onClick={() => {
+          redrawAnnotations();
+          focus();
+        }}
+      >
+        Redraw annotation(s)
       </button>
     </>
   );


### PR DESCRIPTION
### Description

The yjs extension interacts with the annotations extension, and in fact was configured for the story -- but there were no controls exposed to show that.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
