### PR TITLE
docs: fix rendering order of Styling docs

### DIFF
--- a/docs/concepts/styling.md
+++ b/docs/concepts/styling.md
@@ -7,6 +7,8 @@ title: Styling
 
 Remirror requires styles for the editor to function correctly across different browsers. These styles can be added in the following ways:
 
+> In order to use the `styled-components` or `emotion` variants you will need to also install `@remirror/styles`.
+
 With plain css make sure to wrap your editor with the class `.remirror-theme`. This adds the CSS variables with their default values to the dom, for consumption by any editors within this area.
 
 Then import the styles from the `remirror/styles` endpoint as shown below.
@@ -29,11 +31,11 @@ import { MyEditor } from './my-editor';
 // Wrap your editor with the component.
 const App = () => {
   return (
-    <ThemeProvider>
-      <AllStyledComponent>
+    <AllStyledComponent>
+      <ThemeProvider>
         <MyEditor />
-      </AllStyledComponent>
-    </ThemeProvider>
+      </ThemeProvider>
+    </AllStyledComponent>
   );
 };
 ```
@@ -50,11 +52,11 @@ import { MyEditor } from './my-editor';
 // Wrap your editor with the component.
 const App = () => {
   return (
-    <ThemeProvider>
-      <AllStyledComponent>
+    <AllStyledComponent>
+      <ThemeProvider>
         <MyEditor />
-      </AllStyledComponent>
-    </ThemeProvider>
+      </ThemeProvider>
+    </AllStyledComponent>
   );
 };
 ```
@@ -70,5 +72,3 @@ const wrapperElement = document.createElement('div');
 wrapperElement.classList.add(THEME); // Add the css variables to the dom.
 addStylesToElement(wrapperElement, allStyles);
 ```
-
-In order to use the `styled-components` or `emotion` variants you will need to also install `@remirror/styles`.


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

In the Core concepts > Styling tab of the official document, if you apply the example of emotion and styled-component, styling will not be applied.
You need to change the order of `ThemeProvider` and `AllStyledComponent` for it to take effect. So I've edited this part of the documentation.

Also, in emotion and styled-component, `@remirror/styles` was raised to the top because the phrase that install is required is at the end of the document, so you may not be able to find it.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
