### PR TITLE
docs: remove duplicated codes

### DIFF
--- a/docs/react/refs.md
+++ b/docs/react/refs.md
@@ -42,13 +42,7 @@ Here's the **TypeScript** version which, as a bonus should pass type checks.
 
 ```tsx
 import React, { forwardRef, useImperativeHandle } from 'react';
-import {
-  ReactExtensions,
-  ReactFrameworkOutput,
-  ReactFrameworkOutput,
-  Remirror,
-  useRemirror,
-} from '@remirror/react';
+import { ReactExtensions, ReactFrameworkOutput, Remirror, useRemirror } from '@remirror/react';
 
 const extensions = () => [new BoldExtension()];
 type Extensions = ReactExtensions<BoldExtension>;


### PR DESCRIPTION
### Description

Remove duplicated import `ReactFrameworkOutput` from here

``` tsx
import {
  ReactExtensions,
  ReactFrameworkOutput,
  ReactFrameworkOutput,
  Remirror,
  useRemirror,
} from '@remirror/react';
```

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
