### PR TITLE
chore: publish docs and storybook from remirror v1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,11 @@ name: docs
 on:
   push:
     branches:
-      - main
+      - v1-hotfix
   pull_request:
     types: [opened, synchronize]
     branches:
+      - v1-hotfix
       - main
 
 env:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -3,10 +3,11 @@ name: storybook
 on:
   push:
     branches:
-      - main
+      - v1-hotfix
   pull_request:
     types: [opened, synchronize]
     branches:
+      - v1-hotfix
       - main
 
 env:


### PR DESCRIPTION
### Description

**Temporarily** modify CI pipeline to only update docs (remirror.io) and storybook (remirror.vercel.app) on merge to the `v1-hotfix` branch.

Currently React Tables are broken on main (v2 beta). v2 beta is currently deployed to above URLs, making it appear that our "latest" release (**v1**) is broken, which is not true.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
