### PR TITLE
fix(styles): use the inherited text color if the selection is hidden

### DIFF
--- a/.changeset/neat-rockets-boil.md
+++ b/.changeset/neat-rockets-boil.md
@@ -1,0 +1,6 @@
+---
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Fix Ctrl+Click making the selected text invisible on Windows

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -630,12 +630,15 @@ button:active .remirror-menu-pane-shortcut,
 }
 .remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
+  color: inherit;
 }
 .remirror-editor.ProseMirror-hideselection *::selection {
   background: transparent;
+  color: inherit;
 }
 .remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
+  color: inherit;
 }
 .remirror-editor.ProseMirror-hideselection {
   caret-color: transparent;

--- a/packages/remirror__styles/core.css
+++ b/packages/remirror__styles/core.css
@@ -55,12 +55,15 @@
 }
 .remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
+  color: inherit;
 }
 .remirror-editor.ProseMirror-hideselection *::selection {
   background: transparent;
+  color: inherit;
 }
 .remirror-editor.ProseMirror-hideselection *::-moz-selection {
   background: transparent;
+  color: inherit;
 }
 .remirror-editor.ProseMirror-hideselection {
   caret-color: transparent;

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -641,12 +641,15 @@ export const coreStyledCss: ReturnType<typeof css> = css`
   }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection *::selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection {
     caret-color: transparent;

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -644,12 +644,15 @@ export const coreStyledCss: ReturnType<typeof css> = css`
   }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection *::selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection {
     caret-color: transparent;

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -643,12 +643,15 @@ export const coreStyledCss: ReturnType<typeof css> = css`
   }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection *::selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
   .remirror-editor.ProseMirror-hideselection {
     caret-color: transparent;

--- a/packages/remirror__theme/src/core-theme.ts
+++ b/packages/remirror__theme/src/core-theme.ts
@@ -55,10 +55,12 @@ export const EDITOR = css`
 
   &.ProseMirror-hideselection *::selection {
     background: transparent;
+    color: inherit;
   }
 
   &.ProseMirror-hideselection *::-moz-selection {
     background: transparent;
+    color: inherit;
   }
 
   &.ProseMirror-hideselection {


### PR DESCRIPTION
### Description

[Issue raised on Discord](https://discord.com/channels/726035064831344711/745695521305526302/940731226245984326) - On Windows, `Ctrl+Click` makes the text invisible.

![node-selection-Prosemirror-hideselection-class](https://user-images.githubusercontent.com/2003804/153183224-e8925aaf-92fc-4f36-8a59-407e37d04805.gif)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
