### PR TITLE
fix(font-size): support CSS function and avoid throwing error when value cannot be parsed

### DIFF
--- a/.changeset/light-crews-hug.md
+++ b/.changeset/light-crews-hug.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Add support for parsing CSS functions (`min,`max`and`clamp`) to`extractPixelSize`.

--- a/.changeset/young-fishes-march.md
+++ b/.changeset/young-fishes-march.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-font-size': patch
+---
+
+Support font sizes using `min`, `max` or `clamp`. Avoid error if value cannot be parsed.

--- a/packages/remirror__core-utils/__tests__/dom-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/dom-utils.spec.ts
@@ -110,3 +110,67 @@ describe(`viewport-relative units`, () => {
     expect(extractPixelSize('50vmax')).toBe(512);
   });
 });
+
+describe('CSS functions', () => {
+  describe('min()', () => {
+    it(`pixels`, () => {
+      expect(extractPixelSize('min(1px, 2px)')).toBe(1);
+    });
+
+    it(`relative units`, () => {
+      window.document.documentElement.style.fontSize = '10px';
+      expect(extractPixelSize('min(5rem, 10rem)')).toBe(50);
+    });
+
+    it(`mixed units`, () => {
+      expect(extractPixelSize('min(50vh, 50vw)')).toBe(384);
+    });
+  });
+
+  describe('max()', () => {
+    it(`pixels`, () => {
+      expect(extractPixelSize('max(1px, 2px)')).toBe(2);
+    });
+
+    it(`relative units`, () => {
+      window.document.documentElement.style.fontSize = '10px';
+      expect(extractPixelSize('max(5rem, 10rem)')).toBe(100);
+    });
+
+    it(`mixed units`, () => {
+      expect(extractPixelSize('max(50vh, 50vw)')).toBe(512);
+    });
+  });
+
+  describe('clamp()', () => {
+    it(`pixels`, () => {
+      expect(extractPixelSize('clamp(1px, 2px, 3px)')).toBe(2);
+    });
+
+    it(`relative units`, () => {
+      window.document.documentElement.style.fontSize = '10px';
+      expect(extractPixelSize('clamp(1rem, 3rem, 10rem)')).toBe(30);
+    });
+
+    it(`mixed units`, () => {
+      window.document.documentElement.style.fontSize = '16px';
+      expect(extractPixelSize('clamp(1rem, 10vw, 2rem)')).toBe(32);
+    });
+  });
+
+  describe('nested functions', () => {
+    it(`pixels`, () => {
+      expect(extractPixelSize('max(1px, min(2px, 3px))')).toBe(2);
+    });
+
+    it(`relative units`, () => {
+      window.document.documentElement.style.fontSize = '10px';
+      expect(extractPixelSize('max(1rem, min(3rem, 10rem))')).toBe(30);
+    });
+
+    it(`mixed units`, () => {
+      window.document.documentElement.style.fontSize = '16px';
+      expect(extractPixelSize('max(1rem, min(10vw, 2rem))')).toBe(32);
+    });
+  });
+});

--- a/packages/remirror__core-utils/package.json
+++ b/packages/remirror__core-utils/package.json
@@ -42,7 +42,8 @@
     "@remirror/messages": "^1.0.6",
     "@types/min-document": "^2.19.0",
     "css-in-js-utils": "^3.1.0",
-    "min-document": "^2.19.0"
+    "min-document": "^2.19.0",
+    "parenthesis": "^3.1.8"
   },
   "devDependencies": {
     "@remirror/pm": "^1.0.18",

--- a/packages/remirror__core-utils/src/dom-utils.ts
+++ b/packages/remirror__core-utils/src/dom-utils.ts
@@ -1,5 +1,16 @@
-import { Cast, includes, isNumber, isObject, isString } from '@remirror/core-helpers';
+import parse from 'parenthesis';
+import {
+  Cast,
+  clamp,
+  findMatches,
+  includes,
+  isNumber,
+  isObject,
+  isString,
+} from '@remirror/core-helpers';
 import { KebabCase, StringKey } from '@remirror/core-types';
+
+import { getMatchString } from './core-utils';
 
 /**
  * Get the styles for a given property of an element.
@@ -47,13 +58,19 @@ export type DomSizeUnit = typeof DOM_SIZE_UNITS[number];
 export type ParsedDomSize = [size: number, unit: DomSizeUnit];
 
 /**
+ * Matches a CSS dimension returning a group containing the unit name
+ * i.e. '10rem' returns the group 'rem'
+ */
+const CSS_DIMENSION_REGEX = /[\d-.]+(\w+)$/;
+
+/**
  * Parse the font size and font unit from the provided value. When the value
  * type is unsupported it default to `px`.
  */
 export function parseSizeUnit(fontSize: string | undefined | null = '0'): ParsedDomSize {
   const length = fontSize || '0';
   const value = Number.parseFloat(length);
-  const match = length.match(/[\d-.]+(\w+)$/);
+  const match = length.match(CSS_DIMENSION_REGEX);
   const unit = (match?.[1] ?? 'px').toLowerCase(); // Defaults to pixels
 
   return [value, includes(DOM_SIZE_UNITS, unit) ? unit : 'px'];
@@ -70,52 +87,149 @@ export function getFontSize(element?: Element | null): string {
     : getStyle(window.document.documentElement, 'font-size');
 }
 
-/**
- * Extract the pixel value from a size string.
- *
- * Taken from https://github.com/PacoteJS/pacote/blob/20cb1e3a999ed47a8d52b03b750290cf36b8e270/packages/pixels/src/index.ts
- */
-export function extractPixelSize(size: string, element?: Element | null): number {
+type UnitConvertor = (value: number, unit: string) => number;
+
+function createUnitConverter(element?: Element | null): UnitConvertor {
   const view = element?.ownerDocument?.defaultView ?? window;
   const root = view.document.documentElement || view.document.body;
-  const [value, unit] = parseSizeUnit(size);
 
-  switch (unit) {
-    case 'rem':
-      return value * extractPixelSize(getFontSize(root));
-    case 'em':
-      return value * extractPixelSize(getFontSize(element), element?.parentElement);
-    case 'in':
-      return value * PIXELS_PER_INCH;
-    case 'q':
-      return (value * PIXELS_PER_INCH) / MILLIMETERS_PER_INCH / 4;
-    case 'mm':
-      return (value * PIXELS_PER_INCH) / MILLIMETERS_PER_INCH;
-    case 'cm':
-      return (value * PIXELS_PER_INCH * 10) / MILLIMETERS_PER_INCH;
-    case 'pt':
-      return (value * PIXELS_PER_INCH) / POINTS_PER_INCH;
-    case 'pc':
-      return (value * PIXELS_PER_INCH) / PICAS_PER_INCH;
-    case 'vh':
-      return (value * view.innerHeight || root.clientWidth) / 100;
-    case 'vw':
-      return (value * view.innerWidth || root.clientHeight) / 100;
-    case 'vmin':
-      return (
-        (value *
-          Math.min(view.innerWidth || root.clientWidth, view.innerHeight || root.clientHeight)) /
-        100
-      );
-    case 'vmax':
-      return (
-        (value *
-          Math.max(view.innerWidth || root.clientWidth, view.innerHeight || root.clientHeight)) /
-        100
-      );
-    default:
-      return value;
+  return (value: number, unit: string) => {
+    switch (unit) {
+      case 'rem':
+        return value * extractPixelSize(getFontSize(root));
+      case 'em':
+        return value * extractPixelSize(getFontSize(element), element?.parentElement);
+      case 'in':
+        return value * PIXELS_PER_INCH;
+      case 'q':
+        return (value * PIXELS_PER_INCH) / MILLIMETERS_PER_INCH / 4;
+      case 'mm':
+        return (value * PIXELS_PER_INCH) / MILLIMETERS_PER_INCH;
+      case 'cm':
+        return (value * PIXELS_PER_INCH * 10) / MILLIMETERS_PER_INCH;
+      case 'pt':
+        return (value * PIXELS_PER_INCH) / POINTS_PER_INCH;
+      case 'pc':
+        return (value * PIXELS_PER_INCH) / PICAS_PER_INCH;
+      case 'vh':
+        return (value * view.innerHeight || root.clientWidth) / 100;
+      case 'vw':
+        return (value * view.innerWidth || root.clientHeight) / 100;
+      case 'vmin':
+        return (
+          (value *
+            Math.min(view.innerWidth || root.clientWidth, view.innerHeight || root.clientHeight)) /
+          100
+        );
+      case 'vmax':
+        return (
+          (value *
+            Math.max(view.innerWidth || root.clientWidth, view.innerHeight || root.clientHeight)) /
+          100
+        );
+      default:
+        return value;
+    }
+  };
+}
+
+/**
+ * Matches a CSS function returning groups containing the function name and arguments
+ * i.e. 'min(10px, 20px)' returns groups 'min' and '10px, 20px'
+ */
+const CSS_FUNCTION_REGEX = /^([a-z]+)\((.+)\)$/i;
+
+/**
+ * Recursively evaluates CSS functions by parsing into bracket groups
+ *
+ * Does not support the `calc` function
+ *
+ * @param cssFunc a string matching CSS_FUNCTION_REGEX
+ * @param unitConvertor
+ */
+function parseCSSFunction(cssFunc: string, unitConvertor: UnitConvertor): number {
+  if (!CSS_FUNCTION_REGEX.test(cssFunc)) {
+    return Number.NaN;
   }
+
+  const tokens = parse(cssFunc, {
+    brackets: ['()'],
+    escape: '_',
+    flat: true,
+  });
+
+  if (!tokens || tokens.length === 0) {
+    return Number.NaN;
+  }
+
+  function replaceTokenReferences(str: string): string {
+    return str.replace(/_(\d+)_/g, (_, refIndex: string) => {
+      const tokenIndex = Number.parseFloat(refIndex);
+      return tokens[tokenIndex] ?? '';
+    });
+  }
+
+  const firstToken = getMatchString(tokens, 0);
+
+  for (const match of findMatches(firstToken, CSS_FUNCTION_REGEX)) {
+    const funcName = getMatchString(match, 1);
+    const funcArgs = replaceTokenReferences(getMatchString(match, 2));
+    const args = funcArgs.split(/\s*,\s*/);
+
+    const values = args.map((arg) => {
+      if (CSS_FUNCTION_REGEX.test(arg)) {
+        const nestedFunction = replaceTokenReferences(arg);
+        return parseCSSFunction(nestedFunction, unitConvertor);
+      }
+
+      return parseCSSDimension(arg, unitConvertor);
+    });
+
+    switch (funcName) {
+      case 'min':
+        return Math.min(...values);
+      case 'max':
+        return Math.max(...values);
+      case 'clamp': {
+        const [min, value, max] = values;
+
+        if (isNumber(min) && isNumber(value) && isNumber(max)) {
+          return clamp({ min, max, value });
+        }
+
+        break;
+      }
+      case 'calc':
+        // Not practical to implement calc due to the vast amount of operations possible
+        return Number.NaN;
+      default:
+        return Number.NaN;
+    }
+  }
+
+  return Number.NaN;
+}
+
+function parseCSSDimension(dimension: string, unitConvertor: UnitConvertor): number {
+  const [value, unit] = parseSizeUnit(dimension);
+  return unitConvertor(value, unit);
+}
+
+/**
+ * Extract the pixel value from a dimension string or CSS function.
+ *
+ * Supports the CSS functions `min`, `max` and `clamp` even when nested.
+ *
+ * Does not support percentage units or the `calc` function.
+ *
+ * Adapted from https://github.com/PacoteJS/pacote/blob/20cb1e3a999ed47a8d52b03b750290cf36b8e270/packages/pixels/src/index.ts
+ */
+export function extractPixelSize(size: string, element?: Element | null): number {
+  const unitConvertor = createUnitConverter(element);
+
+  return CSS_FUNCTION_REGEX.test(size)
+    ? parseCSSFunction(size.toLowerCase(), unitConvertor)
+    : parseCSSDimension(size, unitConvertor);
 }
 
 /**

--- a/packages/remirror__extension-font-size/src/font-size-extension.ts
+++ b/packages/remirror__extension-font-size/src/font-size-extension.ts
@@ -120,9 +120,15 @@ export class FontSizeExtension extends MarkExtension<FontSizeOptions> {
   }
 
   private getFontSize(size: string) {
-    const { unit, roundingMultiple, max, min } = this.options;
+    const { unit, roundingMultiple, max, min, defaultSize } = this.options;
+    const fontSize = convertPixelsToDomUnit(size, unit, this.store.view?.dom);
+
+    if (Number.isNaN(fontSize)) {
+      return defaultSize || '1rem';
+    }
+
     const value = clamp({
-      value: round(convertPixelsToDomUnit(size, unit, this.store.view?.dom), roundingMultiple),
+      value: round(fontSize, roundingMultiple),
       max,
       min,
     });

--- a/packages/storybook-react/package.json
+++ b/packages/storybook-react/package.json
@@ -71,7 +71,9 @@
     "babel-loader": "^8.2.2",
     "codemirror": "^5.62.0",
     "create-context-state": "^1.0.1",
+    "diffable-html": "^4.1.0",
     "globby": "^11.0.4",
+    "html-escaper": "^3.0.3",
     "is-ci": "^3.0.0",
     "postcss": "^8.3.5",
     "postcss-nested": "^5.0.5",
@@ -88,6 +90,7 @@
     "yjs": "^13.5.23"
   },
   "devDependencies": {
+    "@types/html-escaper": "^3.0.0",
     "@types/node": "^16.3.3"
   },
   "@remirror": {

--- a/packages/storybook-react/preview.js
+++ b/packages/storybook-react/preview.js
@@ -3,7 +3,7 @@ import './storybook.css';
 export const parameters = {
   options: {
     storySort: {
-      order: ['Editors', 'Extensions', 'React Hooks'],
+      order: ['Editors', 'Extensions', 'React Hooks', 'Components (labs)', 'Utils'],
     },
   },
 };

--- a/packages/storybook-react/stories/paste-debugger.stories.tsx
+++ b/packages/storybook-react/stories/paste-debugger.stories.tsx
@@ -1,0 +1,89 @@
+import { css } from '@emotion/css';
+import prettyPrint from 'diffable-html';
+import { escape } from 'html-escaper';
+import React, { useCallback, useEffect, useState } from 'react';
+import markup from 'refractor/lang/markup';
+import { CodeBlockExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const extensions = () => [
+  new CodeBlockExtension({
+    supportedLanguages: [markup],
+  }),
+];
+
+const classNames = [
+  css`
+    max-width: calc(100vw - 2rem);
+  `,
+];
+
+const Editor: React.FC<{ language: string; data: string }> = ({ language, data }) => {
+  const content = `<pre><code data-code-block-language="${language}">${data}</code></pre>`;
+  const { manager, state, onChange, setState } = useRemirror({
+    extensions,
+    content,
+    stringHandler: 'html',
+  });
+
+  useEffect(() => {
+    setState(manager.createState({ content }));
+  }, [manager, setState, content]);
+
+  return (
+    <Remirror
+      manager={manager}
+      state={state}
+      onChange={onChange}
+      autoRender
+      editable={false}
+      classNames={classNames}
+    />
+  );
+};
+
+export const PasteDebugger: React.FC = () => {
+  const [htmlContent, setHtmlContent] = useState<string>();
+  const [textContent, setTextContent] = useState<string>();
+
+  const handlePaste = useCallback((e: ClipboardEvent) => {
+    const { clipboardData } = e;
+    const html = clipboardData?.getData('text/html') ?? '';
+    setHtmlContent(escape(prettyPrint(html)).trim());
+    setTextContent(clipboardData?.getData('text/plain') ?? '');
+  }, []);
+
+  useEffect(() => {
+    window.document.addEventListener('paste', handlePaste);
+
+    return () => {
+      window.document.removeEventListener('paste', handlePaste);
+    };
+  }, [handlePaste]);
+
+  return (
+    <ThemeProvider>
+      <h2>Perform a paste to view the contents of the clipboard</h2>
+      {htmlContent && (
+        <>
+          <h3>HTML Content</h3>
+          <Editor language='markup' data={htmlContent} />
+        </>
+      )}
+      {textContent && (
+        <>
+          <h3>Plain Text Content</h3>
+          <Editor language='text' data={textContent} />
+        </>
+      )}
+    </ThemeProvider>
+  );
+};
+
+export default {
+  component: PasteDebugger,
+  title: 'Utils / Paste Debugger',
+  parameters: {
+    layout: 'centered',
+  },
+};

--- a/packages/storybook-react/stories/patches.d.ts
+++ b/packages/storybook-react/stories/patches.d.ts
@@ -1,0 +1,27 @@
+declare module 'diffable-html' {
+  /**
+   * This formatter will normalize your HTML in a way that when you diff it, you
+   * get a clear sense of what changed.
+   *
+   * This is a "zero-config" and opinionated HTML formatter. Default rules might
+   * change in future releases in which case we will push a major release.
+   *
+   * Feel free to open issues to discuss better defaults.
+   *
+   * ```ts
+   * import toDiffableHtml from 'diffable-html';
+   *
+   * const html = `
+   * <div id="header">
+   * <h1>Hello World!</h1>
+   * <ul id="main-list" class="list"><li><a href="#">My HTML</a></li></ul>
+   * </div>
+   * `
+   *
+   * log(toDiffableHtml(html));
+   * ```
+   *
+   */
+  function toDiffableHtml(html: string): string;
+  export = toDiffableHtml;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2370,6 +2370,7 @@ importers:
       '@storybook/theming': ^6.3.4
       '@svgmoji/blob': ^3.1.0
       '@types/codemirror': ^5.60.2
+      '@types/html-escaper': ^3.0.0
       '@types/node': ^16.3.3
       '@types/react': ^18.0.6
       '@types/react-dom': ^18.0.2
@@ -2379,7 +2380,9 @@ importers:
       babel-loader: ^8.2.2
       codemirror: ^5.62.0
       create-context-state: ^1.0.1
+      diffable-html: ^4.1.0
       globby: ^11.0.4
+      html-escaper: ^3.0.3
       is-ci: ^3.0.0
       postcss: '>= 8.0.0'
       postcss-nested: ^5.0.5
@@ -2433,7 +2436,9 @@ importers:
       babel-loader: 8.2.3_@babel+core@7.15.8
       codemirror: 5.63.3
       create-context-state: link:../create-context-state
+      diffable-html: 4.1.0
       globby: 11.0.4
+      html-escaper: 3.0.3
       is-ci: 3.0.1
       postcss: 8.3.11
       postcss-nested: 5.0.6_postcss@8.3.11
@@ -2449,6 +2454,7 @@ importers:
       y-webrtc: 10.2.2
       yjs: 13.5.23
     devDependencies:
+      '@types/html-escaper': 3.0.0
       '@types/node': 16.11.6
 
   packages/test-keyboard:
@@ -8494,7 +8500,7 @@ packages:
     resolution: {integrity: sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==}
     dependencies:
       '@gar/promisify': 1.1.2
-      semver: 7.3.5
+      semver: 7.3.7
     dev: false
 
   /@npmcli/move-file/1.1.2:
@@ -11474,6 +11480,10 @@ packages:
     dependencies:
       '@types/react': 18.0.6
       hoist-non-react-statics: 3.3.2
+    dev: true
+
+  /@types/html-escaper/3.0.0:
+    resolution: {integrity: sha512-OcJcvP3Yk8mjYwf/IdXZtTE1tb/u0WF0qa29ER07ZHCYUBZXSN29Z1mBS+/96+kNMGTFUAbSz9X+pHmHpZrTCw==}
     dev: true
 
   /@types/html-minifier-terser/5.1.2:
@@ -18434,7 +18444,7 @@ packages:
       '@babel/code-frame': 7.10.4
       chalk: 2.4.2
       micromatch: 3.1.10
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
       worker-rpc: 0.1.1
@@ -18464,7 +18474,7 @@ packages:
       fs-extra: 9.1.0
       glob: 7.2.0
       memfs: 3.3.0
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       schema-utils: 2.7.0
       semver: 7.3.5
       tapable: 1.1.3
@@ -19587,6 +19597,10 @@ packages:
 
   /html-escaper/2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  /html-escaper/3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+    dev: false
 
   /html-minifier-terser/5.1.1:
     resolution: {integrity: sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==}
@@ -23417,7 +23431,7 @@ packages:
     resolution: {integrity: sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=}
     engines: {node: '>= 0.10.5'}
     dependencies:
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: false
 
   /node-emoji/1.11.0:
@@ -24803,7 +24817,7 @@ packages:
       loader-utils: 2.0.0
       postcss: 8.3.11
       schema-utils: 3.1.1
-      semver: 7.3.5
+      semver: 7.3.7
       webpack: 4.46.0
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -808,6 +808,7 @@ importers:
       domino: ^2.1.6
       jsdom: ^17.0.0
       min-document: ^2.19.0
+      parenthesis: ^3.1.8
     dependencies:
       '@babel/runtime': 7.15.4
       '@remirror/core-constants': link:../remirror__core-constants
@@ -817,6 +818,7 @@ importers:
       '@types/min-document': 2.19.0
       css-in-js-utils: 3.1.0
       min-document: 2.19.0
+      parenthesis: 3.1.8
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@types/jsdom': 16.2.13
@@ -24170,6 +24172,10 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+
+  /parenthesis/3.1.8:
+    resolution: {integrity: sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==}
+    dev: false
 
   /parse-asn1/5.1.6:
     resolution: {integrity: sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==}


### PR DESCRIPTION
### Description

Pasting content using CSS functions can cause errors (Firefox). This PR resolves the issue, as well as providing utilities functions as these patterns before more prevalent.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
