### PR TITLE
fix(link-extension): skip onUpdateLink when link mark not added

### DIFF
--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -541,7 +541,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
 
           // Find text that can be auto linked
           tr.doc.nodesBetween(from, to, (node, pos) => {
-            if (!node.isTextblock) {
+            if (!node.isTextblock || !node.type.allowsMarkType(this.type)) {
               return;
             }
 


### PR DESCRIPTION
### Description

When attempting to auto-link in a node that disallows link marks, the onUpdateLink handler was previously still being called. This skips auto-link attempt entirely when we know the node disallows it.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
