### PR TITLE
feat(core): add ability to remove all marks by passing `type: null`

### DIFF
--- a/.changeset/lovely-timers-guess.md
+++ b/.changeset/lovely-timers-guess.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': patch
+'@remirror/core-utils': patch
+---
+
+Add the ability to remove all marks via the `removeMark` command, by passing `{ type: null }`

--- a/.changeset/yellow-ants-brush.md
+++ b/.changeset/yellow-ants-brush.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': patch
+'@remirror/core-utils': patch
+---
+
+Fix `removeMark` to support multiple mark ranges

--- a/packages/remirror__core-utils/src/command-utils.ts
+++ b/packages/remirror__core-utils/src/command-utils.ts
@@ -1,5 +1,5 @@
 import { ErrorConstant } from '@remirror/core-constants';
-import { assertGet, invariant, isNumber, isString, object } from '@remirror/core-helpers';
+import { assertGet, clamp, invariant, isNumber, isString, object } from '@remirror/core-helpers';
 import type {
   AttributesProps,
   CommandFunction,
@@ -481,7 +481,8 @@ export function removeMark(props: RemoveMarkProps): CommandFunction {
     const markRange = getMarkRange($from, rangeMark, $to);
 
     if (expand && markRange) {
-      ({ from, to } = markRange);
+      from = clamp({ min: 0, value: markRange.from, max: from });
+      to = clamp({ min: markRange.to, value: to, max: tr.doc.nodeSize - 2 });
     }
 
     dispatch?.(

--- a/packages/remirror__core-utils/src/command-utils.ts
+++ b/packages/remirror__core-utils/src/command-utils.ts
@@ -1,5 +1,5 @@
 import { ErrorConstant } from '@remirror/core-constants';
-import { assertGet, clamp, invariant, isNumber, isString, object } from '@remirror/core-helpers';
+import { assertGet, invariant, isNumber, isString, object } from '@remirror/core-helpers';
 import type {
   AttributesProps,
   CommandFunction,
@@ -481,8 +481,10 @@ export function removeMark(props: RemoveMarkProps): CommandFunction {
     const markRange = getMarkRange($from, rangeMark, $to);
 
     if (expand && markRange) {
-      from = clamp({ min: 0, value: markRange.from, max: from });
-      to = clamp({ min: markRange.to, value: to, max: tr.doc.nodeSize - 2 });
+      // Expand the from position to the mark range (if it is smaller) - keep bound within doc
+      from = Math.max(0, Math.min(from, markRange.from));
+      // Expand the to position to the mark range (if it is larger) - keep bound within doc
+      to = Math.min(Math.max(to, markRange.to), tr.doc.nodeSize - 2);
     }
 
     dispatch?.(

--- a/packages/remirror__core/__tests__/commands-extension.spec.ts
+++ b/packages/remirror__core/__tests__/commands-extension.spec.ts
@@ -227,6 +227,32 @@ describe('removeMark', () => {
     );
   });
 
+  it('can remove multiple marks ranges by named type', () => {
+    const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
+    const { doc, p } = editor.nodes;
+    const { bold, italic } = editor.marks;
+
+    editor.add(
+      doc(
+        p(
+          '<start>my ',
+          bold('bold ', italic('italic')),
+          ' content ',
+          italic('with'),
+          ' a ',
+          bold('bold'),
+          ' suffix<end>',
+        ),
+      ),
+    );
+
+    editor.commands.removeMark({ type: 'bold' });
+
+    expect(editor.state.doc).toEqualRemirrorDocument(
+      doc(p('my bold ', italic('italic'), ' content ', italic('with'), ' a bold suffix')),
+    );
+  });
+
   it('can remove all marks by passing type === null', () => {
     const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
     const { doc, p } = editor.nodes;
@@ -237,5 +263,31 @@ describe('removeMark', () => {
     editor.commands.removeMark({ type: null });
 
     expect(editor.state.doc).toEqualRemirrorDocument(doc(p('my bold italic content')));
+  });
+
+  it('can remove multiple marks ranges when passing type === null', () => {
+    const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
+    const { doc, p } = editor.nodes;
+    const { bold, italic } = editor.marks;
+
+    editor.add(
+      doc(
+        p(
+          '<start>my ',
+          bold('bold ', italic('italic')),
+          ' content ',
+          italic('with'),
+          ' a ',
+          bold('bold'),
+          ' suffix<end>',
+        ),
+      ),
+    );
+
+    editor.commands.removeMark({ type: null });
+
+    expect(editor.state.doc).toEqualRemirrorDocument(
+      doc(p('my bold italic content with a bold suffix')),
+    );
   });
 });

--- a/packages/remirror__core/__tests__/commands-extension.spec.ts
+++ b/packages/remirror__core/__tests__/commands-extension.spec.ts
@@ -211,3 +211,31 @@ describe('setContent', () => {
     expect(editor.state.doc).toEqualProsemirrorNode(doc(p('my content')));
   });
 });
+
+describe('removeMark', () => {
+  it('can remove a mark by named type', () => {
+    const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
+    const { doc, p } = editor.nodes;
+    const { bold, italic } = editor.marks;
+
+    editor.add(doc(p('<start>my ', bold('bold ', italic('italic')), ' content<end>')));
+
+    editor.commands.removeMark({ type: 'italic' });
+
+    expect(editor.state.doc).toEqualRemirrorDocument(
+      doc(p('my ', bold('bold italic'), ' content')),
+    );
+  });
+
+  it('can remove all marks by passing type === null', () => {
+    const editor = renderEditor([new BoldExtension(), new ItalicExtension()]);
+    const { doc, p } = editor.nodes;
+    const { bold, italic } = editor.marks;
+
+    editor.add(doc(p('<start>my ', bold('bold ', italic('italic')), ' content<end>')));
+
+    editor.commands.removeMark({ type: null });
+
+    expect(editor.state.doc).toEqualRemirrorDocument(doc(p('my bold italic content')));
+  });
+});


### PR DESCRIPTION
This aligns with the behaviour of ProseMirror itself.

Fixes #1398

### Description

Add support for `removeMark` removing _all_ marks by passing 

```tsx
const { removeMark } = useCommands();

const handleClick = useCallback((e) => {
  removeMark({ type: null });
}, [removeMark]); 
```

Also fixes the `removeMark` command, so that it removes marks across multiple mark ranges.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
