### PR TITLE
fix: resolve the shortcut conflict between node formatting and list

### DIFF
--- a/.changeset/famous-waves-join.md
+++ b/.changeset/famous-waves-join.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Return `false` when list indent and dedent commands won't work.

--- a/.changeset/metal-dodos-listen.md
+++ b/.changeset/metal-dodos-listen.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-node-formatting': patch
+---
+
+Make sure NodeFormattingExtension works well with list extensions for `Tab` and `Shift-Tab` shortcuts.

--- a/packages/remirror__extension-list/src/list-command-dedent.ts
+++ b/packages/remirror__extension-list/src/list-command-dedent.ts
@@ -146,7 +146,8 @@ export function dedentList(tr: Transaction): boolean {
 export const dedentListCommand: CommandFunction = ({ tr, dispatch }) => {
   if (dedentList(tr)) {
     dispatch?.(tr.scrollIntoView());
+    return true;
   }
 
-  return true;
+  return false;
 };

--- a/packages/remirror__extension-list/src/list-command-indent.ts
+++ b/packages/remirror__extension-list/src/list-command-indent.ts
@@ -150,8 +150,8 @@ export function indentList(tr: Transaction): boolean {
 export const indentListCommand: CommandFunction = ({ tr, dispatch }) => {
   if (indentList(tr)) {
     dispatch?.(tr.scrollIntoView());
+    return true;
   }
 
-  // always return `true` since we don't want the browser to handle the keyboard event.
-  return true;
+  return false;
 };

--- a/packages/remirror__extension-node-formatting/__tests__/node-formatting-extension.spec.ts
+++ b/packages/remirror__extension-node-formatting/__tests__/node-formatting-extension.spec.ts
@@ -1,5 +1,78 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
+import { BulletListExtension } from 'remirror/extensions';
 
 import { NodeFormattingExtension } from '../';
 
 extensionValidityTest(NodeFormattingExtension);
+
+describe('keybindings', () => {
+  const extensions = [new NodeFormattingExtension()];
+  const editor = renderEditor(extensions);
+  const {
+    nodes: { doc },
+    attributeNodes: { paragraph: p },
+  } = editor;
+
+  it('can increase and decrease indent', () => {
+    editor.add(doc(p()('hello')));
+
+    editor.press('Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p({ nodeIndent: 1 })('hello')));
+    editor.press('Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p({ nodeIndent: 2 })('hello')));
+
+    editor.press('Shift-Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p({ nodeIndent: 1 })('hello')));
+    editor.press('Shift-Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p({ nodeIndent: 0 })('hello')));
+  });
+});
+
+describe('keybindings with list extensions', () => {
+  const extensions = [new NodeFormattingExtension(), new BulletListExtension()];
+  const editor = renderEditor(extensions);
+  const {
+    nodes: { doc, listItem: li, bulletList: ul },
+    attributeNodes: { paragraph: p },
+  } = editor;
+
+  it('ignore the indentation keybindings in list items', () => {
+    const doc1 = doc(
+      ul(
+        //
+        li(p()('A')),
+        li(p()('B')),
+        li(p({ nodeIndent: 0 })('C<cursor>')),
+        li(p()('D')),
+      ),
+    );
+
+    const doc2 = doc(
+      ul(
+        //
+        li(p()('A')),
+        li(
+          //
+          p()('B'),
+          ul(
+            //
+            li(p({ nodeIndent: 0 })('C<cursor>')),
+          ),
+        ),
+        li(p()('D')),
+      ),
+    );
+
+    editor.add(doc1);
+
+    editor.press('Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc2);
+    editor.press('Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc2);
+    editor.press('Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc2);
+
+    editor.press('Shift-Tab');
+    expect(editor.state.doc).toEqualRemirrorDocument(doc1);
+  });
+});

--- a/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
@@ -24,7 +24,6 @@ import {
   extractLineHeight,
   gatherNodes,
   increaseIndentOptions,
-  isSelectionInListItem,
   justifyAlignOptions,
   leftAlignOptions,
   NODE_INDENT_ATTRIBUTE,
@@ -53,7 +52,7 @@ import {
       '180px',
       '200px',
     ],
-    excludeNodes: ['bulletList', 'orderedList', 'taskList', 'listItem', 'taskListItem'],
+    excludeNodes: [],
   },
   staticKeys: ['indents'],
 })
@@ -175,34 +174,20 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
 
   /**
    * Increase the indentation level of the current block node, if applicable.
-   *
-   * @param options
-   * @param options.ignoreList If true, will not increase the indentation if currently in a list. Defaults to true.
    */
   @command(increaseIndentOptions)
-  increaseIndent({ ignoreList = true } = {}): CommandFunction {
+  increaseIndent(): CommandFunction {
     return (props) => {
-      if (ignoreList && isSelectionInListItem(props.state.selection)) {
-        return false;
-      }
-
       return this.setIndent('+1')(props);
     };
   }
 
   /**
    * Decrease the indentation of the current block node.
-   *
-   * @param options
-   * @param options.ignoreList If true, will not increase the indentation if currently in a list. Defaults to true.
    */
   @command(decreaseIndentOptions)
-  decreaseIndent({ ignoreList = true } = {}): CommandFunction {
+  decreaseIndent(): CommandFunction {
     return (props) => {
-      if (ignoreList && isSelectionInListItem(props.state.selection)) {
-        return false;
-      }
-
       return this.setIndent('-1')(props);
     };
   }
@@ -240,8 +225,8 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
   @keyBinding({
     shortcut: NamedShortcut.DecreaseIndent,
     command: 'decreaseIndent',
-    // Ensure this has lower priority than the dedent keybinding in @remirror/extension-list
-    priority: ExtensionPriority.Low,
+    // Ensure this has higher priority than the dedent keybinding in @remirror/extension-list
+    priority: ExtensionPriority.Medium,
   })
   decreaseIndentShortcut(props: KeyBindingProps): boolean {
     return this.decreaseIndent()(props);

--- a/packages/remirror__extension-node-formatting/src/node-formatting-utils.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-utils.ts
@@ -1,14 +1,11 @@
 import {
   clamp,
   EditorState,
-  ExtensionTag,
   extractPixelSize,
-  findParentNode,
   isNumber,
   last,
+  NodeType,
   NodeWithPosition,
-  ProsemirrorNode,
-  Selection,
   Shape,
   Static,
   Transaction,
@@ -60,20 +57,51 @@ function createActiveCheck(
   };
 }
 
+function isValidNodeType(type: NodeType, included: string[], excluded: string[]): boolean {
+  if (excluded.includes(type.name)) {
+    return false;
+  }
+
+  return included.includes(type.name);
+}
+
 export function gatherNodes(
   state: Transaction | EditorState,
   included: string[],
   excluded: string[],
 ): NodeWithPosition[] {
   const gatheredNodes: NodeWithPosition[] = [];
+  const { $from, $to } = state.selection;
+  const range = $from.blockRange($to);
+
+  if (!range) {
+    return [];
+  }
+
+  const { parent, start, end } = range;
+  const isRangeEntireParentContent = parent.nodeSize - 2 === end - start;
+
+  if (isRangeEntireParentContent && isValidNodeType(parent.type, included, excluded)) {
+    return [
+      {
+        node: parent,
+        pos: start - 1,
+      },
+    ];
+  }
 
   // Gather the nodes to indent.
-  state.doc.nodesBetween(state.selection.from, state.selection.to, (node, pos) => {
-    if (excluded.includes(node.type.name) || !included.includes(node.type.name)) {
+  state.doc.nodesBetween(start, end, (node, pos) => {
+    if (pos < start || pos > end) {
       return;
     }
 
-    gatheredNodes.push({ node, pos });
+    if (isValidNodeType(node.type, included, excluded)) {
+      gatheredNodes.push({ node, pos });
+      return false;
+    }
+
+    return;
   });
 
   return gatheredNodes;
@@ -153,15 +181,4 @@ export function extractLineHeight(lineHeight: string | number | null): number | 
   }
 
   return null;
-}
-
-/**
- * @internal
- */
-export function isSelectionInListItem(selection: Selection): boolean {
-  return Boolean(findParentNode({ selection, predicate: isListItemNode }));
-}
-
-function isListItemNode(node: ProsemirrorNode): boolean {
-  return Boolean(node.type.spec.group?.includes(ExtensionTag.ListItemNode));
 }

--- a/packages/remirror__extension-node-formatting/src/node-formatting-utils.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-utils.ts
@@ -1,10 +1,14 @@
 import {
   clamp,
   EditorState,
+  ExtensionTag,
   extractPixelSize,
+  findParentNode,
   isNumber,
   last,
   NodeWithPosition,
+  ProsemirrorNode,
+  Selection,
   Shape,
   Static,
   Transaction,
@@ -149,4 +153,15 @@ export function extractLineHeight(lineHeight: string | number | null): number | 
   }
 
   return null;
+}
+
+/**
+ * @internal
+ */
+export function isSelectionInListItem(selection: Selection): boolean {
+  return Boolean(findParentNode({ selection, predicate: isListItemNode }));
+}
+
+function isListItemNode(node: ProsemirrorNode): boolean {
+  return Boolean(node.type.spec.group?.includes(ExtensionTag.ListItemNode));
 }

--- a/packages/storybook-react/stories/extension-node-formatting/basic.tsx
+++ b/packages/storybook-react/stories/extension-node-formatting/basic.tsx
@@ -2,12 +2,12 @@ import 'remirror/styles/all.css';
 
 import React from 'react';
 import { htmlToProsemirrorNode } from 'remirror';
-import { NodeFormattingExtension } from 'remirror/extensions';
+import { BulletListExtension, NodeFormattingExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useCommands, useRemirror } from '@remirror/react';
 
 const Basic: React.FC = () => {
   const { manager, state, onChange } = useRemirror({
-    extensions: () => [new NodeFormattingExtension()],
+    extensions: () => [new NodeFormattingExtension(), new BulletListExtension()],
     content: '<p>Click buttons to change alignment, indent,<br> and line height</p>',
     stringHandler: htmlToProsemirrorNode,
   });

--- a/packages/storybook-react/stories/extension-node-formatting/basic.tsx
+++ b/packages/storybook-react/stories/extension-node-formatting/basic.tsx
@@ -2,12 +2,20 @@ import 'remirror/styles/all.css';
 
 import React from 'react';
 import { htmlToProsemirrorNode } from 'remirror';
-import { BulletListExtension, NodeFormattingExtension } from 'remirror/extensions';
+import {
+  BlockquoteExtension,
+  BulletListExtension,
+  NodeFormattingExtension,
+} from 'remirror/extensions';
 import { Remirror, ThemeProvider, useCommands, useRemirror } from '@remirror/react';
 
 const Basic: React.FC = () => {
   const { manager, state, onChange } = useRemirror({
-    extensions: () => [new NodeFormattingExtension(), new BulletListExtension()],
+    extensions: () => [
+      new BlockquoteExtension(),
+      new NodeFormattingExtension(),
+      new BulletListExtension(),
+    ],
     content: '<p>Click buttons to change alignment, indent,<br> and line height</p>',
     stringHandler: htmlToProsemirrorNode,
   });


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->
Close #1489 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots


 

https://user-images.githubusercontent.com/24715727/169849485-1503dbee-8f89-4bbd-a5f5-a2ae84036e0c.mp4



<!-- Delete this section if not applicable -->
