### PR TITLE
fix(extension-embed): correctly parse saved iframe dimensions

### DIFF
--- a/.changeset/fuzzy-sloths-knock.md
+++ b/.changeset/fuzzy-sloths-knock.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-embed': patch
+---
+
+Fixes iframe dimensions not being preserved on content restored - https://github.com/remirror/remirror/issues/1615

--- a/packages/remirror__extension-embed/__tests__/iframe-extension.spec.ts
+++ b/packages/remirror__extension-embed/__tests__/iframe-extension.spec.ts
@@ -3,7 +3,7 @@ import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import { htmlToProsemirrorNode, prosemirrorNodeToHtml } from 'remirror';
 import { createCoreManager } from 'remirror/extensions';
 
-import { IframeExtension, IframeOptions } from '../';
+import { IframeAttributes, IframeExtension, IframeOptions } from '../';
 
 extensionValidityTest(IframeExtension);
 
@@ -13,7 +13,12 @@ function create(options?: IframeOptions) {
 
 describe('schema', () => {
   const { schema } = createCoreManager([new IframeExtension()]);
-  const attributes = { src: 'https://awesome.com' };
+  const attributes: IframeAttributes = {
+    src: 'https://awesome.com',
+    width: 234,
+    height: 123,
+    enableResizing: true,
+  };
 
   const { iframe, p, doc } = pmBuild(schema, {
     iframe: { markType: 'iframe', ...attributes },
@@ -22,7 +27,9 @@ describe('schema', () => {
   it('creates the correct dom node', () => {
     expect(prosemirrorNodeToHtml(doc(p(iframe())))).toMatchInlineSnapshot(`
       <p>
-        <iframe class="remirror-iframe remirror-iframe-custom"
+        <iframe width="234"
+                height="123"
+                class="remirror-iframe remirror-iframe-custom"
                 src="https://awesome.com"
                 data-embed-type="custom"
                 allowfullscreen="true"
@@ -36,7 +43,7 @@ describe('schema', () => {
   it('parses the dom structure and finds itself', () => {
     const node = htmlToProsemirrorNode({
       schema,
-      content: `<iframe src="https://awesome.com" data-embed-type="custom" frameborder="0"></iframe>`,
+      content: `<iframe src="https://awesome.com" data-embed-type="custom" frameborder="0" height="123" width="234"></iframe>`,
     });
     const expected = doc(iframe());
 

--- a/packages/remirror__extension-embed/src/iframe-extension.ts
+++ b/packages/remirror__extension-embed/src/iframe-extension.ts
@@ -26,9 +26,9 @@ import { ResizableIframeView } from './resizable-iframe-view';
 export type IframeAttributes = ProsemirrorAttributes<{
   src: string;
   frameBorder?: number | string;
-  allowFullScreen?: 'true';
-  width?: string | number;
-  height?: string | number;
+  allowFullScreen?: 'true' | boolean;
+  width?: number;
+  height?: number;
   type?: LiteralUnion<'youtube', string>;
 }>;
 
@@ -84,19 +84,19 @@ export class IframeExtension extends NodeExtension<IframeOptions> {
       parseDOM: [
         {
           tag: 'iframe',
-          getAttrs: (dom) => {
+          getAttrs: (dom): IframeAttributes => {
             const frameBorder = (dom as HTMLElement).getAttribute('frameborder');
             const width = (dom as HTMLElement).getAttribute('width');
             const height = (dom as HTMLElement).getAttribute('height');
             return {
               ...extra.parse(dom),
-              type: (dom as HTMLElement).getAttribute('data-embed-type'),
-              height: height && Number.parseInt(height, 10),
-              width: width && Number.parseInt(width, 10),
+              type: (dom as HTMLElement).getAttribute('data-embed-type') ?? undefined,
+              height: (height && Number.parseInt(height, 10)) || undefined,
+              width: (width && Number.parseInt(width, 10)) || undefined,
               allowFullScreen:
                 (dom as HTMLElement).getAttribute('allowfullscreen') === 'false' ? false : true,
               frameBorder: frameBorder ? Number.parseInt(frameBorder, 10) : 0,
-              src: (dom as HTMLElement).getAttribute('src'),
+              src: (dom as HTMLElement).getAttribute('src') ?? '',
             };
           },
         },

--- a/packages/remirror__extension-embed/src/iframe-extension.ts
+++ b/packages/remirror__extension-embed/src/iframe-extension.ts
@@ -86,11 +86,13 @@ export class IframeExtension extends NodeExtension<IframeOptions> {
           tag: 'iframe',
           getAttrs: (dom) => {
             const frameBorder = (dom as HTMLElement).getAttribute('frameborder');
+            const width = (dom as HTMLElement).getAttribute('width');
+            const height = (dom as HTMLElement).getAttribute('height');
             return {
               ...extra.parse(dom),
               type: (dom as HTMLElement).getAttribute('data-embed-type'),
-              height: (dom as HTMLElement).getAttribute('height'),
-              width: (dom as HTMLElement).getAttribute('width'),
+              height: height && Number.parseInt(height, 10),
+              width: width && Number.parseInt(width, 10),
               allowFullScreen:
                 (dom as HTMLElement).getAttribute('allowfullscreen') === 'false' ? false : true,
               frameBorder: frameBorder ? Number.parseInt(frameBorder, 10) : 0,

--- a/packages/remirror__extension-embed/src/resizable-iframe-view.ts
+++ b/packages/remirror__extension-embed/src/resizable-iframe-view.ts
@@ -2,6 +2,7 @@ import { ResizableNodeView, ResizableRatioType } from 'prosemirror-resizable-vie
 import { Shape } from '@remirror/core';
 import { EditorView, NodeView, ProsemirrorNode } from '@remirror/pm';
 
+import type { IframeAttributes } from './iframe-extension';
 import { IframeOptions } from './iframe-types';
 
 /**
@@ -16,14 +17,16 @@ export class ResizableIframeView extends ResizableNodeView implements NodeView {
     getPos: () => number,
     iframeOptions: IframeOptions,
   ) {
-    const { width, height } = node.attrs;
+    const { width, height } = node.attrs as IframeAttributes;
+    const initialSize = width && height ? { width, height } : undefined;
+
     super({
       node,
       view,
       getPos,
       aspectRatio: ResizableRatioType.Flexible,
       options: iframeOptions,
-      initialSize: { width, height },
+      initialSize,
     });
     this.options = iframeOptions;
   }


### PR DESCRIPTION
### Description

This PR fixes #1615. The issue description already has an explanation of what's happening and this as a possible solution. As you can see, we weren't parsing the iframe dimensions as numbers but as strings.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
  - I don't think this is applicable, but please let me know if you'd prefer tests and what kind specifically.

### Screenshots

https://www.loom.com/share/8f4c35dd23bc45c3a14960e9e55e2d5f
