### PR TITLE
feat: unicode regex in suggestion matching

### DIFF
--- a/.changeset/bright-beans-kiss.md
+++ b/.changeset/bright-beans-kiss.md
@@ -1,0 +1,9 @@
+---
+'prosemirror-suggest': minor
+---
+
+Add support for Unicode Regexp in suggestion matching.
+
+The change was required to support matching non-latin characters in `MentionAtomExtension` and `MentionExtension` i.e. by using `supportedCharacters: /\p{Letter}+/u` in `matchers` definition.
+
+There is no need to update the code: changes are backwards compatible with no behavior change at all.

--- a/packages/prosemirror-suggest/src/suggest-types.ts
+++ b/packages/prosemirror-suggest/src/suggest-types.ts
@@ -285,6 +285,13 @@ export interface Suggester<Schema extends EditorSchema = EditorSchema> {
   multiline?: boolean;
 
   /**
+   * When true support matches using Unicode Regex.
+   *
+   * @default false
+   */
+  unicode?: boolean;
+
+  /**
    * Whether to capture the `char character as the first capture group.
    *
    * When this is set to true it will be the first matching group with

--- a/packages/prosemirror-suggest/src/suggest-utils.ts
+++ b/packages/prosemirror-suggest/src/suggest-utils.ts
@@ -151,8 +151,16 @@ function findMatch<Schema extends EditorSchema = EditorSchema>(
   props: FindMatchProps<Schema>,
 ): SuggestMatch<Schema> | undefined {
   const { $pos, suggester } = props;
-  const { char, name, startOfLine, supportedCharacters, matchOffset, multiline, caseInsensitive } =
-    suggester;
+  const {
+    char,
+    name,
+    startOfLine,
+    supportedCharacters,
+    matchOffset,
+    multiline,
+    caseInsensitive,
+    unicode,
+  } = suggester;
 
   // Create the regular expression to match the text against
   const regexp = createRegexFromSuggester({
@@ -162,6 +170,7 @@ function findMatch<Schema extends EditorSchema = EditorSchema>(
     supportedCharacters,
     multiline,
     caseInsensitive,
+    unicode,
   });
 
   // All the text in the current node
@@ -604,7 +613,7 @@ export function getCharAsRegex(char: RegExp | string): RegExp {
 
 interface CreateRegExpFromSuggesterProps
   extends Pick<Required<Suggester>, 'startOfLine' | 'char' | 'supportedCharacters' | 'matchOffset'>,
-    Pick<Suggester, 'multiline' | 'caseInsensitive' | 'captureChar'> {}
+    Pick<Suggester, 'multiline' | 'caseInsensitive' | 'captureChar' | 'unicode'> {}
 
 /**
  * Create a regex expression which evaluate matches directly from the suggester
@@ -619,8 +628,9 @@ export function createRegexFromSuggester(props: CreateRegExpFromSuggesterProps):
     captureChar = true,
     caseInsensitive = false,
     multiline = false,
+    unicode = false,
   } = props;
-  const flags = `g${multiline ? 'm' : ''}${caseInsensitive ? 'i' : ''}`;
+  const flags = `g${multiline ? 'm' : ''}${caseInsensitive ? 'i' : ''}${unicode ? 'u' : ''}`;
   let charRegex = getCharAsRegex(char).source;
 
   if (captureChar) {
@@ -661,6 +671,7 @@ export const DEFAULT_SUGGESTER: PickPartial<Suggester<any>> = {
   emptySelectionsOnly: false,
   caseInsensitive: false,
   multiline: false,
+  unicode: false,
   captureChar: true,
 };
 


### PR DESCRIPTION
### Description

I needed to work with non-latin words for `MentionAtomExtension` (and `MentionExtension` too), so I dug deep enough to understand what is missing: support for Unicode RegExp (required to support Unicode character types: https://caniuse.com/?search=%5Cp). This PR adds that as an option to in `matchers` list.

#### How to use it:

If you need non-latin characters to be matched in your matchers add `supportedCharacters` definition along with `unicode: true` option, i.e.

```jsx
export const Editor = ({ initialValue }) => {
  const extensions = () => [
    new MentionAtomExtension({ matchers: [{ char: '@', name: 'at', supportedCharacters: /\p{Letter}+/u, unicode: true }] }),
  };
  const { manager, state } = useRemirror({ extensions, content: initialValue, stringHandler: 'html' });

  return (
    <Remirror initialContent={state} manager={manager}>
      <YourMentionSuggestionsComponent />
    </Remirror>
  );
};
```

Now Remirror should match words like "@michał" (that's a Polish name) whereas earlier it didn't.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
