### PR TITLE
fix(prosemirror-paste-rules): paste multiple block nodes

### DIFF
--- a/.changeset/mean-queens-deliver.md
+++ b/.changeset/mean-queens-deliver.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-heading': patch
+---
+
+Simplify the paste rule regex.

--- a/.changeset/yellow-jobs-divide.md
+++ b/.changeset/yellow-jobs-divide.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Paste multiple block nodes correctly.

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -3,6 +3,7 @@ import {
   doc,
   em,
   h1,
+  h2,
   hardBreak,
   p,
   schema,
@@ -268,12 +269,40 @@ describe('pasteRules', () => {
   describe('type: node', () => {
     it('can transform node matches', () => {
       const plugin = pasteRules([
-        { regexp: /# ([\s\w]+)$/, type: 'node', nodeType: schema.nodes.heading },
+        { regexp: /^# ([\s\w]+)$/, type: 'node', nodeType: schema.nodes.heading },
       ]);
       createEditor(doc(p('Hello <cursor>')), { plugins: [plugin] })
         .paste('# This is a heading')
         .callback((content) => {
           expect(content.doc).toEqualProsemirrorNode(doc(p('Hello '), h1('This is a heading')));
+        });
+    });
+
+    it('can transform multiple nodes', () => {
+      const plugin = pasteRules([
+        {
+          regexp: /^# ([\s\w]+)$/,
+          type: 'node',
+          nodeType: schema.nodes.heading,
+          getAttributes: () => ({
+            level: 1,
+          }),
+        },
+        {
+          regexp: /^## ([\s\w]+)$/,
+          type: 'node',
+          nodeType: schema.nodes.heading,
+          getAttributes: () => ({
+            level: 2,
+          }),
+        },
+      ]);
+      createEditor(doc(p('Hello <cursor>')), { plugins: [plugin] })
+        .paste('# This is a heading\n\n## This is another heading')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(
+            doc(p('Hello '), h1('This is a heading'), h2('This is another heading')),
+          );
         });
     });
 

--- a/packages/remirror__extension-heading/src/heading-extension.ts
+++ b/packages/remirror__extension-heading/src/heading-extension.ts
@@ -140,7 +140,7 @@ export class HeadingExtension extends NodeExtension<HeadingOptions> {
     return this.options.levels.map((level) => ({
       type: 'node',
       nodeType: this.type,
-      regexp: new RegExp(`^#{1,${level}}\\s([\\s\\w]+)$`),
+      regexp: new RegExp(`^#{${level}}\\s([\\s\\w]+)$`),
       getAttributes: () => ({ level }),
       startOfTextBlock: true,
     }));


### PR DESCRIPTION
### Description

Close #1238 
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/24715727/166499392-8174e4e3-04ed-48e3-946b-97347394a30d.mp4


<!-- Delete this section if not applicable -->
