### PR TITLE
feat: allow to disable yjs undo/redo

### DIFF
--- a/.changeset/dry-jars-relax.md
+++ b/.changeset/dry-jars-relax.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-yjs': patch
+---
+
+Allow disabling the yjs undo functionality in the yjs extension

--- a/docs/extensions/yjs-extension.mdx
+++ b/docs/extensions/yjs-extension.mdx
@@ -23,7 +23,9 @@ You can use the imports in the following way:
 import { YjsExtension } from 'remirror/extensions';
 ```
 
-The `yjs` extension provides support for "undo"/"redo" commands, which conflicts with the default `history` extension. You should therefore disable the `history` extension when using the `yjs` extension in the core preset configuration:
+The `yjs` extension provides support for "undo"/"redo" commands, which conflicts with the default `history` extension. The `history` extension provides "undo"/"redo" for the changes done by the _current user_ only, while the `yjs` extension provides "undo"/"redo" on the level of the underlying yjs transactions, which covers changes by _all active users._ Note however that a `yjs` "undo" replaces the complete document, which prevents other extensions (such as the `annotations` extension) from tracking positions.
+
+You can select the `yjs` "undo"/"redo" implementation by disabling the `history` extension in the core preset configuration:
 
 ```ts
 const { manager } = useRemirror({
@@ -33,6 +35,16 @@ const { manager } = useRemirror({
   },
 });
 ```
+
+Alternatively you can also disable the "undo"/"redo" functionality of the `yjs` extension:
+
+```ts
+const { manager } = useRemirror({
+  extensions: () => [new YjsExtension({ getProvider, disableUndo: true })],
+});
+```
+
+_Note that using the `history` extension "undo"/"redo" requires [additional support from the `y-prosemirror` library](https://github.com/yjs/y-prosemirror/pull/91)._
 
 ### Examples
 

--- a/packages/remirror__extension-annotation/src/annotation-plugin.ts
+++ b/packages/remirror__extension-annotation/src/annotation-plugin.ts
@@ -102,8 +102,15 @@ export class AnnotationState<Type extends Annotation = Annotation> {
       this.annotations = this.formatAnnotations();
       this.decorationSet = this.createDecorations(tr, this.annotations);
     } else {
-      // Adjust annotation positions based on changes in the editor, e.g.
-      // if new text was added before the decoration
+      // Adjust cached annotation positions based on changes in the editor, e.g.
+      // if new text was added before the decoration.
+      //
+      // Note: If you see annotations getting removed here check the source of
+      // the transaction and whether it contains any unexpected steps. In particular
+      // 'replace' steps that modify the entire document range, such as the one
+      // used by the Yjs extension for supporting `undo`, can cause issues.
+      // Consider using the `disableUndo` option of the Yjs extension, if you are
+      // using both the Yjs and Annotations extensions.
       this.annotations = this.annotations
         .map((annotation) => ({
           ...annotation,
@@ -116,8 +123,6 @@ export class AnnotationState<Type extends Annotation = Annotation> {
         }))
         // Remove annotations for which all containing content was deleted
         .filter((annotation) => annotation.to !== annotation.from);
-      // Performance optimization: Adjust decoration positions based on changes
-      // in the editor, e.g. if new text was added before the decoration
       this.decorationSet = this.decorationSet.map(tr.mapping, tr.doc);
     }
 

--- a/packages/remirror__extension-yjs/__tests__/__snapshots__/yjs-extension.spec.ts.snap
+++ b/packages/remirror__extension-yjs/__tests__/__snapshots__/yjs-extension.spec.ts.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`configuration throws when updating undo-related options ({ disableUndo: true }) 1`] = `
+"A call to \`extension.setOptions\` was made with invalid keys.
+
+Invalid properties passed into the 'setOptions()' method: [\\"disableUndo\\"].
+
+For more information visit https://remirror.io/docs/errors#rmr0103"
+`;
+
 exports[`configuration throws when updating undo-related options ({ protectedNodes: Set(0) {} }) 1`] = `
 "A call to \`extension.setOptions\` was made with invalid keys.
 

--- a/packages/remirror__extension-yjs/__tests__/__snapshots__/yjs-extension.spec.ts.snap
+++ b/packages/remirror__extension-yjs/__tests__/__snapshots__/yjs-extension.spec.ts.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`configuration throws when updating undo-related options 1`] = `"Cannot change \\"protectedNodes\\" or \\"trackedOrigins\\" options"`;
+exports[`configuration throws when updating undo-related options ({ protectedNodes: Set(0) {} }) 1`] = `
+"A call to \`extension.setOptions\` was made with invalid keys.
+
+Invalid properties passed into the 'setOptions()' method: [\\"protectedNodes\\"].
+
+For more information visit https://remirror.io/docs/errors#rmr0103"
+`;
+
+exports[`configuration throws when updating undo-related options ({ trackedOrigins: [ [length]: 0 ] }) 1`] = `
+"A call to \`extension.setOptions\` was made with invalid keys.
+
+Invalid properties passed into the 'setOptions()' method: [\\"trackedOrigins\\"].
+
+For more information visit https://remirror.io/docs/errors#rmr0103"
+`;
 
 exports[`configuration throws without a provider 1`] = `
 "An error occurred within an extension. More details should be made available.

--- a/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
+++ b/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
@@ -53,17 +53,15 @@ describe('configuration', () => {
     expect(extension.options.destroyProvider).toHaveBeenCalledTimes(1);
   });
 
-  it('throws when updating undo-related options', () => {
-    const { manager } = create();
-    const extension = manager.getExtension(YjsExtension);
+  it.each([{ protectedNodes: new Set<string>() }, { trackedOrigins: [] }])(
+    'throws when updating undo-related options (%o)',
+    (option: any) => {
+      const { manager } = create();
+      const extension = manager.getExtension(YjsExtension);
 
-    const protectedNodes = new Set<string>();
-    const trackedOrigins: any[] = [];
-
-    expect(() =>
-      extension.setOptions({ protectedNodes, trackedOrigins }),
-    ).toThrowErrorMatchingSnapshot();
-  });
+      expect(() => extension.setOptions({ ...option })).toThrowErrorMatchingSnapshot();
+    },
+  );
 
   it('uses the same undo manager in each state', () => {
     const { manager } = create();

--- a/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
+++ b/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
@@ -53,7 +53,7 @@ describe('configuration', () => {
     expect(extension.options.destroyProvider).toHaveBeenCalledTimes(1);
   });
 
-  it.each([{ protectedNodes: new Set<string>() }, { trackedOrigins: [] }])(
+  it.each([{ protectedNodes: new Set<string>() }, { trackedOrigins: [] }, { disableUndo: true }])(
     'throws when updating undo-related options (%o)',
     (option: any) => {
       const { manager } = create();

--- a/packages/remirror__extension-yjs/src/yjs-extension.ts
+++ b/packages/remirror__extension-yjs/src/yjs-extension.ts
@@ -41,6 +41,7 @@ import {
   ProsemirrorPlugin,
   Selection,
   Shape,
+  Static,
 } from '@remirror/core';
 import {
   Annotation,
@@ -119,8 +120,8 @@ export interface YjsOptions<Provider extends YjsRealtimeProvider = YjsRealtimePr
    *
    * @default `new Set('paragraph')`
    */
-  protectedNodes?: Set<string>;
-  trackedOrigins?: any[];
+  protectedNodes?: Static<Set<string>>;
+  trackedOrigins?: Static<any[]>;
 }
 
 interface YjsAnnotationPosition {
@@ -235,6 +236,7 @@ class YjsAnnotationStore<Type extends Annotation> implements AnnotationStore<Typ
     trackedOrigins: [],
   },
   defaultPriority: ExtensionPriority.High,
+  staticKeys: ['protectedNodes', 'trackedOrigins'],
 })
 export class YjsExtension extends PlainExtension<YjsOptions> {
   get name() {
@@ -329,16 +331,7 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
       'getProvider',
       'getSelection',
       'syncPluginOptions',
-      'protectedNodes',
-      'trackedOrigins',
     ]);
-
-    if (changes.protectedNodes.changed || changes.trackedOrigins.changed) {
-      // Cannot change these, as we would need a new undo manager instance, and for that
-      // we would need to unregister the previous instance from the document to avoid
-      // memory leaks.
-      throw new Error(`Cannot change "protectedNodes" or "trackedOrigins" options`);
-    }
 
     if (changes.getProvider.changed) {
       this._provider = undefined;


### PR DESCRIPTION
### Description

The yjs extension provides a undo/redo implementation, which the docs suggest should be used instead of the default one provided in remirror (through the history extension). This suggestion is somewhat problematic, depending on the use case:
1. `yUndo` is using the Yjs `UndoManager`, which works on the level of the Yjs document, and as such actually collects also changes of other users. The manager is configured to watch transactions from the sync-plugin.
2. Even worse (IMHO) is that while the undo manager is able to track changes in a very fine-grained way ("character appeared over here"), the yjs extension applies any such changes by rendering the complete prosemirror document based on the Yjs document, and then simply replacing the document inside the editor with that. That makes the document change appear to be completely different to any other place that tracks positions, such as the annotation information.

In our environment we found that both of these behaviors are problematic: We need annotations, and from a user's point of view it is really odd to press your undo key, and see a change disappear from another currently active user. 

Unfortunately the fix for this is requiring multiple parts:
* remirror (this PR): Make it possible to disable the yjs extension `yUndo`/`yRedo` commands (and, as a side-effect, save the memory for the undo manager tracking changes)
* y-prosemirror (https://github.com/yjs/y-prosemirror/pull/91): Mark all transactions from the sync-plugin to be not included in the changes the history extension tracks for undo purposes

**Note**: I think it is fine to merge this change without https://github.com/yjs/y-prosemirror/pull/91, as disabling the UndoManager is already quite something. But, a note might be helpful in the docs that one needs a modified `y-prosemirror` library as well. In our case we actually have [that](https://github.com/Collaborne/y-prosemirror) anyways for historic reasons, *and* a [@remirror/extension-yjs fork](https://github.com/Collaborne/remirror-extension-yjs) using that library. While both of these are open-source, we do _NOT_ recommend to use them in your own projects though, as they receive fairly experimental changes whenever we need them. :)

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
