### PR TITLE
docs: improve the docs for initial JSON

### DIFF
--- a/docs/getting-started/create-manager.md
+++ b/docs/getting-started/create-manager.md
@@ -89,6 +89,20 @@ Hence, you want to persist Remirror's native JSON format, and load this in your 
 import { BoldExtension, CalloutExtension, ItalicExtension } from 'remirror/extensions';
 import { useRemirror } from '@remirror/react';
 
+const remirrorJsonFromStorage = {
+  type: 'doc',
+  content: [
+    { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Hello world' }] },
+    {
+      type: 'paragraph',
+      content: [
+        { type: 'text', text: 'Hello ' },
+        { type: 'text', marks: [{ type: 'italic' }], text: 'word' },
+      ],
+    },
+  ],
+};
+
 const { manager, state } = useRemirror({
   extensions: () => [
     new BoldExtension(),


### PR DESCRIPTION
### Description

Let's make it clear that `content` should accept a JSON object instead of a JSON string. 
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
