### PR TITLE
fix(react-tables): inject controllers when pasting a table

### DIFF
--- a/.changeset/stupid-stingrays-approve.md
+++ b/.changeset/stupid-stingrays-approve.md
@@ -1,0 +1,7 @@
+---
+'@remirror/core-utils': patch
+'@remirror/extension-link': patch
+'@remirror/extension-react-tables': patch
+---
+
+Fix paste of tables in React Tables extension

--- a/packages/remirror__core-utils/__tests__/prosemirror-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/prosemirror-utils.spec.ts
@@ -21,6 +21,7 @@ import { NodeSelection, Selection, TextSelection } from '@remirror/pm/state';
 
 import {
   cloneTransaction,
+  composeTransactionSteps,
   containsAttributes,
   findElementAtPosition,
   findNodeAtSelection,
@@ -349,6 +350,57 @@ describe('cloneTransaction', () => {
 
       jest.advanceTimersByTime(20);
     });
+  });
+});
+
+describe('composeTransactionSteps', () => {
+  it('combines the steps of the given transactions', () => {
+    const { state } = createEditor(doc(p('one'), p('two')));
+    const tr1 = cloneTransaction(state.tr.replaceRangeWith(0, 5, p('ONE')));
+    const tr2 = cloneTransaction(state.tr.replaceRangeWith(5, 10, p('TWO')));
+
+    const composedTr = composeTransactionSteps([tr1, tr2], state);
+    expect(composedTr.steps).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": 0,
+          "slice": Object {
+            "content": Array [
+              Object {
+                "content": Array [
+                  Object {
+                    "text": "ONE",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+          },
+          "stepType": "replace",
+          "to": 5,
+        },
+        Object {
+          "from": 5,
+          "slice": Object {
+            "content": Array [
+              Object {
+                "content": Array [
+                  Object {
+                    "text": "TWO",
+                    "type": "text",
+                  },
+                ],
+                "type": "paragraph",
+              },
+            ],
+          },
+          "stepType": "replace",
+          "to": 10,
+        },
+      ]
+    `);
+    expect(composedTr.doc).toEqualProsemirrorNode(doc(p('ONE'), p('TWO')));
   });
 });
 

--- a/packages/remirror__core-utils/src/index.ts
+++ b/packages/remirror__core-utils/src/index.ts
@@ -126,6 +126,7 @@ export {
   applyClonedTransaction,
   chainKeyBindingCommands,
   cloneTransaction,
+  composeTransactionSteps,
   containsAttributes,
   findElementAtPosition,
   findNodeAtPosition,

--- a/packages/remirror__core-utils/src/prosemirror-utils.ts
+++ b/packages/remirror__core-utils/src/prosemirror-utils.ts
@@ -128,6 +128,24 @@ export function applyClonedTransaction(props: ApplyClonedTransactionProps): void
 }
 
 /**
+ * Returns a new transaction by combining all steps of the passed transactions onto the previous state
+ */
+export function composeTransactionSteps(
+  transactions: Transaction[],
+  oldState: EditorState,
+): Transaction {
+  const { tr } = oldState;
+
+  transactions.forEach((transaction) => {
+    transaction.steps.forEach((step) => {
+      tr.step(step);
+    });
+  });
+
+  return tr;
+}
+
+/**
  * Checks if the type a given `node` has a given `nodeType`.
  */
 export function markEqualsType<Schema extends EditorSchema = EditorSchema>(

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -3,6 +3,7 @@ import {
   ApplySchemaAttributes,
   command,
   CommandFunction,
+  composeTransactionSteps,
   CreateExtensionPlugin,
   EditorState,
   extension,
@@ -556,12 +557,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
         }
 
         // Create a single transaction, by combining all transactions
-        const composedTransaction = prevState.tr;
-        transactions.forEach((transaction) => {
-          transaction.steps.forEach((step) => {
-            composedTransaction.step(step);
-          });
-        });
+        const composedTransaction = composeTransactionSteps(transactions, prevState);
 
         const changes = getChangedRanges(composedTransaction, [ReplaceAroundStep, ReplaceStep]);
         const { mapping } = composedTransaction;


### PR DESCRIPTION
### Description

Fixes behaviour when pasting a table using the React Tables extension.

Previously, editor state was updated, but the controllers were not injected, meaning nothing was displayed visually.

Copy and paste the table below [here](https://pr1644-remirror-ocavue.vercel.app/?path=/story/extensions-react-table--basic), to see the bug.

| Company                      | Contact          | Country |
|------------------------------|------------------|---------|
| Alfreds Futterkiste          | Maria Anders     | Germany |
| Centro comercial Moctezuma   | Francisco Chang  | Mexico  |
| Ernst Handel                 | Roland Mendel    | Austria |
| Island Trading               | Helen Bennett    | UK      |
| Laughing Bacchus Winecellars | Yoshi Tannamuri  | Canada  |
| Magazzini Alimentari Riuniti | Giovanni Rovelli | Italy   |

Copy and paste the same table above [here](https://pr1650-remirror-ocavue.vercel.app/?path=/story/extensions-react-table--basic), to see the behaviour fixed.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
