### PR TITLE
fix(extension-react-tables): deleted an incorrect preselectClass style on react-table-extension

### DIFF
--- a/.changeset/poor-apples-fry.md
+++ b/.changeset/poor-apples-fry.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-react-tables': patch
+---
+
+deleted an incorrect preselectClass style on react-table-extension

--- a/packages/remirror__extension-react-tables/src/table-plugins.ts
+++ b/packages/remirror__extension-react-tables/src/table-plugins.ts
@@ -31,12 +31,11 @@ export function getTableStyle(attrs: ControllerStateValues): string {
   if (attrs.preselectColumn !== -1) {
     classNames = css`
       & table.${ExtensionTablesTheme.TABLE} tbody tr {
-        th, td {
+        th,
+        td {
           &:nth-child(${attrs.preselectColumn + 1}) {
             ${preselectClass};
           }
-       }
-          ${preselectClass};
         }
         th.${ExtensionTablesTheme.TABLE_CONTROLLER}:nth-child(${attrs.preselectColumn + 1}) {
           ${preselectControllerClass}
@@ -46,8 +45,8 @@ export function getTableStyle(attrs: ControllerStateValues): string {
   } else if (attrs.preselectRow !== -1) {
     classNames = css`
       & table.${ExtensionTablesTheme.TABLE} tbody tr:nth-child(${attrs.preselectRow + 1}) {
-        td,
-        th {
+        th,
+        td {
           ${preselectClass};
         }
         th.${ExtensionTablesTheme.TABLE_CONTROLLER} {

--- a/packages/remirror__extension-react-tables/src/table-plugins.ts
+++ b/packages/remirror__extension-react-tables/src/table-plugins.ts
@@ -45,8 +45,8 @@ export function getTableStyle(attrs: ControllerStateValues): string {
   } else if (attrs.preselectRow !== -1) {
     classNames = css`
       & table.${ExtensionTablesTheme.TABLE} tbody tr:nth-child(${attrs.preselectRow + 1}) {
-        th,
-        td {
+        td,
+        th {
           ${preselectClass};
         }
         th.${ExtensionTablesTheme.TABLE_CONTROLLER} {


### PR DESCRIPTION
### Description

An abandoned `preselectclass` style was highlighting all borders.
link - https://remirror.vercel.app/?path=/story/extensions-react-table--basic
 
<img width="1118" alt="Screenshot 2022-04-04 at 9 33 18 AM" src="https://user-images.githubusercontent.com/3799600/161471910-f0f667cf-596f-472c-a7e4-fb5a35c4cf89.png">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<img width="1197" alt="Screenshot 2022-04-04 at 9 36 37 AM" src="https://user-images.githubusercontent.com/3799600/161472189-899324cf-6fee-4832-8fa0-c64647f0acd3.png">

