### PR TITLE
fix(jest-remirror): add client rect to `createRange` polyfill

### DIFF
--- a/.changeset/tasty-starfishes-remember.md
+++ b/.changeset/tasty-starfishes-remember.md
@@ -1,0 +1,5 @@
+---
+'jest-remirror': patch
+---
+
+Add client rect methods when createRange is not available

--- a/packages/jest-remirror/src/jsdom-polyfills.ts
+++ b/packages/jest-remirror/src/jsdom-polyfills.ts
@@ -196,6 +196,8 @@ function supportRanges() {
         nodeName: 'BODY',
         ownerDocument: document,
       } as Node,
+      getClientRects: Element.prototype.getClientRects,
+      getBoundingClientRect: Element.prototype.getBoundingClientRect,
     } as any;
   }
 


### PR DESCRIPTION
### Description

We polyfill `document.createRange` however, we don't polyfill `getClientRects` / `getBoundingClientRects` which are need for `posAtCoords` etc.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
