### PR TITLE
fix(mention-atom): mention atom should not allow marks

### DIFF
--- a/.changeset/moody-scissors-burn.md
+++ b/.changeset/moody-scissors-burn.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-italic': patch
+---
+
+Prevent italic input rule activation in middle of words

--- a/.changeset/stale-seas-pull.md
+++ b/.changeset/stale-seas-pull.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-mention-atom': patch
+---
+
+Prevent marks in MentionAtom, to prevent input rules being triggered within the node

--- a/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
+++ b/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
@@ -76,6 +76,23 @@ describe('inputRules', () => {
       });
   });
 
+  it('should not make text italic within a word', () => {
+    const {
+      add,
+      nodes: { doc, p },
+    } = renderEditor([new ItalicExtension()]);
+
+    add(doc(p('<cursor>')))
+      .insertText('BBC_News')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('BBC_News')));
+      })
+      .insertText('_Labs')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('BBC_News_Labs')));
+      });
+  });
+
   it('supports nested input rule matches', () => {
     const {
       add,
@@ -97,6 +114,30 @@ describe('inputRules', () => {
       .insertText(' more')
       .callback((content) => {
         expect(content.doc).toEqualRemirrorDocument(doc(p(italic(bold('bold italic')), ' more')));
+      });
+  });
+
+  it('supports nested input rule matches (reversed)', () => {
+    const {
+      add,
+      nodes: { doc, p },
+      marks: { bold, italic },
+    } = renderEditor([new BoldExtension(), new ItalicExtension()]);
+
+    add(doc(p('**_italic bold<cursor>')))
+      .insertText('_')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p('**', italic('italic bold'), '<cursor>')));
+      })
+      .insertText('**')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(
+          doc(p(bold(italic('italic bold')), '<cursor>')),
+        );
+      })
+      .insertText(' more')
+      .callback((content) => {
+        expect(content.doc).toEqualRemirrorDocument(doc(p(bold(italic('italic bold')), ' more')));
       });
   });
 });

--- a/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
+++ b/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
@@ -127,7 +127,9 @@ describe('inputRules', () => {
     add(doc(p('**_italic bold<cursor>')))
       .insertText('_')
       .callback((content) => {
-        expect(content.doc).toEqualRemirrorDocument(doc(p('**', italic('italic bold'), '<cursor>')));
+        expect(content.doc).toEqualRemirrorDocument(
+          doc(p('**', italic('italic bold'), '<cursor>')),
+        );
       })
       .insertText('**')
       .callback((content) => {

--- a/packages/remirror__extension-italic/src/italic-extension.ts
+++ b/packages/remirror__extension-italic/src/italic-extension.ts
@@ -64,7 +64,7 @@ export class ItalicExtension extends MarkExtension {
           !fullMatch.startsWith('*') ? { fullMatch: fullMatch.slice(1), start: start + 1 } : {},
       }),
       markInputRule({
-        regexp: /(?:^|[^_])_([^_]+)_$/,
+        regexp: /(?:^|\W)_([^_]+)_$/,
         type: this.type,
         ignoreWhitespace: true,
         updateCaptured: ({ fullMatch, start }) => {

--- a/packages/remirror__extension-italic/src/italic-extension.ts
+++ b/packages/remirror__extension-italic/src/italic-extension.ts
@@ -78,7 +78,7 @@ export class ItalicExtension extends MarkExtension {
 
   createPasteRules(): MarkPasteRule[] {
     return [
-      { type: 'mark', markType: this.type, regexp: /_([^_]+)_/g },
+      { type: 'mark', markType: this.type, regexp: /(?:^|\W)_([^_]+)_/g },
       { type: 'mark', markType: this.type, regexp: /\*([^*]+)\*/g },
     ];
   }

--- a/packages/remirror__extension-mention-atom/src/mention-atom-extension.ts
+++ b/packages/remirror__extension-mention-atom/src/mention-atom-extension.ts
@@ -146,6 +146,7 @@ export class MentionAtomExtension extends NodeExtension<MentionAtomOptions> {
 
     return {
       inline: true,
+      marks: '',
       selectable: this.options.selectable,
       draggable: this.options.draggable,
       atom: true,


### PR DESCRIPTION
### Description

Prevent marks in Mention atom, to prevent `@some_mention_text` rendering as

![unknown](https://user-images.githubusercontent.com/2003804/159448915-e163125a-7c31-4c45-bd7c-71b233b81c37.png)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
