### PR TITLE
fix(core): prevent shared state between editor plugin instances

### DIFF
--- a/.changeset/blue-dodos-reply.md
+++ b/.changeset/blue-dodos-reply.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+Avoid adding `pluginState` to the constructor, as it leading to sharing between multiple instances

--- a/packages/remirror__core/src/builtins/plugins-extension.ts
+++ b/packages/remirror__core/src/builtins/plugins-extension.ts
@@ -198,7 +198,7 @@ export class PluginsExtension extends PlainExtension<PluginsOptions> {
       const getter = this.getPluginStateCreator(key);
 
       extension.pluginKey = key;
-      extension.constructor.prototype.getPluginState = getter;
+      extension.getPluginState = getter;
 
       this.stateGetters.set(extension.name, getter);
       this.stateGetters.set(extension.constructor, getter);

--- a/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
+++ b/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
@@ -666,3 +666,45 @@ describe('custom positions', () => {
     ]);
   });
 });
+
+describe('multiple editors', () => {
+  it('different editors should have different collections of annotations', () => {
+    const {
+      add: add1,
+      nodes: { p: p1, doc: doc1 },
+      commands: commands1,
+      helpers: helpers1,
+    } = create();
+
+    add1(doc1(p1('Some text in <start>editor 1<end>')));
+    commands1.addAnnotation({ id: 'editor-1-annotation' });
+
+    const {
+      add: add2,
+      nodes: { p: p2, doc: doc2 },
+      commands: commands2,
+      helpers: helpers2,
+    } = create();
+
+    add2(doc2(p2('Some other text in <start>editor 2<end>')));
+    commands2.addAnnotation({ id: 'editor-2-annotation' });
+
+    expect(helpers1.getAnnotations()).toEqual([
+      {
+        id: 'editor-1-annotation',
+        from: 14,
+        to: 22,
+        text: 'editor 1',
+      },
+    ]);
+
+    expect(helpers2.getAnnotations()).toEqual([
+      {
+        id: 'editor-2-annotation',
+        from: 20,
+        to: 28,
+        text: 'editor 2',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #1607

### Description

Adding `getPluginState` to the constructor prototype meant that state could be shared between editor instances.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
