### PR TITLE
fix(prosemirror-resizable-view): fix an error during resizing

### DIFF
--- a/.changeset/cold-spies-ring.md
+++ b/.changeset/cold-spies-ring.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-resizable-view': patch
+---
+
+Fix a RangeError when the document is updated during the resizing.

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -75,11 +75,11 @@ export abstract class ResizableNodeView implements NodeView {
     const handles = types.map((type) => new ResizableHandle(type));
 
     for (const handle of handles) {
-      const handler = (e: MouseEvent) => {
-        this.resizeHandler(e, view, getPos, handle);
+      const onMouseDown = (e: MouseEvent) => {
+        this.startResizing(e, view, getPos, handle);
       };
-      handle.dom.addEventListener('mousedown', handler);
-      this.#destroyList.push(() => handle.dom.removeEventListener('mousedown', handler));
+      handle.dom.addEventListener('mousedown', onMouseDown);
+      this.#destroyList.push(() => handle.dom.removeEventListener('mousedown', onMouseDown));
       outer.append(handle.dom);
     }
 
@@ -156,7 +156,7 @@ export abstract class ResizableNodeView implements NodeView {
     return outer;
   }
 
-  resizeHandler(
+  startResizing(
     e: MouseEvent,
     view: EditorView,
     getPos: () => number,
@@ -261,6 +261,8 @@ export abstract class ResizableNodeView implements NodeView {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+    this.#destroyList.push(() => document.removeEventListener('mousemove', onMouseMove));
+    this.#destroyList.push(() => document.removeEventListener('mouseup', onMouseUp));
   }
 
   /**


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->



After pressing the resizable handle, if the node is updated and causes the node view to re-render, the `onmouseup` listener that was bound to `document` should be removed. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/24715727/161974430-929b7225-9bd2-4eef-ac36-f2d1d8b2d0a9.mp4

