### PR TITLE
docs(hooks): improve docs on Remirror's hooks

### DIFF
--- a/docs/hooks/use-active.md
+++ b/docs/hooks/use-active.md
@@ -1,0 +1,100 @@
+---
+hide_title: true
+title: 'useActive'
+---
+
+# `useActive`
+
+```tsx
+const active = useActive();
+```
+
+## Parameters
+
+`autoUpdate` (Optional)
+
+> A boolean indicating whether this hook should trigger a component render when the editor state changes.
+>
+> Default true.
+
+## Return value
+
+An object containing all the nodes and marks in your editor, which when called as functions returns `true` if the node/mark is present within the current user selection.
+
+## Description
+
+This hooks helps you determine whether nodes or marks from your chosen extensions are present within the current user selection.
+
+#### Empty selections (cursors)
+
+If the user's cursor (denoted by "⏐") was present within
+
+> Some blockquote with **bold⏐ text** and _italic text_.
+
+`active.bold()` would return **true** - similarly `active.blockquote()` would also return **true**.
+
+Conversely `active.italic()` would return **false** as it is not present in the current user's selection.
+
+#### Range selections
+
+With <mark>range selections</mark>
+
+> Some blockquote <mark>with **bold text** and _italic text_.</mark>
+
+`active.bold()`, `active.italic()` and `active.blockquote()` would all return **true**, as they are present within the range selection.
+
+#### Filtering by attributes
+
+Some extensions provide nodes/marks with attributes, for instance the [HeadingExtension](/docs/extensions/heading-extension) provides a `level` attribute indicating which heading level (`<h1>`-`<h6>`) to use.
+
+`useActive` provides a means of filtering results by attribute values. So you could determine the difference between different heading levels.
+
+Given some editor content like, and a cursor ("⏐") position
+
+> ## Heading 2⏐
+>
+> Some text
+>
+> ### Heading 3
+>
+> More text
+
+`active.heading()` would return **true**
+
+`active.heading({ level: 2 })` would return **true**
+
+`active.heading({ level: 3 })` would return **false**
+
+Multiple attribute values can be provided to the filter (where all values must match). Any attributes not provided will be ignored.
+
+Mark attribute filtering is also supported.
+
+## Usage
+
+This hook is most commonly used to modify the toggle state of toolbar buttons, or set the selected item in a dropdown.
+
+Here we use `active.code()` to toggle a class name, and the state of `aria-pressed`.
+
+```tsx
+const CodeButton = () => {
+  const { toggleCode } = useCommands();
+  const active = useActive();
+
+  const handleClick = useCallback(() => {
+    if (toggleCode.enabled()) {
+      toggleCode();
+    }
+  }, [toggleCode]);
+
+  return (
+    <button
+      disabled={!toggleCode.enabled()}
+      onClick={handleClick}
+      className={cx({ isActive: active.code() })}
+      aria-pressed={active.code()}
+    >
+      Code
+    </button>
+  );
+};
+```

--- a/docs/hooks/use-chained-commands.md
+++ b/docs/hooks/use-chained-commands.md
@@ -1,0 +1,131 @@
+---
+hide_title: true
+title: 'useChainedCommands'
+---
+
+# `useChainedCommands`
+
+```tsx
+const chain = useChainedCommands();
+```
+
+## Parameters
+
+`tr` (optional)
+
+> A transaction to append chained steps to.
+>
+> Defaults to a new transaction
+
+## Return value
+
+An object containing all the chainable commands available in the editor, an introspection method `enabled()`, as well as two chain terminating methods - `run()` and `tr()`.
+
+## Description
+
+This hook exposes all the _chainable_ commands from your chosen extensions (and those built in by default).
+
+[Commands](/docs/getting-started/commands-and-helpers#commands) allow you to modify editor state.
+
+When a command obtained from `useChainedCommands` is called, it returns an object containing other chainable commands. This allows you to form chains of multiple commands.
+
+:::info
+
+We are using the terminology "chainable commands" as not all commands are chainable, for instance `undo` or `redo` cannot be chained. The reasons why are explored in [this blog post](/blog/chainable-commands/#caveats).
+
+:::info
+
+Commands from `useChainedCommands` differ from their [`useCommands`](/docs/hooks/use-commands) cousins in _when_ they are dispatched. Commands from `useCommands` are dispatched _immediately_ - whereas chained commands **are not dispatched until you call `.run()` on the chain**.
+
+## Usage
+
+This hook is most commonly used in _controlled_ editor scenarios - where chained commands are the only way to dispatch multiple commands at the same time. This hook can however be used for _both_ controlled and uncontrolled editor scenarios.
+
+By convention, when using this hook, you do **not** deconstruct the commands returned from the hook. Instead, we keep a reference to the entire chain.
+
+```tsx
+const chain = useChainedCommands();
+```
+
+By convention, we also dispatch the commands with `run()` in the same React render phase as when the commands were created. That is to say we `run()` the commands in the same callback as we create them.
+
+```tsx
+const handleToggleHeading = useCallback(() => {
+  chain.toggleHeading({ level: 1 }).focus().run();
+}, [toggleHeading]);
+```
+
+A command chain does not have to be one continuous statement - the chain will cache any previous commands, meaning you can break your chain up with conditional statements.
+
+```jsx
+const chain = useChainedCommands();
+
+const handleUpdateHref = useCallback(
+  (href) => {
+    chain.focus();
+
+    if (href === '') {
+      chain.removeLink();
+    } else {
+      chain.updateLink({ href });
+    }
+
+    chain.run();
+  },
+  [chain],
+);
+```
+
+### Greedy application of commands
+
+Command chains are greedy - when `run()` they will try to apply as many commands as they can, **even if some commands fail**.
+
+:::info
+
+For the code samples below, assume we are **_not_** within a callout node, and therefore `updateCallout` cannot not be applied.
+
+:::info
+
+Consider the following chain:
+
+```tsx
+const chain = useChainedCommands();
+
+const handleClick = useCallback(() => {
+  chain.toggleBold().updateCallout({ type: 'info' }).toggleItalic().run();
+}, [chain]);
+```
+
+When this chain is `run()` the `toggleBold` and `toggleItalic` _are_ dispatched, but the second command `updateCallout` is **not** (as we're not within a callout, there is nothing to update).
+
+By default, `run()` will try and greedily dispatch as many commands as it can.
+
+To opt out of this greedy behaviour, you can;
+
+1. Check if an entire command chain is valid by interrogating it's `enabled()` property.
+
+   ```tsx
+   const chain = useChainedCommands();
+
+   const handleClick = useCallback(() => {
+     chain.toggleBold().updateCallout({ type: 'info' }).toggleItalic();
+
+     // No commands would be dispatched in this scenario (as run is never called), so the chain is preserved.
+     if (chain.enabled()) {
+       chain.run();
+     }
+   }, [chain]);
+   ```
+
+2. Choose to exit the chain when a command fails with `exitEarly`. This also destroys the chain.
+
+   ```tsx
+   const chain = useChainedCommands();
+
+   const handleClick = useCallback(() => {
+     chain.toggleBold().updateCallout({ type: 'info' }).toggleItalic();
+
+     // No commands would be dispatched in this scenario, and chain is destroyed.
+     chain.run({ exitEarly: true });
+   }, [chain]);
+   ```

--- a/docs/hooks/use-commands.md
+++ b/docs/hooks/use-commands.md
@@ -73,4 +73,40 @@ const handleToggleBoldItalic = useCallback(() => {
 
 When using a **controlled** editor, multiple commands must be performed via _chained_ commands instead (via the `useChainedCommands` hook).
 
-See [potential pitfalls](https://remirror.io/docs/react/controlled/#potential-pitfalls) in the controlled editor documentation for a in-depth description of the problem.
+See [potential pitfalls](/docs/react/controlled/#potential-pitfalls) in the controlled editor documentation for a in-depth description of the problem.
+
+## Custom Dispatch (Advanced)
+
+`useCommands` exposes a command `customDispatch` that allows you to dispatch ProseMirror transactions directly to the editor.
+
+This allows you to write ad-hoc [command functions](/docs/getting-started/commands-and-helpers#how-this-works-advanced) that enable the bare-metal power of ProseMirror.
+
+```tsx
+const insertCustomText = (text = 'Powered by Remirror!') => {
+  return ({ tr, dispatch }) => {
+    if (!isTextSelection(tr.selection)) {
+      return false;
+    }
+
+    dispatch?.(tr.insertText(text));
+
+    return true;
+  };
+};
+
+const Button = () => {
+  const { customDispatch } = useCommands();
+
+  const handleClick = useCallback(() => {
+    customDispatch(insertCustomText());
+  }, [customDispatch]);
+
+  return <button onClick={handleClick}>Click me!</button>;
+};
+```
+
+:::tip
+
+Consider whether your custom commands might be better suited as proper commands surfaced by a [custom extension](/docs/getting-started/custom-extension).
+
+:::tip

--- a/docs/hooks/use-commands.md
+++ b/docs/hooks/use-commands.md
@@ -5,18 +5,72 @@ title: 'useCommands'
 
 # `useCommands`
 
-A core hook which provides the commands for usage in your editor.
+```tsx
+const allCommands = useCommands();
+```
+
+## Parameters
+
+N/A
+
+## Return value
+
+An object containing all the commands available in the editor.
+
+## Description
+
+This hooks exposes all the commands from your chosen extensions (and those built in by default).
+
+For instance the command `selectText` is provided by a built-in extension and always available. However `toggleBold` would require the `BoldExtension` to be present.
+
+[Commands](/docs/getting-started/commands-and-helpers#commands) allow you to modify editor state.
+
+## Usage
+
+By convention, when using this hook, you deconstruct the commands needed for your use case.
 
 ```tsx
-import { useCommands } from '@remirror/react';
-
-const EditorButton = () => {
-  const commands = useCommands();
-
-  return (
-    <>
-      <button onClick={() => commands.toggleBold()}>Click me!</button>
-    </>
-  );
-};
+const { toggleHeading } = useCommands();
 ```
+
+Each command can be called as a function, passing the arguments as required.
+
+```tsx
+const handleToggleHeading = useCallback(() => {
+  toggleHeading({ level: 1 });
+}, [toggleHeading]);
+```
+
+However, be aware that a command might not make sense in the current selection context. For instance, you cannot add a link within a code block.
+
+Remirror provides the `<commandName>.enabled()` property on each command, so you can disable or hide parts of your UI where the command is not available.
+
+:::tip
+
+It is good practice to pass the same arguments to `.enabled()`, as you do the command itself, to ensure accurate results.
+
+:::tip
+
+```tsx
+<button onClick={handleToggleHeading} disabled={!toggleHeading.enabled({ level: 1 })}>
+  Toggle heading
+</button>
+```
+
+## Multiple commands
+
+If you are using an **uncontrolled** editor, you can use multiple commands from `useCommands` one after the other without concern.
+
+```jsx
+const { toggleBold, toggleItalic } = useCommands();
+
+const handleToggleBoldItalic = useCallback(() => {
+  // N.B. This only works in uncontrolled editors
+  toggleBold();
+  toggleItalic();
+}, [toggleBold, toggleItalic]);
+```
+
+When using a **controlled** editor, multiple commands must be performed via _chained_ commands instead (via the `useChainedCommands` hook).
+
+See [potential pitfalls](https://remirror.io/docs/react/controlled/#potential-pitfalls) in the controlled editor documentation for a in-depth description of the problem.

--- a/docs/hooks/use-commands.md
+++ b/docs/hooks/use-commands.md
@@ -21,7 +21,7 @@ An object containing all the commands available in the editor.
 
 This hooks exposes all the commands from your chosen extensions (and those built in by default).
 
-For instance the command `selectText` is provided by a built-in extension and always available. However `toggleBold` would require the `BoldExtension` to be present.
+For instance the command `selectText` is provided by a built-in extension and always available. However `toggleBold` would require the [BoldExtension](/docs/extensions/bold-extension) to be present.
 
 [Commands](/docs/getting-started/commands-and-helpers#commands) allow you to modify editor state.
 

--- a/docs/hooks/use-commands.md
+++ b/docs/hooks/use-commands.md
@@ -71,7 +71,7 @@ const handleToggleBoldItalic = useCallback(() => {
 }, [toggleBold, toggleItalic]);
 ```
 
-When using a **controlled** editor, multiple commands must be performed via _chained_ commands instead (via the `useChainedCommands` hook).
+When using a **controlled** editor, multiple commands must be performed via _chained_ commands instead (via the [`useChainedCommands`](/docs/hooks/use-chained-commands) hook).
 
 See [potential pitfalls](/docs/react/controlled/#potential-pitfalls) in the controlled editor documentation for a in-depth description of the problem.
 

--- a/docs/hooks/use-event.md
+++ b/docs/hooks/use-event.md
@@ -1,0 +1,150 @@
+---
+hide_title: true
+title: 'useEvent'
+---
+
+# `useEvent`
+
+```tsx
+useEvent(event, handler);
+```
+
+## Parameters
+
+`event`
+
+> A case-sensitive string representing the event type to listen to
+
+`handler`
+
+> A callback function that returns a `boolean`.
+>
+> When an event of a type matching `event` is triggered, this function will be called.
+
+## Return value
+
+`void`
+
+## Description
+
+This hook allows you to trigger behaviour based on events **within the editor**
+
+The callback function given as the second parameter, should **return a boolean** indicating whether any _other_ event handlers should be run.
+
+```jsx
+const handleEvent = useCallback((event) => {
+  console.log('Event triggered', event);
+
+  // Prevent other event handlers being run
+  // return true;
+
+  // Allow other event handlers to run
+  return false;
+}, []);
+```
+
+`return true` means no other event handlers for this type should be run.
+
+This should be used with caution, as returning true could prevent expected standard browser behaviour.
+
+`return false` means allow other event handlers for this type to be run.
+
+```tsx
+const handleMouseDown = useCallback((event) => {
+  console.log('Mousedown event occured');
+  event.preventDefault();
+
+  // Allow other mouse down event handlers to be run.
+  return false;
+}, []);
+
+useEvent('mousedown', handleMouseDown);
+```
+
+:::tip
+
+`useEvent` is syntax sugar, it is a specialised application of the `useExtension` hook.
+
+```tsx
+useExtension(
+  EventsExtension,
+  ({ addHandler }) => {
+    return addHandler(event, handler);
+  },
+  [event, handler],
+);
+```
+
+You could create custom hooks and adopt this pattern for other handlers. For instance
+
+```tsx
+function useMentionAtomClick(handler) {
+  useExtension(
+    MentionAtomExtension,
+    ({ addHandler }) => {
+      return addHandler('onClick', handler);
+    },
+    [handler],
+  );
+}
+```
+
+:::tip
+
+## Usage
+
+Remirror allows you to listen multiple event types within the editor. These can be used to trigger behaviour via an event handler.
+
+Remirror supports the following events
+
+`blur`, `focus`, `mousedown`, `mouseup`, `mouseenter`, `mouseleave`, `textInput`, `keypress`, `keyup`, `keydown`, `click`, `clickMark`, `contextmenu`, `hover`, `scroll`, `copy`, and `paste`.
+
+Unless listed in the exceptions below, the event handlers have the signature.
+
+```
+(event) => boolean
+```
+
+### Exceptions
+
+`click` and `clickMark` have a second parameter, an object with helper methods to interrogate the source of the event.
+
+```tsx
+const handleClick = useCallback((event, props) => {
+  const { pos, ...rest } = props;
+  console.log('Clicked pos', pos, 'rest', rest);
+
+  return false;
+}, []);
+
+useEvent('click', handleClick);
+```
+
+`textinput`, has no associated event, and instead provides a `from` and `to` position, and the added `text`.
+
+`({ from, to, text }) => boolean`
+
+:::warning
+
+The following events will be standardized in a future release of Remirror.
+
+:::warning
+
+Two outliers are the `contextmenu` and `hover` events, for historical reasons they return a helper object as **_both_** the first and second parameter. The **first** parameter only has an `event` property to expose the browser event.
+
+Remirror maintainers plan to standardize this behaviour in a future release, to return just the `event` object as the first argument, and the helper object as the second argument.
+
+To ease your future migration path, use the pattern below - where we deconstruct `event` from the first argument, and use the second argument helper.
+
+```tsx
+const handleHover = useCallback(({ event }, props) => {
+  const { getNode, hovering, ...rest } = props;
+  console.log('node', getNode(), 'is hovering', hovering, 'rest', rest);
+
+  return false;
+}, []);
+
+useEvent('hover', handleHover);
+```
+
+This means in the future, all you would need to do is to replace `{ event }` with `event`, to migrate your code.

--- a/docs/hooks/use-helpers.md
+++ b/docs/hooks/use-helpers.md
@@ -1,0 +1,52 @@
+---
+hide_title: true
+title: 'useHelpers'
+---
+
+# `useHelpers`
+
+```tsx
+const allHelpers = useHelpers();
+```
+
+## Parameters
+
+N/A
+
+## Return value
+
+An object containing all the commands available in the editor.
+
+## Description
+
+This hooks exposes all the helpers from your chosen extensions (and those built in by default).
+
+For instance `getJSON` is provided by a built-in extension and always available. However `getMarkdown` would require the `MarkdownExtension` to be present.
+
+[Helpers](/docs/getting-started/commands-and-helpers#helpers) allow you to read editor state.
+
+## Usage
+
+By convention, when using this hook, you deconstruct the helpers needed for your use case.
+
+```tsx
+const { getJSON } = useHelpers();
+```
+
+Each helper can be called as a function, passing the arguments as required.
+
+```tsx
+const { getJSON } = useHelpers();
+
+const onSave = useCallback(
+  ({ state }) => {
+    saveToBackend(getJSON(state));
+
+    // Prevents any further key handlers from being run.
+    return true;
+  },
+  [getJSON],
+);
+
+useKeymap('Mod-s', onSave);
+```

--- a/docs/hooks/use-helpers.md
+++ b/docs/hooks/use-helpers.md
@@ -26,7 +26,7 @@ An object containing all the helpers available in the editor.
 
 This hooks exposes all the helpers from your chosen extensions (and those built in by default).
 
-For instance `getJSON` is provided by a built-in extension and always available. However `getMarkdown` would require the `MarkdownExtension` to be present.
+For instance `getJSON` is provided by a built-in extension and always available. However `getMarkdown` would require the [MarkdownExtension](/docs/extensions/markdown-extension) to be present.
 
 [Helpers](/docs/getting-started/commands-and-helpers#helpers) allow you to read editor state.
 

--- a/docs/hooks/use-helpers.md
+++ b/docs/hooks/use-helpers.md
@@ -7,15 +7,20 @@ title: 'useHelpers'
 
 ```tsx
 const allHelpers = useHelpers();
+const allHelpersWithUpdate = useHelpers(true);
 ```
 
 ## Parameters
 
-N/A
+`update` (Optional)
+
+> A boolean indicating whether this hook should trigger a component render when the editor state changes.
+>
+> Default false.
 
 ## Return value
 
-An object containing all the commands available in the editor.
+An object containing all the helpers available in the editor.
 
 ## Description
 
@@ -49,4 +54,16 @@ const onSave = useCallback(
 );
 
 useKeymap('Mod-s', onSave);
+```
+
+By passing true to `useHelpers` you can ensure your component uses the latest editor state. Be aware this has performance implications, e.g. triggering a React render on every key press.
+
+```tsx
+const { getJSON } = useHelpers(true);
+
+return (
+  <pre>
+    <code>{JSON.stringify(getJSON(), null, 2)}</code>
+  </pre>
+);
 ```

--- a/docs/hooks/use-keymap.md
+++ b/docs/hooks/use-keymap.md
@@ -1,0 +1,150 @@
+---
+hide_title: true
+title: 'useKeymap'
+---
+
+# `useKeymap`
+
+```tsx
+useKeymap(name, handler);
+useKeymap(name, handler, priority);
+```
+
+## Parameters
+
+`name`
+
+> A string describing a key combination. This can be a single key like `'Enter'`, or multiple keys seperated by a dash, i.e. `'Mod-s'`.
+>
+> :::tip
+>
+> In ProseMirror you can use `Mod` as a shorthand for `Cmd` on Mac, and `Ctrl` on other platforms.
+>
+> :::tip
+
+`handler`
+
+> A callback function that returns a `boolean`.
+>
+> When a key press matching `name` is activated, this function will be called.
+
+`priority` (Optional)
+
+> Overrides the priority of this key handler. Defaults to `ExtensionPriority.Medium`;
+
+## Return value
+
+`void`
+
+## Description
+
+This hook allows you to create custom keyboard shortcuts that trigger behaviour.
+
+The callback function given as the second parameter, should **return a boolean** indicating whether any _other_ key handlers should be run.
+
+```jsx
+const handleKeyPress = useCallback(({ tr, state, dispatch, next }) => {
+  console.log('Key combination pressed');
+
+  // Prevent other key handlers being run
+  // return true;
+
+  // Not applicable here, run other key handlers
+  // return false;
+
+  // Run other key handlers (allows for composition - see below)
+  return next();
+}, []);
+```
+
+`return true` means no other key handlers should be run.
+
+This should be used with caution, especially with common keyboard shortcuts like `Enter`, as returning true could prevent things like creating a new line. Consider `return next()` instead.
+
+`return false` means this key handler is not applicable, and other key handlers should be run.
+
+`return next()` allows for composition (and improved readability), see [Composing key handlers](#composing-key-handlers) below.
+
+```tsx
+const onSave = useCallback(
+  ({ state }) => {
+    console.log('Mod and S key pressed!');
+
+    // Prevents any further key handlers from being run.
+    return true;
+  },
+  [getJSON],
+);
+
+useKeymap('Mod-s', onSave);
+```
+
+## Usage
+
+When combined with other Remirror hooks, such as `useCommands` or `useHelpers` you can create powerful features for novice and power users alike.
+
+Here we use the `getJSON` helper to extract the editor state as JSON and "save to backend" when the user presses `Cmd + S` on Mac, or `Ctrl + S` on other platforms.
+
+```tsx
+const { getJSON } = useHelpers();
+
+const onSave = useCallback(
+  ({ state }) => {
+    saveToBackend(getJSON(state));
+
+    // Prevents any further key handlers from being run.
+    return true;
+  },
+  [getJSON],
+);
+
+useKeymap('Mod-s', onSave);
+```
+
+:::tip
+
+Commands exposed by `useCommands` have a property `.original()` this will expose the raw command in a form acceptable to `useKeymap`.
+
+```tsx
+const { toggleCode } = useCommands();
+// Avoid this pattern for common keys like 'Enter' or 'Backspace'
+useKeymap('Mod-/', toggleCode.original());
+```
+
+**WARNING:** commands return a boolean, which will prevent other key handlers being run when the command returns true.
+
+:::tip
+
+## Composing key handlers
+
+The `useKeymap` callback will receive a property `next`.
+
+Consider using `return next()` instead of `return true/false`.
+
+- Using instead of `return true` will allow you to _compose_ multiple behaviours (still return true if you want to override everything)
+- Using instead of `return false` will improve the readability of your code by making the intention clearer.
+
+```tsx
+import { ExtensionPriority } from 'remirror';
+import { useHelpers, useKeymap } from 'remirror/extensions';
+
+export function useKeyboardAnalytics() {
+  const { sendEvent } = useSomeAnalyticsProvider();
+
+  const onSave = useCallback(
+    ({ next }) => {
+      sendEvent({ type: 'keyboard', shortcut: 'Mod-s' });
+
+      // returning true would prevent other handlers for Mod-s being run
+      // which would break our existing saveToBackend functionality (above)
+
+      // Instead, we return next, which will run other key handlers too
+      return next();
+    },
+    [sendEvent],
+    ExtensionPriority.Highest,
+  );
+
+  useKeymap('Mod-s', onSave);
+}
+```

--- a/docs/hooks/use-keymap.md
+++ b/docs/hooks/use-keymap.md
@@ -66,15 +66,12 @@ This should be used with caution, especially with common keyboard shortcuts like
 `return next()` allows for composition (and improved readability), see [Composing key handlers](#composing-key-handlers) below.
 
 ```tsx
-const onSave = useCallback(
-  ({ state }) => {
-    console.log('Mod and S key pressed!');
+const onSave = useCallback(({ tr, state, dispatch, next }) => {
+  console.log('Mod and S key pressed!');
 
-    // Prevents any further key handlers from being run.
-    return true;
-  },
-  [getJSON],
-);
+  // Prevents any further key handlers from being run.
+  return true;
+}, []);
 
 useKeymap('Mod-s', onSave);
 ```

--- a/website/sidebar.js
+++ b/website/sidebar.js
@@ -132,17 +132,21 @@ const docs = [
       .readdirSync(path.join(__dirname, '../docs/hooks'))
       .map((name) => `hooks/${name.replace(/\.mdx?$/, '')}`),
   },
-  {
+];
+
+if (getApiItems().length > 0) {
+  docs.push({
     type: 'category',
     label: 'API',
     collapsed: true,
     items: getApiItems(),
-  },
-  {
-    type: 'link',
-    label: 'Storybook',
-    href: 'https://remirror.vercel.app/',
-  },
-];
+  });
+}
+
+docs.push({
+  type: 'link',
+  label: 'Storybook',
+  href: 'https://remirror.vercel.app/',
+});
 
 exports.docs = docs;


### PR DESCRIPTION
### Description

Add initial docs for Remirror's hooks

- [x] `useActive`
- [ ] `useAttrs`
- [x] `useChainedCommands`
- [x] `useCommands`
- [ ] `useCurrentSelection`
- [ ] `useEditorFocus`
- [ ] `useEditorState`
- [ ] `useEditorView`
- [x] `useEvent`
- [ ] `useExtension`
- [x] `useHelpers`
- [ ] `useHistory`
- [x] `useKeymap`
- [ ] `useMarkRange`
- [ ] `useMention`
- [ ] `useMentionAtom`
- [ ] `useRemirror`
- [ ] `useRemirrorContext`
- [ ] `useSelectedText`
- [ ] `useSuggest`
- [ ] `usePositioner`

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

