### PR TITLE
fix(jest-remirror): add `default` filed in the `package.json`

### DIFF
--- a/.changeset/unlucky-waves-deliver.md
+++ b/.changeset/unlucky-waves-deliver.md
@@ -1,0 +1,5 @@
+---
+'jest-remirror': patch
+---
+
+Add `default` filed in the `package.json`.

--- a/packages/jest-remirror/package.json
+++ b/packages/jest-remirror/package.json
@@ -21,11 +21,13 @@
   "exports": {
     ".": {
       "require": "./dist/jest-remirror.cjs.js",
-      "types": "./dist/jest-remirror.cjs.d.ts"
+      "types": "./dist/jest-remirror.cjs.d.ts",
+      "default": "./dist/jest-remirror.cjs.js"
     },
     "./environment": {
       "require": "./environment/dist/jest-remirror-environment.cjs.js",
-      "types": "./environment/dist/jest-remirror-environment.cjs.d.ts"
+      "types": "./environment/dist/jest-remirror-environment.cjs.d.ts",
+      "default": "./environment/dist/jest-remirror-environment.cjs.js"
     },
     "./package.json": "./package.json",
     "./types/*": "./dist/declarations/src/*.d.ts"

--- a/packages/remirror__cli/package.json
+++ b/packages/remirror__cli/package.json
@@ -16,10 +16,12 @@
   "exports": {
     ".": {
       "require": "./dist/remirror-cli.cjs.js",
-      "types": "./dist/remirror-cli.cjs.d.ts"
+      "types": "./dist/remirror-cli.cjs.d.ts",
+      "default": "./dist/remirror-cli.cjs.js"
     },
     "./cli": {
-      "require": "./cli/dist/remirror-cli-cli.cjs.js"
+      "require": "./cli/dist/remirror-cli-cli.cjs.js",
+      "default": "./cli/dist/remirror-cli-cli.cjs.js"
     },
     "./package.json": "./package.json",
     "./types/*": "./dist/declarations/src/*.d.ts"

--- a/packages/storybook-react/package.json
+++ b/packages/storybook-react/package.json
@@ -11,11 +11,13 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/storybook-react.cjs.js"
+      "require": "./dist/storybook-react.cjs.js",
+      "default": "./dist/storybook-react.cjs.js"
     },
     "./package.json": "./package.json",
     "./storybook-react-main": {
-      "require": "./storybook-react-main/dist/storybook-react-storybook-react-main.cjs.js"
+      "require": "./storybook-react-main/dist/storybook-react-storybook-react-main.cjs.js",
+      "default": "./storybook-react-main/dist/storybook-react-storybook-react-main.cjs.js"
     },
     "./types/*": "./dist/declarations/src/*.d.ts"
   },

--- a/support/scripts/src/generate-configs.ts
+++ b/support/scripts/src/generate-configs.ts
@@ -222,7 +222,7 @@ function augmentExportsObject(rootJson: PackageJson, filepath: string, subJson: 
     // Experimental since this is not currently resolved by TypeScript.
     types: prefixRelativePath(subJson.types ? path.join(filepath, subJson.types) : undefined),
   };
-  field.default = field.import;
+  field.default = field.import || field.require;
 
   let exportsObject: Exports;
 


### PR DESCRIPTION
### Description


Make sure all conditional exports in `package.json` have a "default" field. 

<!-- Describe your changes in detail and reference any issues it addresses-->

> https://nodejs.org/docs/latest-v16.x/api/packages.html#conditional-exports
>
> When using environment branches, always include a "default" condition where possible. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
