### PR TITLE
fix: don't extend annotation when the user types at the beginning

### DIFF
--- a/.changeset/ninety-kids-shave.md
+++ b/.changeset/ninety-kids-shave.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-annotation': patch
+---
+
+fix: don't extend annotation when the user types at the beginning

--- a/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
+++ b/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
@@ -248,6 +248,25 @@ describe('plugin#apply', () => {
     expect(helpers.getAnnotations()[0]?.text).toBe('HeADDEDllo');
   });
 
+  it("doesn't extend annotation when content is added at the beginning of an annotation", () => {
+    const {
+      add,
+      helpers,
+      nodes: { p, doc },
+      commands,
+    } = create();
+
+    add(doc(p('<start>Hello<end>')));
+    commands.addAnnotation({ id: '1' });
+
+    // Pre-condition
+    expect(helpers.getAnnotations()[0]?.text).toBe('Hello');
+
+    commands.insertText('ADDED', { from: 0 });
+
+    expect(helpers.getAnnotations()[0]?.text).toBe('Hello');
+  });
+
   it("doesn't extend annotation when content is added at the end of an annotation", () => {
     const {
       add,

--- a/packages/remirror__extension-annotation/src/annotation-plugin.ts
+++ b/packages/remirror__extension-annotation/src/annotation-plugin.ts
@@ -128,7 +128,9 @@ export class AnnotationState<Type extends Annotation = Annotation> {
       // if new text was added before the decoration
       .map((annotation) => ({
         ...annotation,
-        from: tr.mapping.map(annotation.from, -1),
+        // 1 indicates that the annotation isn't extended when the user types
+        // at the beginning of the annotation
+        from: tr.mapping.map(annotation.from, 1),
         // -1 indicates that the annotation isn't extended when the user types
         // at the end of the annotation
         to: tr.mapping.map(annotation.to, -1),


### PR DESCRIPTION
### Description

Typing at the beginning of annotation extends the annotation, instead of entering the text in front of the annotation. This is unexpected for users because the annotation doesn't extend when entering text at the end of the annotation.

Fixes https://github.com/remirror/remirror/issues/1493

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
