### PR TITLE
fix(tables,react-tables): avoid highlighting cells while resizing

### DIFF
--- a/.changeset/selfish-toys-draw.md
+++ b/.changeset/selfish-toys-draw.md
@@ -1,0 +1,8 @@
+---
+'@remirror/extension-tables': patch
+'@remirror/extension-react-tables': patch
+---
+
+Reorder the external plugins of the tables extensions, to avoid highlighting cells while resizing.
+
+Proposed by Pierre\_ on Discord

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -60,11 +60,14 @@ export class TableExtension extends BaseTableExtension {
    * Add the table plugins to the editor.
    */
   createExternalPlugins(): ProsemirrorPlugin[] {
-    const plugins = [tableEditing(), createTableControllerPlugin()];
+    const plugins = [];
 
     if (this.options.resizable) {
+      // Add first to avoid highlighting cells while resizing
       plugins.push(columnResizing({ firstResizableColumn: 1 }));
     }
+
+    plugins.push(tableEditing(), createTableControllerPlugin());
 
     return plugins;
   }

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -106,11 +106,14 @@ export class TableExtension extends NodeExtension<TableOptions> {
    * Add the table plugins to the editor.
    */
   createExternalPlugins(): ProsemirrorPlugin[] {
-    const plugins = [tableEditing()];
+    const plugins = [];
 
     if (this.options.resizable) {
+      // Add first to avoid highlighting cells while resizing
       plugins.push(columnResizing({}));
     }
+
+    plugins.push(tableEditing());
 
     return plugins;
   }


### PR DESCRIPTION
### Description

Prevent highlighting cells while resizing columns.

Highlighted by [Pierre_ on Discord](https://discord.com/channels/726035064831344711/745695557976195072/964507362331340860)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

![column-resizing-cell-selection](https://user-images.githubusercontent.com/2003804/164037656-0199c31e-38fd-4462-ba04-d65104a8b2e6.gif)

