### PR TITLE
fix(prosemirror-paste-rules): set open depth more precisely

### DIFF
--- a/.changeset/three-owls-admire.md
+++ b/.changeset/three-owls-admire.md
@@ -1,0 +1,9 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Fix open depths in node paste rules.
+
+When excuting a node paste rule, only reset open depths ([openStart](https://prosemirror.net/docs/ref/#model.Slice.openStart) and [openEnd](https://prosemirror.net/docs/ref/#model.Slice.openEnd)) when the node paste rule is actually applied and it's for a block node.
+
+This patch will fix the extra paragraph after pasting text.


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

 

https://user-images.githubusercontent.com/24715727/168612431-c0064c97-7237-4901-adf9-351ea1c3560e.mp4

 
