### PR TITLE
chore: deploy docs and storybook from v1-hotfix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,7 @@ jobs:
         uses: nwtgck/actions-netlify@develop
         with:
           publish-dir: './website/build'
-          production-branch: main
+          production-branch: v1-hotfix
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: 'Deploy Docs from GitHub Actions - ${{ github.event.pull_request.title || github.ref }}'
         env:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: deploy storybook for production
         uses: amondnet/vercel-action@v20
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/v1-hotfix'
         with:
           working-directory: ./packages/storybook-react/storybook-static
           vercel-token: ${{ secrets.VERCEL_STORYBOOK_TOKEN }}


### PR DESCRIPTION
### Description

**N.B.** This branch merges to `v1-hotfix` **_NOT_** `main`

Temporarily modify CI pipeline to only update docs (remirror.io) and storybook (remirror.vercel.app) on merge to the v1-hotfix branch.

Currently React Tables are broken on main (v2 beta). v2 beta is currently deployed to above URLs, making it appear that our "latest" release (v1) is broken, which is not true.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
