### PR TITLE
fix(tasklist): prevent checkbox toggle when view is not editable

### DIFF
--- a/.changeset/tough-boxes-battle.md
+++ b/.changeset/tough-boxes-battle.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Prevent checkbox toggle when view is not editable

--- a/packages/remirror__extension-list/__tests__/task-list-extension.spec.ts
+++ b/packages/remirror__extension-list/__tests__/task-list-extension.spec.ts
@@ -1,6 +1,10 @@
+import { extensionValidityTest } from 'jest-remirror';
 import { htmlToProsemirrorNode } from '@remirror/core';
 
+import { TaskListItemExtension } from '../src';
 import { setupListEditor } from './list-setup';
+
+extensionValidityTest(TaskListItemExtension);
 
 describe('schema', () => {
   it('parses the dom structure and finds itself', () => {

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -87,12 +87,19 @@ export class TaskListItemExtension extends NodeExtension {
       mark.type = 'checkbox';
       mark.classList.add(ExtensionListTheme.LIST_ITEM_CHECKBOX);
       mark.contentEditable = 'false';
-      mark.addEventListener('click', () => {
+      mark.addEventListener('click', (e: MouseEvent) => {
+        if (!view.editable) {
+          e.preventDefault();
+        }
+      });
+      mark.addEventListener('change', () => {
         const pos = (getPos as () => number)();
         const $pos = view.state.doc.resolve(pos + 1);
         this.store.commands.toggleCheckboxChecked({ $pos });
-        return true;
       });
+
+      // Use the node as the source of truth of the checkbox state.
+      mark.checked = node.attrs.checked;
 
       return createCustomMarkListItemNodeView({
         node,


### PR DESCRIPTION
Fixes #1657

### Description

Checkboxes should not be clickable when the view is not editable.

This isn't an ideal solutions as the checkboxes are not visually disabled

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
