### PR TITLE
chore(extension-react-tables): bump jsx-dom version

### DIFF
--- a/packages/remirror__extension-react-tables/package.json
+++ b/packages/remirror__extension-react-tables/package.json
@@ -58,7 +58,7 @@
     "@remirror/react-core": "^1.1.0",
     "@remirror/react-hooks": "^1.0.27",
     "@remirror/theme": "^1.2.1",
-    "jsx-dom": "^6.4.23"
+    "jsx-dom": "^7.0.2"
   },
   "devDependencies": {
     "@remirror/pm": "^1.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1522,7 +1522,7 @@ importers:
       '@remirror/theme': ^1.2.1
       '@types/react': ^17.0.14
       '@types/react-dom': ^17.0.9
-      jsx-dom: ^6.4.23
+      jsx-dom: ^7.0.2
       react: ^17.0.2
       react-dom: ^17.0.2
       y-webrtc: ^10.2.2
@@ -1542,7 +1542,7 @@ importers:
       '@remirror/react-core': link:../remirror__react-core
       '@remirror/react-hooks': link:../remirror__react-hooks
       '@remirror/theme': link:../remirror__theme
-      jsx-dom: 6.4.23
+      jsx-dom: 7.0.4
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@types/react': 17.0.33
@@ -19470,8 +19470,8 @@ packages:
       object.assign: 4.1.2
     dev: false
 
-  /jsx-dom/6.4.23:
-    resolution: {integrity: sha512-Y0ax82xa4nzqFdbUXs3ma2haDZy4pB638kMZsGRzZqdmtyzY2nAKs7Bh3DrLn0vqMuxmvZQ3g9hq3NtnI5yXtQ==}
+  /jsx-dom/7.0.4:
+    resolution: {integrity: sha512-CX5ayrg1/fvsXlXmff/ovhdFnA9iGAveATla1adsjsfd0c1XtBChK4ZoL0fT4euOuC4lTcGlNDfUf5Q0H1XJFw==}
     dependencies:
       csstype: 3.0.9
     dev: false


### PR DESCRIPTION
### Description

From https://github.com/proteriax/jsx-dom/blob/master/CHANGELOG.md#700= this update should not affect remirror.

---

When using remirror in frameworks that do not support ESM, it is required to use `jsx-dom-cjs`, but `jsx-dom-cjs` in available only with `jsx-dom@v7+`

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` was completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test extension-react-tables`.

### Screenshots

<!-- Delete this section if not applicable -->
