### PR TITLE
Remove annotation support from yjs-extension

### DIFF
--- a/.changeset/breezy-games-boil.md
+++ b/.changeset/breezy-games-boil.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-yjs': major
+---
+
+Remove annotation support from yjs-extension

--- a/packages/remirror__extension-yjs/__tests__/tsconfig.json
+++ b/packages/remirror__extension-yjs/__tests__/tsconfig.json
@@ -35,9 +35,6 @@
       "path": "../../remirror__core/src"
     },
     {
-      "path": "../../remirror__extension-annotation/src"
-    },
-    {
       "path": "../../remirror__messages/src"
     }
   ]

--- a/packages/remirror__extension-yjs/package.json
+++ b/packages/remirror__extension-yjs/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "^1.4.3",
-    "@remirror/extension-annotation": "^1.1.21",
     "@remirror/messages": "^1.0.6",
     "y-prosemirror": "^1.0.19",
     "y-protocols": "^1.0.5"

--- a/packages/remirror__extension-yjs/src/tsconfig.json
+++ b/packages/remirror__extension-yjs/src/tsconfig.json
@@ -20,9 +20,6 @@
       "path": "../../remirror__core/src"
     },
     {
-      "path": "../../remirror__extension-annotation/src"
-    },
-    {
       "path": "../../remirror__messages/src"
     }
   ]

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -659,13 +659,7 @@
     "name": "@remirror/extension-yjs",
     "limit": "115 KB",
     "path": "packages/remirror__extension-yjs/dist/remirror-extension-yjs.browser.esm.js",
-    "ignore": [
-      "@remirror/pm",
-      "yjs",
-      "@remirror/core",
-      "@remirror/extension-annotation",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "yjs", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },


### PR DESCRIPTION
### Description

We had initially added annotation support to the yjs-extension because we considered this to be required for collaborative editing with annotations. By now, this has proven to be wrong: sync'ing annotations outside of the Prosemirror document is bound to be unreliable (better approach: model annotations as marks).
Yet, having annotations hardwired in the yjs-extension gives a hard time to everyone wanting to use the yjs-extenion without annotations.

Requested a.o. by https://discord.com/channels/726035064831344711/745695521305526302/958036526443401217

This PR leads to a breaking change. We decided in the Remirror maintainers meeting (@ocavue , @whawker) that we will nonetheless include it without a new major Remirror version. That's because the current yjs-extension is very hard to use for most relevant use cases.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
