### PR TITLE
feat(extension-positioner): allow force update of positioners

### DIFF
--- a/.changeset/mean-jars-dress.md
+++ b/.changeset/mean-jars-dress.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-positioner': minor
+---
+
+Add the ability to force update positioners with a new command `forceUpdatePositioners`.
+
+This can be useful to update positioners when the view is updated in a way that doesn't trigger a ProseMirror state change. For instance when an image URL is loaded and the document is reflowed.

--- a/packages/remirror__extension-positioner/src/positioner-extension.ts
+++ b/packages/remirror__extension-positioner/src/positioner-extension.ts
@@ -1,5 +1,7 @@
 import {
   AddCustomHandler,
+  command,
+  CommandFunction,
   CustomHandler,
   debounce,
   EditorState,
@@ -33,7 +35,11 @@ import type {
   PositionerUpdateEvent,
   SetActiveElement,
 } from './positioner';
-import { POSITIONER_WIDGET_KEY } from './positioner-utils';
+import {
+  POSITIONER_UPDATE_ALL,
+  POSITIONER_UPDATE_KEY,
+  POSITIONER_WIDGET_KEY,
+} from './positioner-utils';
 
 export interface PositionerOptions {
   /**
@@ -150,6 +156,21 @@ export class PositionerExtension extends PlainExtension<PositionerOptions> {
       stopEvent: () => true,
     });
     return DecorationSet.create(state.doc, [decoration]);
+  }
+
+  /**
+   * Trigger an update of positioners manually. This can be useful to update positioners when
+   * the view is updated in a way that doesn't trigger a ProseMirror state change. For instance
+   * when an image URL is loaded and the document is reflowed.
+   *
+   * @param key - Allows filtering a specific type of positioner to update. Defaults to all.
+   */
+  @command()
+  forceUpdatePositioners(key = POSITIONER_UPDATE_ALL): CommandFunction {
+    return ({ tr, dispatch }) => {
+      dispatch?.(tr.setMeta(POSITIONER_UPDATE_KEY, { key }));
+      return true;
+    };
   }
 
   /**

--- a/packages/remirror__extension-positioner/src/positioner-utils.ts
+++ b/packages/remirror__extension-positioner/src/positioner-utils.ts
@@ -4,6 +4,7 @@ import {
   getStyle,
   hasTransactionChanged,
   isElementDomNode,
+  Transaction,
   TransactionProps,
   within,
 } from '@remirror/core';
@@ -12,6 +13,20 @@ export { isEmptyBlockNode } from '@remirror/core';
 
 interface HasChangedProps extends EditorStateProps, Partial<TransactionProps> {
   previousState: EditorState | undefined;
+}
+
+/**
+ * Checks if the given transaction force updates positioners.
+ *
+ * @param tr - the Transaction to check
+ * @param key - filter for a specific key. Defaults to all.
+ */
+export function isPositionerUpdateTransaction(
+  tr: Transaction,
+  key = POSITIONER_UPDATE_ALL,
+): boolean {
+  const { key: trKey } = tr?.getMeta(POSITIONER_UPDATE_KEY) ?? {};
+  return trKey === key;
 }
 
 /**
@@ -24,6 +39,10 @@ export function hasStateChanged(props: HasChangedProps): boolean {
   const { tr, state, previousState } = props;
 
   if (!previousState) {
+    return true;
+  }
+
+  if (tr && isPositionerUpdateTransaction(tr)) {
     return true;
   }
 
@@ -105,3 +124,7 @@ export function isPositionVisible(
 }
 
 export const POSITIONER_WIDGET_KEY = 'remirror-positioner-widget';
+
+export const POSITIONER_UPDATE_KEY = 'positionerUpdate';
+
+export const POSITIONER_UPDATE_ALL = '__all_positioners__';


### PR DESCRIPTION
### Description

Add the ability to force update positioners with a new command `forceUpdatePositioners`.

This can be useful to update positioners when the view is updated in a way that doesn't trigger a ProseMirror state change. For instance when an image URL is loaded and the document is reflowed.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
