### PR TITLE
fix(markdown): fix rendering and parsing of tasklists in markdown

### DIFF
--- a/.changeset/giant-zebras-tan.md
+++ b/.changeset/giant-zebras-tan.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-markdown': patch
+---
+
+Fix rendering and parsing of tasklists in markdown

--- a/packages/remirror__extension-markdown/__tests__/__snapshots__/markdown-extension.spec.ts.snap
+++ b/packages/remirror__extension-markdown/__tests__/__snapshots__/markdown-extension.spec.ts.snap
@@ -1,5 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`commands.insertMarkdown can insert lists 1`] = `
+<div
+  aria-label=""
+  aria-multiline="true"
+  class="ProseMirror remirror-editor"
+  contenteditable="true"
+  role="textbox"
+  translate="no"
+>
+  <p>
+    Bullet list
+  </p>
+  <ul>
+    <li>
+      <p>
+        Item 1
+      </p>
+    </li>
+    <li>
+      <p>
+        Item 2
+      </p>
+    </li>
+  </ul>
+  <p>
+    Ordered list
+  </p>
+  <ol>
+    <li>
+      <p>
+        Item 1
+      </p>
+    </li>
+    <li>
+      <p>
+        Item 2
+      </p>
+    </li>
+  </ol>
+  <p>
+    Task list
+  </p>
+  <ul
+    data-task-list=""
+  >
+    <li
+      class="remirror-list-item-with-custom-mark"
+      data-checked=""
+      data-task-list-item=""
+    >
+      <label
+        class="remirror-list-item-marker-container"
+      >
+        <input
+          class="remirror-list-item-checkbox"
+          type="checkbox"
+        />
+      </label>
+      <div>
+        <p>
+          Item 1
+        </p>
+      </div>
+    </li>
+    <li
+      class="remirror-list-item-with-custom-mark"
+      data-task-list-item=""
+    >
+      <label
+        class="remirror-list-item-marker-container"
+      >
+        <input
+          class="remirror-list-item-checkbox"
+          type="checkbox"
+        />
+      </label>
+      <div>
+        <p>
+          Item 2
+        </p>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`commands.insertMarkdown can insert marks 1`] = `
 <div
   aria-label=""

--- a/packages/remirror__extension-markdown/__tests__/html-to-markdown.spec.ts
+++ b/packages/remirror__extension-markdown/__tests__/html-to-markdown.spec.ts
@@ -4,11 +4,15 @@ const casesArray = [
   ['strike', '<strike>Lorem ipsum</strike>', '~Lorem ipsum~'],
   ['s', '<s>Lorem ipsum</s>', '~Lorem ipsum~'],
   ['del', '<del>Lorem ipsum</del>', '~Lorem ipsum~'],
-  ['unchecked inputs', '<ul><li><input type="checkbox">Check Me!</li></ul>', '*   [ ] Check Me!'],
+  [
+    'unchecked inputs',
+    '<ul data-task-list><li data-task-list-item><p>Check Me!</p></li></ul>',
+    '- [ ] Check Me!',
+  ],
   [
     'checked inputs',
-    '<ul><li><input type="checkbox" checked="">Checked!</li></ul>',
-    '*   [x] Checked!',
+    '<ul data-task-list><li data-task-list-item data-checked><p>Checked!</p></li></ul>',
+    '- [x] Checked!',
   ],
   [
     'basic table',

--- a/packages/remirror__extension-markdown/src/html-to-markdown.ts
+++ b/packages/remirror__extension-markdown/src/html-to-markdown.ts
@@ -75,10 +75,11 @@ function cell(content: string, node: Node) {
 const turndownService = new TurndownService({ codeBlockStyle: 'fenced', headingStyle: 'atx' })
   .addRule('taskListItems', {
     filter: (node) => {
-      return (node as HTMLInputElement).type === 'checkbox' && node.parentNode?.nodeName === 'LI';
+      return node.nodeName === 'LI' && node.hasAttribute('data-task-list-item');
     },
-    replacement: (_, node) => {
-      return `${(node as HTMLInputElement).checked ? '[x]' : '[ ]'} `;
+    replacement: (content, node) => {
+      const isChecked = (node as HTMLElement).hasAttribute('data-checked');
+      return `- ${isChecked ? '[x]' : '[ ]'} ${content.trimStart()}`;
     },
   })
   .addRule('tableCell', {

--- a/packages/remirror__extension-markdown/src/markdown-to-html.ts
+++ b/packages/remirror__extension-markdown/src/markdown-to-html.ts
@@ -6,6 +6,28 @@
 
 import { marked } from 'marked';
 
+marked.use({
+  renderer: {
+    list(body: string, isOrdered: boolean, start: number): string {
+      if (isOrdered) {
+        const startAttr = start !== 1 ? `start="${start}"` : '';
+        return `<ol ${startAttr}>\n${body}</ol>\n`;
+      }
+
+      const taskListAttr = body.startsWith('<li data-task-list-item ') ? 'data-task-list' : '';
+      return `<ul ${taskListAttr}>\n${body}</ul>\n`;
+    },
+    listitem(text: string, isTask: boolean, isChecked: boolean): string {
+      if (!isTask) {
+        return `<li>${text}</li>\n`;
+      }
+
+      const checkedAttr = isChecked ? 'data-checked' : '';
+      return `<li data-task-list-item ${checkedAttr}>${text}</li>\n`;
+    },
+  },
+});
+
 /**
  * Converts the provided markdown to HTML.
  */


### PR DESCRIPTION
Fixes #1357

### Description

`getMarkdown` now renders tasklists as specified in the GitHub flavoured markdown spec

Example
```
- [x] Checked
- [ ] Unchecked 
```

The markdown string handler now also parses tasklist markdown correctly.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
