### PR TITLE
fix(prosemirror-paste-rules): fix the replace selection when selecting two characters

### DIFF
--- a/.changeset/tough-dingos-clap.md
+++ b/.changeset/tough-dingos-clap.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Fix an issue that causes the selected text being deleted when pasting.

--- a/.changeset/yellow-wolves-change.md
+++ b/.changeset/yellow-wolves-change.md
@@ -1,0 +1,5 @@
+---
+'jest-prosemirror': patch
+---
+
+Make the result more accurate when pasting plain text from the clipboard.

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -25,10 +25,14 @@ import {
   isTextDomNode,
 } from '@remirror/core-utils';
 import { inputRules } from '@remirror/pm/inputrules';
-import { DOMParser, Slice } from '@remirror/pm/model';
+import { Slice } from '@remirror/pm/model';
 import { AllSelection, NodeSelection, Selection, TextSelection } from '@remirror/pm/state';
 import { cellAround, CellSelection } from '@remirror/pm/tables';
-import { DirectEditorProps, EditorView } from '@remirror/pm/view';
+import {
+  __parseFromClipboard as parseFromClipboard,
+  DirectEditorProps,
+  EditorView,
+} from '@remirror/pm/view';
 
 import { createEvents, EventType } from './jest-prosemirror-events';
 import { createState, pm, selectionFor, taggedDocHasSelection } from './jest-prosemirror-nodes';
@@ -126,12 +130,13 @@ export function pasteContent<Schema extends EditorSchema = EditorSchema>(
   let slice: ProsemirrorNode[] | Slice | Slice[];
 
   if (isString(content)) {
-    const element = document.createElement('div');
-    element.innerHTML = content;
-    slice = DOMParser.fromSchema(view.state.schema).parseSlice(element, {
-      context: view.state.selection.$head,
-      preserveWhitespace: true,
-    });
+    const parsedSlice = parseFromClipboard(view, content, '', true, view.state.selection.$head);
+
+    if (!parsedSlice) {
+      throw new Error('No content to paste');
+    }
+
+    slice = parsedSlice;
   } else {
     const { from, to } =
       content.type.name === 'doc'

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -25,7 +25,7 @@ import {
   isTextDomNode,
 } from '@remirror/core-utils';
 import { inputRules } from '@remirror/pm/inputrules';
-import { Slice } from '@remirror/pm/model';
+import { DOMParser, Slice } from '@remirror/pm/model';
 import { AllSelection, NodeSelection, Selection, TextSelection } from '@remirror/pm/state';
 import { cellAround, CellSelection } from '@remirror/pm/tables';
 import {
@@ -144,11 +144,10 @@ export function pasteContent<Schema extends EditorSchema = EditorSchema>(
         : { from: 0, to: undefined };
 
     slice = content.slice(from, to);
+    view.someProp('transformPasted', (f) => {
+      slice = f(slice);
+    });
   }
-
-  view.someProp('transformPasted', (f) => {
-    slice = f(slice);
-  });
 
   view.dispatch(view.state.tr.replaceSelection(slice));
 }

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -25,7 +25,7 @@ import {
   isTextDomNode,
 } from '@remirror/core-utils';
 import { inputRules } from '@remirror/pm/inputrules';
-import { DOMParser, Slice } from '@remirror/pm/model';
+import { Slice } from '@remirror/pm/model';
 import { AllSelection, NodeSelection, Selection, TextSelection } from '@remirror/pm/state';
 import { cellAround, CellSelection } from '@remirror/pm/tables';
 import {

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -92,7 +92,7 @@ export function pasteRules(pasteRules: PasteRule[]): Plugin<void> {
                 }
               });
 
-              return new Slice(Fragment.fromArray(newTextNodes), slice.openStart, slice.openEnd);
+              return Slice.maxOpen(Fragment.fromArray(newTextNodes));
             }
           }
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Close #1538 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
