### PR TITLE
fix: update annotations in Yjs transaction

### DIFF
--- a/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
+++ b/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
@@ -2,6 +2,7 @@ import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import type { AnnotationOptions } from '../';
 import { Annotation, AnnotationExtension } from '../';
+import { MapLikeAnnotationStore } from '../src/annotation-store';
 
 extensionValidityTest(AnnotationExtension);
 
@@ -534,10 +535,50 @@ describe('custom styling', () => {
   });
 });
 
+describe('custom store', () => {
+  it('should use the provided store', () => {
+    const myStore = new (class extends MapLikeAnnotationStore<Annotation> {
+      public get innerMap() {
+        return this.map;
+      }
+    })();
+    const options = {
+      getStore: () => myStore,
+    };
+    const {
+      add,
+      nodes: { p, doc },
+      commands,
+      helpers,
+    } = create(options);
+
+    add(doc(p('Hello <start>again<end> my friend')));
+
+    commands.addAnnotation({ id: 'an-id' });
+
+    expect(myStore.innerMap.size).toBe(1);
+    expect(myStore.innerMap.get('an-id')).toEqual({
+      id: 'an-id',
+      from: 7,
+      to: 12,
+    });
+
+    expect(helpers.getAnnotations()).toEqual([
+      {
+        id: 'an-id',
+        from: 7,
+        to: 12,
+        text: 'again',
+      },
+    ]);
+  });
+});
+
 describe('custom map like via getMap', () => {
   it('should use the provided map like object passed via `getMap`', () => {
     const myMap = new Map();
     const options = {
+      getStore: undefined,
       getMap: () => myMap,
     };
     const {
@@ -573,6 +614,7 @@ describe('custom positions', () => {
   it('should use the provided map like object passed via `getMap`', () => {
     const myMap = new Map();
     const options = {
+      getStore: undefined,
       getMap: () => myMap,
       transformPosition: (pos: number) => ({ pos, meta: { mock: 'data' } }),
       transformPositionBeforeRender: (obj: any) => obj.pos,

--- a/packages/remirror__extension-annotation/src/annotation-actions.ts
+++ b/packages/remirror__extension-annotation/src/annotation-actions.ts
@@ -1,4 +1,4 @@
-import type { Annotation, GetData, OmitText } from './annotation-types';
+import type { Annotation, OmitText, OmitTextAndPosition } from './annotation-types';
 
 export enum ActionType {
   ADD_ANNOTATION,
@@ -12,13 +12,13 @@ export interface AddAnnotationAction<Type extends Annotation> {
   type: ActionType.ADD_ANNOTATION;
   from: number;
   to: number;
-  annotationData: GetData<Type>;
+  annotationData: OmitTextAndPosition<Type>;
 }
 
 export interface UpdateAnnotationAction<Type extends Annotation> {
   type: ActionType.UPDATE_ANNOTATION;
   annotationId: string;
-  annotationData: GetData<Type>;
+  annotationData: OmitTextAndPosition<Type>;
 }
 
 export interface RemoveAnnotationsAction {

--- a/packages/remirror__extension-annotation/src/annotation-store.ts
+++ b/packages/remirror__extension-annotation/src/annotation-store.ts
@@ -1,0 +1,85 @@
+import { assert } from '@remirror/core';
+
+import { Annotation } from '.';
+import {
+  AnnotationStore,
+  MapLike,
+  OmitText,
+  OmitTextAndPosition,
+  TransformedAnnotation,
+} from './annotation-types';
+
+export class MapLikeAnnotationStore<Type extends Annotation> implements AnnotationStore<Type> {
+  /**
+   * @param map a custom map-like object for storing internal annotations
+   */
+  constructor(
+    protected readonly map: MapLike<string, TransformedAnnotation<OmitText<Type>>> = new Map(),
+    private readonly positionToStored: (pos: number) => any = (pos) => pos,
+    private readonly positionFromStored: (storedPos: any) => number | null = (storedPos) =>
+      storedPos,
+  ) {}
+
+  addAnnotation({ from, to, ...annotation }: OmitText<Type>): void {
+    // XXX: Review cast
+    const storedAnnotation: TransformedAnnotation<OmitText<Type>> = {
+      from: this.positionToStored(from),
+      to: this.positionToStored(to),
+      ...annotation,
+    } as TransformedAnnotation<OmitText<Type>>;
+    this.map.set(annotation.id, storedAnnotation);
+  }
+
+  updateAnnotation(id: string, data: OmitTextAndPosition<Type>): void {
+    const existing = this.map.get(id);
+    assert(existing);
+
+    this.map.set(id, {
+      ...existing,
+      ...data,
+    });
+  }
+
+  removeAnnotations(ids: string[]): void {
+    ids.forEach((id) => {
+      this.map.delete(id);
+    });
+  }
+
+  setAnnotations(annotations: Array<OmitText<Type>>): void {
+    // `clear` is optional for historic reasons: Older versions of the Yjs maps
+    // didn't provide it.
+    if (typeof this.map.clear === 'function') {
+      this.map.clear();
+    } else {
+      this.map.forEach((annotation) => this.map.delete(annotation.id));
+    }
+
+    annotations.forEach((annotation) => {
+      this.addAnnotation(annotation);
+    });
+  }
+
+  formatAnnotations(): Array<OmitText<Type>> {
+    const annotations: Array<OmitText<Type>> = [];
+
+    this.map.forEach(({ from: storedFrom, to: storedTo, ...storedData }) => {
+      const from = this.positionFromStored(storedFrom);
+      const to = this.positionFromStored(storedTo);
+
+      if (!from || !to) {
+        return;
+      }
+
+      // XXX: Review cast
+      const annotation: OmitText<Type> = {
+        from,
+        to,
+        ...storedData,
+      } as unknown as OmitText<Type>;
+      annotations.push(annotation);
+    });
+
+    return annotations;
+  }
+}

--- a/packages/remirror__extension-annotation/src/annotation-types.ts
+++ b/packages/remirror__extension-annotation/src/annotation-types.ts
@@ -1,9 +1,5 @@
 import type { AcceptUndefined } from '@remirror/core';
 
-export type GetStyle<Type extends Annotation> = (
-  annotations: Array<OmitText<Type>>,
-) => string | undefined;
-
 export interface MapLike<K extends string, V> {
   clear?: () => void;
   delete: (key: K) => any;
@@ -12,63 +8,6 @@ export interface MapLike<K extends string, V> {
   has: (key: K) => boolean;
   set: (key: K, value: V) => any;
   readonly size: number;
-}
-
-export interface AnnotationOptions<Type extends Annotation = Annotation> {
-  /**
-   * Method to calculate styles for a segment with one or more annotations
-   *
-   * @remarks
-   *
-   * This can be used e.g. to assign different shades of a color depending on
-   * the amount of annotations in a segment.
-   */
-  getStyle?: GetStyle<Type>;
-
-  /**
-   * Allows to format the text returned for each annotation.
-   *
-   * When `blockSeparator` is given, it will be inserted whenever a new
-   * block node is started.
-   *
-   * @see ProsemirrorNode.textBetween
-   */
-  blockSeparator?: AcceptUndefined<string>;
-
-  /**
-   * Allows a custom map-like object for storing internal annotations
-   *
-   * @remarks
-   *
-   * This can be used to pass something like a Yjs Y.Map for shared annotations
-   */
-  getMap?: () => MapLike<string, TransformedAnnotation<Type>>;
-
-  /**
-   * Allows a custom transform function that modifies how positions are stored
-   * internally
-   *
-   * @remarks
-   *
-   * This can be used to transform positions to other representations, like a
-   * Yjs Relative Position
-   *
-   * @see AnnotationOptions.transformPositionBeforeRender
-   */
-  transformPosition?: (pos: number) => any;
-
-  /**
-   * Allows a custom transform function that modifies how internal positions
-   * representations are returned externally
-   *
-   * @remarks
-   *
-   * This can be used to transform positions from other representations, like a
-   * Yjs Relative Position to a ProseMirror integer (absolute) position
-   *
-   * @see AnnotationOptions.transformPosition
-   */
-  transformPositionBeforeRender?: (rpos: any) => number | null;
 }
 
 export interface Annotation {
@@ -101,7 +40,30 @@ export interface Annotation {
   className?: string;
 }
 
-export type TransformedAnnotation<T extends object> = T & {
+/**
+ * Remove the text field from an annotation.
+ */
+export type OmitText<Type extends Annotation> = Omit<Type, 'text'>;
+
+/**
+ * Get the data of the annotation without the fields managed by ProseMirror.
+ */
+export type OmitTextAndPosition<Type extends Annotation> = Omit<Type, 'text' | 'from' | 'to'>;
+
+export type GetStyle<Type extends Annotation> = (
+  annotations: Array<OmitText<Type>>,
+) => string | undefined;
+
+export interface AnnotationStore<Type extends Annotation> {
+  addAnnotation: (data: OmitText<Type>) => void;
+  updateAnnotation: (id: string, updateData: OmitTextAndPosition<Type>) => void;
+  removeAnnotations: (ids: string[]) => void;
+
+  setAnnotations: (annotations: Array<OmitText<Type>>) => void;
+  formatAnnotations: () => Array<OmitText<Type>>;
+}
+
+export type TransformedAnnotation<T extends object> = Omit<T, 'from' | 'to'> & {
   /**
    * Document transformed position where the annotation starts.
    */
@@ -114,11 +76,74 @@ export type TransformedAnnotation<T extends object> = T & {
 };
 
 /**
- * Remove the text field from an annotation.
+ * Options related to configuring another {@link MapLike} structure to store annotations.
+ *
+ * @deprecated
  */
-export type OmitText<Type extends Annotation> = Omit<Type, 'text'>;
+interface ExternalMapOptions<Type extends Annotation> {
+  /**
+   * Allows a custom map-like object for storing internal annotations
+   *
+   * @remarks
+   *
+   * This can be used to pass something like a Yjs Y.Map for shared annotations
+   */
+  // NOTE: Historically this was a MapList<string, TransformedAnnotation<Type>>
+  //       even though the input always was a OmitText<Type>. This was missed
+  //       due to hard casts and JS being nice enough to not care.
+  getMap?: () => MapLike<string, TransformedAnnotation<OmitText<Type>>>;
 
-/**
- * Get the data of the annotation without the fields managed by ProseMirror.
- */
-export type GetData<Type extends Annotation> = Omit<OmitText<Type>, 'from' | 'to'>;
+  /**
+   * Allows a custom transform function that modifies how positions are stored
+   * internally
+   *
+   * @remarks
+   *
+   * This can be used to transform positions to other representations, like a
+   * Yjs Relative Position
+   *
+   * @see ExternalMapOptions.transformPositionBeforeRender
+   */
+  transformPosition?: (pos: number) => any;
+
+  /**
+   * Allows a custom transform function that modifies how internal positions
+   * representations are returned externally
+   *
+   * @remarks
+   *
+   * This can be used to transform positions from other representations, like a
+   * Yjs Relative Position to a ProseMirror integer (absolute) position
+   *
+   * @see ExternalMapOptions.transformPosition
+   */
+  transformPositionBeforeRender?: (rpos: any) => number | null;
+}
+
+/** Translate all options in T to use {@link AcceptUndefined} */
+type ObsoleteOptions<T> = { [K in keyof T]: AcceptUndefined<T[K]> };
+
+export interface AnnotationOptions<Type extends Annotation = Annotation>
+  extends ObsoleteOptions<ExternalMapOptions<Type>> {
+  /**
+   * Method to calculate styles for a segment with one or more annotations
+   *
+   * @remarks
+   *
+   * This can be used e.g. to assign different shades of a color depending on
+   * the amount of annotations in a segment.
+   */
+  getStyle?: GetStyle<Type>;
+
+  /**
+   * Allows to format the text returned for each annotation.
+   *
+   * When `blockSeparator` is given, it will be inserted whenever a new
+   * block node is started.
+   *
+   * @see ProsemirrorNode.textBetween
+   */
+  blockSeparator?: AcceptUndefined<string>;
+
+  getStore?: () => AnnotationStore<Type>;
+}

--- a/packages/remirror__extension-annotation/src/index.ts
+++ b/packages/remirror__extension-annotation/src/index.ts
@@ -1,3 +1,9 @@
 export { AnnotationExtension } from './annotation-extension';
 export { createCenteredAnnotationPositioner } from './annotation-positioners';
-export type { Annotation, AnnotationOptions } from './annotation-types';
+export type {
+  Annotation,
+  AnnotationOptions,
+  AnnotationStore,
+  OmitText,
+  OmitTextAndPosition,
+} from './annotation-types';

--- a/packages/remirror__extension-yjs/src/yjs-extension.ts
+++ b/packages/remirror__extension-yjs/src/yjs-extension.ts
@@ -18,7 +18,7 @@ import type {
   Transaction as YjsTransaction,
   XmlFragment as YXmlFragment,
 } from 'yjs';
-import { UndoManager } from 'yjs';
+import { transact, UndoManager } from 'yjs';
 import {
   AcceptUndefined,
   assert,
@@ -173,12 +173,16 @@ class YjsAnnotationStore<Type extends Annotation> implements AnnotationStore<Typ
   }
 
   removeAnnotations(ids: string[]): void {
-    ids.forEach((id) => this.map.delete(id));
+    transact(this.doc, () => {
+      ids.forEach((id) => this.map.delete(id));
+    });
   }
 
   setAnnotations(annotations: Array<OmitText<Type>>): void {
-    this.map.clear();
-    annotations.forEach((annotation) => this.addAnnotation(annotation));
+    transact(this.doc, () => {
+      this.map.clear();
+      annotations.forEach((annotation) => this.addAnnotation(annotation));
+    });
   }
 
   formatAnnotations(): Array<OmitText<Type>> {

--- a/packages/remirror__extension-yjs/src/yjs-extension.ts
+++ b/packages/remirror__extension-yjs/src/yjs-extension.ts
@@ -11,10 +11,17 @@ import {
   yUndoPlugin,
   yUndoPluginKey,
 } from 'y-prosemirror';
-import type { Doc, RelativePosition, Transaction as YjsTransaction } from 'yjs';
+import type {
+  Doc,
+  Map as YMap,
+  RelativePosition,
+  Transaction as YjsTransaction,
+  XmlFragment as YXmlFragment,
+} from 'yjs';
 import { UndoManager } from 'yjs';
 import {
   AcceptUndefined,
+  assert,
   command,
   convertCommand,
   Dispose,
@@ -36,7 +43,13 @@ import {
   Selection,
   Shape,
 } from '@remirror/core';
-import { AnnotationExtension } from '@remirror/extension-annotation';
+import {
+  Annotation,
+  AnnotationExtension,
+  AnnotationStore,
+  OmitText,
+  OmitTextAndPosition,
+} from '@remirror/extension-annotation';
 import { ExtensionHistoryMessages as Messages } from '@remirror/messages';
 
 export interface ColorDef {
@@ -111,6 +124,90 @@ export interface YjsOptions<Provider extends YjsRealtimeProvider = YjsRealtimePr
   trackedOrigins?: any[];
 }
 
+interface YjsAnnotationPosition {
+  from: RelativePosition;
+  to: RelativePosition;
+}
+
+/**
+ * Data stored for annotations inside the Y.Doc
+ *
+ * Note that these fields are part of the API, and changes may require handling
+ * older stored documents.
+ */
+type StoredType<Type extends Annotation> = OmitTextAndPosition<Type> & YjsAnnotationPosition;
+
+class YjsAnnotationStore<Type extends Annotation> implements AnnotationStore<Type> {
+  type: YXmlFragment;
+  map: YMap<StoredType<Type>>;
+
+  constructor(
+    private readonly doc: Doc,
+    pmName: string,
+    mapName: string,
+    private readonly getMapping: () => /* ProsemirrorMapping */ any,
+  ) {
+    this.type = doc.getXmlFragment(pmName);
+    this.map = doc.getMap(mapName);
+  }
+
+  addAnnotation({ from, to, ...data }: OmitText<Type>): void {
+    // XXX: Why is this cast needed?
+    const storedData: StoredType<Type> = {
+      ...data,
+      from: this.absolutePositionToRelativePosition(from),
+      to: this.absolutePositionToRelativePosition(to),
+    } as StoredType<Type>;
+    this.map.set(data.id, storedData);
+  }
+
+  updateAnnotation(id: string, updateData: OmitTextAndPosition<Type>): void {
+    const existing = this.map.get(id);
+    assert(existing);
+
+    this.map.set(id, {
+      ...updateData,
+      from: existing.from,
+      to: existing.to,
+    });
+  }
+
+  removeAnnotations(ids: string[]): void {
+    ids.forEach((id) => this.map.delete(id));
+  }
+
+  setAnnotations(annotations: Array<OmitText<Type>>): void {
+    this.map.clear();
+    annotations.forEach((annotation) => this.addAnnotation(annotation));
+  }
+
+  formatAnnotations(): Array<OmitText<Type>> {
+    const result: Array<OmitText<Type>> = [];
+    this.map.forEach(({ from: relFrom, to: relTo, ...data }) => {
+      const from = this.relativePositionToAbsolutePosition(relFrom);
+      const to = this.relativePositionToAbsolutePosition(relTo);
+
+      if (!from || !to) {
+        return;
+      }
+
+      // XXX: Why is this cast needed?
+      result.push({ ...data, from, to } as unknown as OmitText<Type>);
+    });
+    return result;
+  }
+
+  private absolutePositionToRelativePosition(pos: number): RelativePosition {
+    const mapping = this.getMapping();
+    return absolutePositionToRelativePosition(pos, this.type, mapping);
+  }
+
+  private relativePositionToAbsolutePosition(relPos: RelativePosition): number | null {
+    const mapping = this.getMapping();
+    return relativePositionToAbsolutePosition(this.doc, this.type, relPos, mapping);
+  }
+}
+
 /**
  * The YJS extension is the recommended extension for creating a collaborative
  * editor.
@@ -149,12 +246,22 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
     return (this._provider ??= getLazyValue(getProvider));
   }
 
+  getBinding(): { mapping: Map<any, any> } | undefined {
+    const state = this.store.getState();
+    const { binding } = ySyncPluginKey.getState(state);
+    return binding;
+  }
+
   onView(): Dispose | void {
     try {
+      const annotationStore = new YjsAnnotationStore(
+        this.provider.doc,
+        'prosemirror',
+        'annotations',
+        () => this.getBinding()?.mapping,
+      );
       this.store.manager.getExtension(AnnotationExtension).setOptions({
-        getMap: () => this.provider.doc.getMap('annotations'),
-        transformPosition: this.absolutePositionToRelativePosition.bind(this),
-        transformPositionBeforeRender: this.relativePositionToAbsolutePosition.bind(this),
+        getStore: () => annotationStore,
       });
 
       const handler = (_update: Uint8Array, _origin: any, _doc: Doc, yjsTr: YjsTransaction) => {
@@ -330,18 +437,6 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
   @keyBinding({ shortcut: NamedShortcut.Redo, command: 'yRedo' })
   redoShortcut(props: KeyBindingProps): boolean {
     return this.yRedo()(props);
-  }
-
-  private absolutePositionToRelativePosition(pos: number): RelativePosition {
-    const state = this.store.getState();
-    const { type, binding } = ySyncPluginKey.getState(state);
-    return absolutePositionToRelativePosition(pos, type, binding.mapping);
-  }
-
-  private relativePositionToAbsolutePosition(relPos: RelativePosition): number | null {
-    const state = this.store.getState();
-    const { type, binding } = ySyncPluginKey.getState(state);
-    return relativePositionToAbsolutePosition(this.provider.doc, type, relPos, binding.mapping);
   }
 }
 


### PR DESCRIPTION
### Description

Annotations with the Yjs extension enabled are stored in a Y.Map, which is "almost but not quite" a Map. But, apart from that, the pattern in which is should be used is quite different, and changes that
conceptually belong together should be executed inside a single transaction.

This PR has two parts:
1. Refactor how the annotation extension stores the annotations, and instead of exposing a "map + transform" interface expose a more flexible "store" interface.
2. Use that interface and implement `setAnnotations` and `removeAnnotations` for the yjs extension with a `Y.transact` wrapper

Note that I would have loved to kill the `getMap` part, because there shouldn't be any other user of this (it feels like a "escape hatch" purely intended for the Yjs extension), but semver-wise that would be problematic. So, the code does have backwards compatibility for it, but it will throw an AssertionError in non-production environments (`getStore` has a non-`undefined` default, and providing both `getStore` and `getMap` is not allowed)

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
