### PR TITLE
feat(core): expose appended transactions in the onChange handler

### DIFF
--- a/.changeset/perfect-vans-roll.md
+++ b/.changeset/perfect-vans-roll.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': minor
+'@remirror/react-core': minor
+---
+
+Expose appended transactions via the onChange handler

--- a/packages/remirror__core/src/framework/base-framework.ts
+++ b/packages/remirror__core/src/framework/base-framework.ts
@@ -260,6 +260,16 @@ export interface RemirrorEventListenerProps<Extension extends AnyExtension>
   tr?: Transaction<GetSchema<Extension>>;
 
   /**
+   * When the state updates are not controlled and it was a transaction that
+   * caused the state to be updated this value captures all the transaction
+   * updates caused by prosemirror plugins hook state methods like
+   * `filterTransactions` and `appendTransactions`.
+   *
+   * This is for advanced users only.
+   */
+  transactions?: Array<Transaction<GetSchema<Extension>>>;
+
+  /**
    * A shorthand way of checking whether the update was triggered by editor
    * usage (internal) or overwriting the state.
    *
@@ -324,7 +334,17 @@ export interface TriggerChangeProps {
 
 export interface ListenerProps<Extension extends AnyExtension>
   extends Partial<EditorStateProps<GetSchema<Extension>>>,
-    Partial<TransactionProps<GetSchema<Extension>>> {}
+    Partial<TransactionProps<GetSchema<Extension>>> {
+  /**
+   * When the state updates are not controlled and it was a transaction that
+   * caused the state to be updated this value captures all the transaction
+   * updates caused by prosemirror plugins hook state methods like
+   * `filterTransactions` and `appendTransactions`.
+   *
+   * This is for advanced users only.
+   */
+  transactions?: Array<Transaction<GetSchema<Extension>>>;
+}
 
 export interface FrameworkEvents<Extension extends AnyExtension>
   extends Pick<ManagerEvents, 'destroy'> {

--- a/packages/remirror__core/src/framework/framework.ts
+++ b/packages/remirror__core/src/framework/framework.ts
@@ -460,10 +460,11 @@ export abstract class Framework<
   protected eventListenerProps(
     props: ListenerProps<Extension> = object(),
   ): RemirrorEventListenerProps<Extension> {
-    const { state, tr } = props;
+    const { state, tr, transactions } = props;
 
     return {
       tr,
+      transactions,
       internalUpdate: !tr,
       view: this.view,
       firstRender: this.#firstRender,

--- a/packages/remirror__react-core/src/react-framework.tsx
+++ b/packages/remirror__react-core/src/react-framework.tsx
@@ -200,7 +200,7 @@ export class ReactFramework<Extension extends AnyExtension> extends Framework<
         this.previousStateOverride = this.getState();
       }
 
-      this.onChange({ state, tr });
+      this.onChange({ state, tr, transactions });
 
       return;
     }
@@ -218,7 +218,7 @@ export class ReactFramework<Extension extends AnyExtension> extends Framework<
     // If `transactions` is an empty array, that means the transaction was cancelled by `filterTransaction`.
     if (triggerChange && transactions?.length !== 0) {
       // Update the `onChange` handler before notifying the manager but only when a change should be triggered.
-      this.onChange({ state, tr });
+      this.onChange({ state, tr, transactions });
     }
 
     this.manager.onStateUpdate({ previousState: this.previousState, state, tr, transactions });


### PR DESCRIPTION
### Description

When transactions are appended via plugins (i.e. `appendTransaction`) these transactions are not visible to the `onChange` handler passed to the `<Remirror />` root component.

##### Example usage

```jsx
const handleChange = useCallback(({
  tr, // As before
  transactions // Now available
}) => {
  const steps = [];
  transactions?.forEach((transaction) => {
    steps.push(...transaction.steps);
  });
  if (steps.length > 0) {
    myHandlerForSteps(steps);
  }
}, [myHandlerForSteps]);


return (
  <Remirror
    manager={manager}
    initialContent={state}
    onChange={handleChange}
  />
);
``` 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
