### PR TITLE
fix(link): fix autolink breaking input rules at end of doc

### DIFF
--- a/.changeset/lovely-chairs-run.md
+++ b/.changeset/lovely-chairs-run.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core-utils': patch
+'@remirror/extension-link': patch
+---
+
+Fix an error with auto link preventing input rules at the end of a document

--- a/packages/remirror__core-utils/__tests__/core-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/core-utils.spec.ts
@@ -594,9 +594,9 @@ describe('getChangedNodeRanges', () => {
     expect(nodeRanges[0]?.startIndex).toBe(0);
     expect(nodeRanges[0]?.endIndex).toBe(1);
 
-    expect(nodeRanges[1]?.start).toBe(18);
+    expect(nodeRanges[1]?.start).toBe(23);
     expect(nodeRanges[1]?.end).toBe(40);
-    expect(nodeRanges[1]?.startIndex).toBe(2);
+    expect(nodeRanges[1]?.startIndex).toBe(3);
     expect(nodeRanges[1]?.endIndex).toBe(4);
   });
 });

--- a/packages/remirror__core-utils/__tests__/prosemirror-node-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/prosemirror-node-utils.spec.ts
@@ -237,13 +237,11 @@ describe('getChangedNodes', () => {
       .insertText('abc');
     const nodes = getChangedNodes(tr);
 
-    expect(nodes).toHaveLength(3);
+    expect(nodes).toHaveLength(2);
     expect(nodes[0]?.pos).toBe(0);
     expect(nodes[0]?.node.type.name).toBe('paragraph');
 
-    expect(nodes[1]?.pos).toBe(18);
-
-    expect(nodes[2]?.pos).toBe(23);
+    expect(nodes[1]?.pos).toBe(23);
   });
 
   it('handles deletions', () => {

--- a/packages/remirror__core-utils/src/core-utils.ts
+++ b/packages/remirror__core-utils/src/core-utils.ts
@@ -712,7 +712,7 @@ export function getChangedRanges(
 
       rawRanges.push({ from, to });
     } else {
-      step.getMap().forEach((_, __, from, to) => {
+      step.getMap().forEach((from, to) => {
         rawRanges.push({ from, to });
       });
     }
@@ -731,11 +731,13 @@ export function getChangedRanges(
 
     if (noOverlap) {
       // Add the new range when no overlap is found.
+      const newFrom = tr.mapping.map(from, -1);
+      const newTo = tr.mapping.map(to);
       ranges.push({
-        from,
-        to,
-        prevFrom: tr.mapping.invert().map(from, -1),
-        prevTo: tr.mapping.invert().map(to),
+        from: newFrom,
+        to: newTo,
+        prevFrom: tr.mapping.invert().map(newFrom, -1),
+        prevTo: tr.mapping.invert().map(newTo),
       });
     } else if (lastRange) {
       // Update the lastRange's end value.

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -10,7 +10,13 @@ import {
   NodeExtensionSpec,
   prosemirrorNodeToHtml,
 } from 'remirror';
-import { createCoreManager, extractHref, LinkExtension, LinkOptions } from 'remirror/extensions';
+import {
+  BoldExtension,
+  createCoreManager,
+  extractHref,
+  LinkExtension,
+  LinkOptions,
+} from 'remirror/extensions';
 
 extensionValidityTest(LinkExtension);
 
@@ -119,7 +125,7 @@ function create(options: LinkOptions = {}) {
     linkExtension.addHandler('onUpdateLink', options.onUpdateLink);
   }
 
-  return renderEditor([linkExtension]);
+  return renderEditor([linkExtension, new BoldExtension()]);
 }
 
 describe('commands', () => {
@@ -476,8 +482,9 @@ describe('plugin', () => {
 describe('autolinking', () => {
   let onUpdateLink = jest.fn(() => {});
   let editor = create({ autoLink: true, onUpdateLink });
-  let { doc, p } = editor.nodes;
   let { link } = editor.attributeMarks;
+  let { doc, p } = editor.nodes;
+  let { bold } = editor.marks;
 
   beforeEach(() => {
     onUpdateLink = jest.fn(() => {});
@@ -486,6 +493,7 @@ describe('autolinking', () => {
     ({
       attributeMarks: { link },
       nodes: { doc, p },
+      marks: { bold },
     } = editor);
   });
 
@@ -790,6 +798,12 @@ describe('autolinking', () => {
     expect(editor.doc).toEqualRemirrorDocument(
       doc(p(link({ auto: true, href: 'mailto:user@example.com' })('user@example.com'))),
     );
+  });
+
+  it('works with other input rules', () => {
+    editor.add(doc(p('__bold_<cursor>'))).insertText('_');
+
+    expect(editor.doc).toEqualRemirrorDocument(doc(p(bold('bold'))));
   });
 });
 


### PR DESCRIPTION
### Description

Fixes #1592

This fix seems to have an impact of `getChangedNodes`/`getChangedNodeRanges` - I'm trying to figure out whether this is a breaking change or a correction.

E.g.

```
doc(
  p('Paragraph 1'),
  p('Paragraph 2<cursor>'),
)
```

> `insertParagraph('Paragraph 3')`

```
doc(
  p('Paragraph 1'),
  p('Paragraph 2'),
  p('Paragraph 3'),
)
```

Before:
Changed nodes: `[ p('Paragraph 2'), p('Paragraph 3') ]`

After:
Changed nodes: `[ p('Paragraph 3') ]`

Thoughts? @ocavue @ronnyroeller @devcer ?

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
