### PR TITLE
fix(react-tables): fix initialisation on tables on view, and copy and paste bugs

### DIFF
--- a/.changeset/three-scissors-deny.md
+++ b/.changeset/three-scissors-deny.md
@@ -1,0 +1,13 @@
+---
+'@remirror/extension-markdown': minor
+'@remirror/extension-react-tables': minor
+'@remirror/extension-tables': patch
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Add a customisible floating button to completely delete React tables.
+
+Fix creating React tables from markdown initial state.
+
+Fix copy and paste of React tables, which resulted in duplicated controlled cells.

--- a/packages/remirror__extension-markdown/__tests__/__snapshots__/markdown-extension.spec.ts.snap
+++ b/packages/remirror__extension-markdown/__tests__/__snapshots__/markdown-extension.spec.ts.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`commands.insertMarkdown can insert basic tables from markdown 1`] = `
+<div
+  aria-label=""
+  aria-multiline="true"
+  class="ProseMirror remirror-editor"
+  contenteditable="true"
+  role="textbox"
+  translate="no"
+>
+  <div
+    class="tableWrapper"
+  >
+    <table
+      style="min-width: 50px;"
+    >
+      <colgroup>
+        <col />
+        <col />
+      </colgroup>
+      <tbody>
+        <tr>
+          <th>
+            <p>
+              Column 1
+            </p>
+          </th>
+          <th>
+            <p>
+              Column 2
+            </p>
+          </th>
+        </tr>
+        <tr>
+          <td>
+            <p>
+              Row 1, Column 1
+            </p>
+          </td>
+          <td>
+            <p>
+              Row 1, Column 2
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <p>
+              Row 2, Column 1
+            </p>
+          </td>
+          <td>
+            <p>
+              Row 2, Column 2
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`commands.insertMarkdown can insert lists 1`] = `
 <div
   aria-label=""
@@ -121,6 +183,222 @@ exports[`commands.insertMarkdown can insert marks as blocks 1`] = `
       is bold.
     </strong>
   </p>
+</div>
+`;
+
+exports[`commands.insertMarkdown can insert react tables from markdown 1`] = `
+<div
+  aria-label=""
+  aria-multiline="true"
+  class="ProseMirror remirror-editor"
+  contenteditable="true"
+  role="textbox"
+  translate="no"
+>
+  <div
+    class="remirror-table-show-controllers"
+  >
+    <table
+      class="remirror-table remirror-table-with-controllers"
+      data-controllers-injected=""
+      style="min-width: 30px;"
+    >
+      <colgroup
+        class="remirror-table-colgroup"
+      >
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <tbody
+        class="remirror-table-tbody-with-controllers"
+      >
+        <tr>
+          <th
+            class="remirror-table-controller remirror-controllers-toggle"
+            contenteditable="false"
+            data-controller-cell=""
+          >
+            <div
+              class="remirror-table-controller-wrapper"
+              contenteditable="false"
+            >
+              <div />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-mark-row-corner"
+              />
+              <div
+                class="remirror-table-controller-mark-column-corner"
+              />
+            </div>
+          </th>
+          <th
+            class="remirror-table-controller remirror-controllers-toggle"
+            contenteditable="false"
+            data-controller-cell=""
+          >
+            <div
+              class="remirror-table-controller-wrapper"
+              contenteditable="false"
+            >
+              <div />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-mark-row-corner"
+              />
+              <div
+                class="remirror-table-controller-mark-column-corner"
+              />
+            </div>
+          </th>
+          <th
+            class="remirror-table-controller remirror-controllers-toggle"
+            contenteditable="false"
+            data-controller-cell=""
+          >
+            <div
+              class="remirror-table-controller-wrapper"
+              contenteditable="false"
+            >
+              <div />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-mark-row-corner"
+              />
+              <div
+                class="remirror-table-controller-mark-column-corner"
+              />
+            </div>
+          </th>
+        </tr>
+        <tr>
+          <th
+            class="remirror-table-controller remirror-controllers-toggle"
+            contenteditable="false"
+            data-controller-cell=""
+          >
+            <div
+              class="remirror-table-controller-wrapper"
+              contenteditable="false"
+            >
+              <div />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-mark-row-corner"
+              />
+              <div
+                class="remirror-table-controller-mark-column-corner"
+              />
+            </div>
+          </th>
+          <th>
+            <p>
+              Column 1
+            </p>
+          </th>
+          <th>
+            <p>
+              Column 2
+            </p>
+          </th>
+        </tr>
+        <tr>
+          <th
+            class="remirror-table-controller remirror-controllers-toggle"
+            contenteditable="false"
+            data-controller-cell=""
+          >
+            <div
+              class="remirror-table-controller-wrapper"
+              contenteditable="false"
+            >
+              <div />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-mark-row-corner"
+              />
+              <div
+                class="remirror-table-controller-mark-column-corner"
+              />
+            </div>
+          </th>
+          <td>
+            <p>
+              Row 1, Column 1
+            </p>
+          </td>
+          <td>
+            <p>
+              Row 1, Column 2
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <th
+            class="remirror-table-controller remirror-controllers-toggle"
+            contenteditable="false"
+            data-controller-cell=""
+          >
+            <div
+              class="remirror-table-controller-wrapper"
+              contenteditable="false"
+            >
+              <div />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-trigger-area"
+              />
+              <div
+                class="remirror-table-controller-mark-row-corner"
+              />
+              <div
+                class="remirror-table-controller-mark-column-corner"
+              />
+            </div>
+          </th>
+          <td>
+            <p>
+              Row 2, Column 1
+            </p>
+          </td>
+          <td>
+            <p>
+              Row 2, Column 2
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div />
+  </div>
 </div>
 `;
 

--- a/packages/remirror__extension-markdown/__tests__/markdown-extension.spec.ts
+++ b/packages/remirror__extension-markdown/__tests__/markdown-extension.spec.ts
@@ -5,8 +5,10 @@ import {
   HeadingExtension,
   ItalicExtension,
   OrderedListExtension,
+  TableExtension,
   TaskListExtension,
 } from 'remirror/extensions';
+import { TableExtension as ReactTableExtension } from '@remirror/extension-react-tables';
 
 import { MarkdownExtension } from '../';
 
@@ -161,6 +163,99 @@ Task list
       .selectText('end')
       .run();
     expect(editor.state.doc).toEqualProsemirrorNode(doc(p('Content '), p(bold('is bold.'))));
+    expect(editor.dom).toMatchSnapshot();
+  });
+
+  it('can insert basic tables from markdown', () => {
+    const editor = renderEditor([new TableExtension(), new MarkdownExtension()]);
+    const { doc, p, table, tableRow: tr, tableHeaderCell: th, tableCell: td } = editor.nodes;
+
+    editor.add(doc(p('<cursor>')));
+
+    const markdown = `
+| Column 1 | Column 2 |
+| --- | --- |
+| Row 1, Column 1 | Row 1, Column 2 |
+| Row 2, Column 1 | Row 2, Column 2 |`;
+
+    editor.chain.insertMarkdown(markdown).selectText('end').run();
+    expect(editor.state.doc).toEqualProsemirrorNode(
+      doc(
+        //
+        table(
+          tr(
+            //
+            th(p('Column 1')),
+            th(p('Column 2')),
+          ),
+          tr(
+            //
+            td(p('Row 1, Column 1')),
+            td(p('Row 1, Column 2')),
+          ),
+          tr(
+            //
+            td(p('Row 2, Column 1')),
+            td(p('Row 2, Column 2')),
+          ),
+        ),
+      ),
+    );
+    expect(editor.dom).toMatchSnapshot();
+  });
+
+  it('can insert react tables from markdown', () => {
+    const editor = renderEditor([new ReactTableExtension(), new MarkdownExtension()]);
+    const {
+      doc,
+      p,
+      tableRow: tr,
+      tableHeaderCell: th,
+      tableCell: td,
+      tableControllerCell: tcc,
+    } = editor.nodes;
+    const { table } = editor.attributeNodes;
+
+    editor.add(doc(p('<cursor>')));
+
+    const markdown = `
+| Column 1 | Column 2 |
+| --- | --- |
+| Row 1, Column 1 | Row 1, Column 2 |
+| Row 2, Column 1 | Row 2, Column 2 |`;
+
+    editor.chain.insertMarkdown(markdown).selectText('end').run();
+    expect(editor.state.doc).toEqualProsemirrorNode(
+      doc(
+        //
+        table({ isControllersInjected: true })(
+          tr(
+            //
+            tcc(),
+            tcc(),
+            tcc(),
+          ),
+          tr(
+            //
+            tcc(),
+            th(p('Column 1')),
+            th(p('Column 2')),
+          ),
+          tr(
+            //
+            tcc(),
+            td(p('Row 1, Column 1')),
+            td(p('Row 1, Column 2')),
+          ),
+          tr(
+            //
+            tcc(),
+            td(p('Row 2, Column 1')),
+            td(p('Row 2, Column 2')),
+          ),
+        ),
+      ),
+    );
     expect(editor.dom).toMatchSnapshot();
   });
 });

--- a/packages/remirror__extension-markdown/package.json
+++ b/packages/remirror__extension-markdown/package.json
@@ -44,6 +44,7 @@
     "turndown-plugin-gfm": "^1.0.2"
   },
   "devDependencies": {
+    "@remirror/extension-react-tables": "^2.0.0-beta.9",
     "@remirror/pm": "^2.0.0-beta.9"
   },
   "peerDependencies": {

--- a/packages/remirror__extension-react-tables/src/components/table-components.tsx
+++ b/packages/remirror__extension-react-tables/src/components/table-components.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 import { TableCellMenu, TableCellMenuProps } from './table-cell-menu';
-import { TableDeleteRowColumnButton, TableDeleteRowColumnButtonProps } from './table-delete-button';
+import {
+  TableDeleteRowColumnButton,
+  TableDeleteRowColumnButtonProps,
+} from './table-delete-row-column-button';
+import { TableDeleteButton, TableDeleteButtonProps } from './table-delete-table-button';
 
 export interface TableComponentsProps {
   /**
@@ -27,21 +31,35 @@ export interface TableComponentsProps {
    * The props that will passed to `TableDeleteRowColumnButton`
    */
   tableDeleteRowColumnButtonProps?: TableDeleteRowColumnButtonProps;
+
+  /**
+   * Whether to use `TableDeleteButton`.
+   *
+   * @default true
+   */
+  enableTableDeleteButton?: boolean;
+
+  /**
+   * The props that will passed to `TableDeleteButton`
+   */
+  tableDeleteButtonProps?: TableDeleteButtonProps;
 }
 
-const defaultTableComponentsProps: TableComponentsProps = {
-  enableTableCellMenu: true,
-  enableTableDeleteRowColumnButton: true,
-};
-
-export const TableComponents: React.FC<TableComponentsProps> = (props) => {
-  props = { ...defaultTableComponentsProps, ...props };
+export const TableComponents: React.FC<TableComponentsProps> = ({
+  enableTableCellMenu = true,
+  enableTableDeleteRowColumnButton = true,
+  enableTableDeleteButton = true,
+  tableCellMenuProps,
+  tableDeleteRowColumnButtonProps,
+  tableDeleteButtonProps,
+}) => {
   return (
     <>
-      {props.enableTableCellMenu ? <TableCellMenu {...props.tableCellMenuProps} /> : null}
-      {props.enableTableDeleteRowColumnButton ? (
-        <TableDeleteRowColumnButton {...props.tableDeleteRowColumnButtonProps} />
-      ) : null}
+      {enableTableCellMenu && <TableCellMenu {...tableCellMenuProps} />}
+      {enableTableDeleteRowColumnButton && (
+        <TableDeleteRowColumnButton {...tableDeleteRowColumnButtonProps} />
+      )}
+      {enableTableDeleteButton && <TableDeleteButton {...tableDeleteButtonProps} />}
     </>
   );
 };

--- a/packages/remirror__extension-react-tables/src/components/table-delete-row-column-button.tsx
+++ b/packages/remirror__extension-react-tables/src/components/table-delete-row-column-button.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, MouseEventHandler, useCallback } from 'react';
 import type { EditorView, FindProsemirrorNodeResult } from '@remirror/core';
-import { findParentNodeOfType, isElementDomNode } from '@remirror/core';
+import { cx, findParentNodeOfType, isElementDomNode } from '@remirror/core';
 import {
   defaultAbsolutePosition,
   hasStateChanged,
@@ -115,6 +115,11 @@ export interface TableDeleteRowColumnInnerButtonProps {
   onClick: MouseEventHandler;
 
   /**
+   * The action when the mouse is pressed on the button.
+   */
+  onMouseDown: MouseEventHandler;
+
+  /**
    * The action when the mouse is over the button.
    */
   onMouseOver: MouseEventHandler;
@@ -128,29 +133,31 @@ export interface TableDeleteRowColumnInnerButtonProps {
 export const TableDeleteRowColumnInnerButton: React.FC<TableDeleteRowColumnInnerButtonProps> = ({
   position,
   onClick,
+  onMouseDown,
   onMouseOver,
   onMouseOut,
 }) => {
   const size = 18;
   return (
-    <div
+    <button
       ref={position.ref}
-      onMouseDown={(e) => {
-        // onClick doesn't work. I don't know why.
-        onClick(e);
-      }}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
       onMouseOver={onMouseOver}
       onMouseOut={onMouseOut}
       style={
         {
-          '--remirror-table-delete-button-y': `${position.y}px`,
-          '--remirror-table-delete-button-x': `${position.x}px`,
+          '--remirror-table-delete-row-column-button-y': `${position.y}px`,
+          '--remirror-table-delete-row-column-button-x': `${position.x}px`,
         } as CSSProperties
       }
-      className={ExtensionTablesTheme.TABLE_DELETE_ROW_COLUMN_INNER_BUTTON}
+      className={cx(
+        ExtensionTablesTheme.TABLE_DELETE_INNER_BUTTON,
+        ExtensionTablesTheme.TABLE_DELETE_ROW_COLUMN_INNER_BUTTON,
+      )}
     >
       <Icon name='closeFill' size={size} color={'#ffffff'} />
-    </div>
+    </button>
   );
 };
 
@@ -196,11 +203,16 @@ export const TableDeleteRowColumnButton: React.FC<TableDeleteRowColumnButtonProp
 
   Component = Component ?? TableDeleteRowColumnInnerButton;
 
+  const handleMouseDown: MouseEventHandler = useCallback((e) => {
+    e.preventDefault();
+  }, []);
+
   return (
     <PositionerPortal>
       <Component
         position={position}
         onClick={handleClick}
+        onMouseDown={handleMouseDown}
         onMouseOver={handleMouseOver}
         onMouseOut={handleMouseOut}
       />

--- a/packages/remirror__extension-react-tables/src/components/table-delete-table-button.tsx
+++ b/packages/remirror__extension-react-tables/src/components/table-delete-table-button.tsx
@@ -1,0 +1,207 @@
+import React, { CSSProperties, MouseEventHandler, useCallback } from 'react';
+import type { CommandFunction, FindProsemirrorNodeResult } from '@remirror/core';
+import { cx, findParentNodeOfType, isElementDomNode, last } from '@remirror/core';
+import {
+  defaultAbsolutePosition,
+  hasStateChanged,
+  isPositionVisible,
+  Positioner,
+} from '@remirror/extension-positioner';
+import { TableMap } from '@remirror/pm/tables';
+import { Icon, PositionerPortal } from '@remirror/react-components';
+import { useCommands } from '@remirror/react-core';
+import type { UsePositionerReturn } from '@remirror/react-hooks';
+import { usePositioner } from '@remirror/react-hooks';
+import { ExtensionTablesTheme } from '@remirror/theme';
+
+import { resetControllerPluginMeta, setControllerPluginMeta } from '../table-plugins';
+import { mergeDOMRects } from '../utils/dom';
+
+interface DeleteTableButtonPositionerData {
+  tableResult: FindProsemirrorNodeResult;
+}
+
+const highlightTable: CommandFunction = ({ tr, dispatch }) => {
+  const node = findParentNodeOfType({
+    types: 'table',
+    selection: tr.selection,
+  });
+
+  if (!node) {
+    return false;
+  }
+
+  dispatch?.(setControllerPluginMeta(tr, { preselectTable: true, predelete: true }));
+  return true;
+};
+
+const unhighlightTable: CommandFunction = ({ tr, dispatch }) => {
+  dispatch?.(resetControllerPluginMeta(tr));
+  return true;
+};
+
+function createDeleteTableButtonPositioner(): Positioner<DeleteTableButtonPositionerData> {
+  return Positioner.create<DeleteTableButtonPositionerData>({
+    hasChanged: hasStateChanged,
+
+    getActive(props) {
+      const { selection } = props.state;
+      const tableResult = findParentNodeOfType({ types: 'table', selection });
+
+      if (tableResult) {
+        const positionerData: DeleteTableButtonPositionerData = {
+          tableResult,
+        };
+        return [positionerData];
+      }
+
+      return Positioner.EMPTY;
+    },
+
+    getPosition(props) {
+      const { view, data } = props;
+
+      const { node, pos } = data.tableResult;
+      const map = TableMap.get(node);
+
+      const firstCellDOM = view.nodeDOM(pos + map.map[0] + 1);
+      const lastCellDOM = view.nodeDOM(pos + last(map.map) + 1);
+
+      if (
+        !firstCellDOM ||
+        !lastCellDOM ||
+        !isElementDomNode(firstCellDOM) ||
+        !isElementDomNode(lastCellDOM)
+      ) {
+        return defaultAbsolutePosition;
+      }
+
+      const rect = mergeDOMRects(
+        firstCellDOM.getBoundingClientRect(),
+        lastCellDOM.getBoundingClientRect(),
+      );
+      const editorRect = view.dom.getBoundingClientRect();
+
+      // The top and left relative to the parent `editorRect`.
+      const left = view.dom.scrollLeft + rect.left - editorRect.left;
+      const top = view.dom.scrollTop + rect.top - editorRect.top;
+      const visible = isPositionVisible(rect, view.dom);
+
+      const margin = 16;
+
+      return {
+        rect,
+        visible,
+        height: 0,
+        width: 0,
+        x: left + rect.width / 2,
+        y: top + rect.height + margin,
+      };
+    },
+  });
+}
+
+export interface TableDeleteInnerButtonProps {
+  /**
+   * The position of the button
+   */
+  position: UsePositionerReturn;
+
+  /**
+   * The action when the button is pressed.
+   */
+  onClick: MouseEventHandler;
+
+  /**
+   * The action when the mouse is pressed on the button.
+   */
+  onMouseDown: MouseEventHandler;
+
+  /**
+   * The action when the mouse is over the button.
+   */
+  onMouseEnter: MouseEventHandler;
+
+  /**
+   * The action when the mouse level the button.
+   */
+  onMouseLeave: MouseEventHandler;
+}
+
+export const TableDeleteInnerButton: React.FC<TableDeleteInnerButtonProps> = ({
+  position,
+  onClick,
+  onMouseDown,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  const size = 18;
+
+  return (
+    <button
+      ref={position.ref}
+      onClick={onClick}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={
+        {
+          '--remirror-table-delete-button-y': `${position.y}px`,
+          '--remirror-table-delete-button-x': `${position.x}px`,
+        } as CSSProperties
+      }
+      className={cx(
+        ExtensionTablesTheme.TABLE_DELETE_INNER_BUTTON,
+        ExtensionTablesTheme.TABLE_DELETE_TABLE_INNER_BUTTON,
+      )}
+    >
+      <Icon name='deleteBinLine' size={size} color={'#ffffff'} />
+    </button>
+  );
+};
+
+export interface TableDeleteButtonProps {
+  Component?: React.ComponentType<TableDeleteInnerButtonProps>;
+}
+
+const deleteButtonPositioner = createDeleteTableButtonPositioner();
+
+function usePosition() {
+  const position = usePositioner(deleteButtonPositioner, []);
+  return position;
+}
+
+export const TableDeleteButton: React.FC<TableDeleteButtonProps> = ({ Component }) => {
+  const position = usePosition();
+  const { customDispatch, deleteTable } = useCommands();
+
+  const handleMouseDown: MouseEventHandler = useCallback((e) => {
+    e.preventDefault();
+  }, []);
+
+  const handleMouseEnter: MouseEventHandler = useCallback(() => {
+    customDispatch(highlightTable);
+  }, [customDispatch]);
+
+  const handleMouseLeave: MouseEventHandler = useCallback(() => {
+    customDispatch(unhighlightTable);
+  }, [customDispatch]);
+
+  const handleClick = useCallback(() => {
+    deleteTable();
+  }, [deleteTable]);
+
+  Component = Component ?? TableDeleteInnerButton;
+
+  return (
+    <PositionerPortal>
+      <Component
+        position={position}
+        onClick={handleClick}
+        onMouseDown={handleMouseDown}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      />
+    </PositionerPortal>
+  );
+};

--- a/packages/remirror__extension-react-tables/src/index.ts
+++ b/packages/remirror__extension-react-tables/src/index.ts
@@ -1,7 +1,8 @@
 export type { TableCellMenuComponentProps, TableCellMenuProps } from './components/table-cell-menu';
 export { TableCellMenu } from './components/table-cell-menu';
 export { TableComponents } from './components/table-components';
-export * from './components/table-delete-button';
+export * from './components/table-delete-row-column-button';
+export * from './components/table-delete-table-button';
 export {
   TableCellExtension,
   TableControllerCellExtension,

--- a/packages/remirror__extension-react-tables/src/react-table-commands.ts
+++ b/packages/remirror__extension-react-tables/src/react-table-commands.ts
@@ -18,7 +18,7 @@ export function addColumn(
   { map, tableStart, table }: { map: TableMap; tableStart: number; table: ProsemirrorNode },
   col: number,
 ): Transaction {
-  const refColumn: number = col < map.width - 1 ? 0 : -1;
+  const refColumn: number = col < map.width ? 0 : -1;
 
   for (let row = 0; row < map.height; row++) {
     const index = row * map.width + col;

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -12,7 +12,6 @@ import {
   findChildren,
   getChangedNodes,
   isElementDomNode,
-  NodeExtension,
   NodeSpecOverride,
   NodeViewMethod,
   ProsemirrorNode,
@@ -24,6 +23,7 @@ import {
   createTable,
   createTableOptions,
   TableCellExtension as BaseTableCellExtension,
+  TableControllerCellExtension as BaseTableControllerCellExtension,
   TableExtension as BaseTableExtension,
   TableHeaderCellExtension as BaseTableHeaderCellExtension,
   TableRowExtension as BaseTableRowExtension,
@@ -332,11 +332,7 @@ export interface ReactTableControllerCellAttrs {
   background: null | string;
 }
 
-export class TableControllerCellExtension extends NodeExtension {
-  get name() {
-    return 'tableControllerCell' as const;
-  }
-
+export class TableControllerCellExtension extends BaseTableControllerCellExtension {
   createNodeSpec(extra: ApplySchemaAttributes): TableSchemaSpec {
     const cellAttrs = {
       ...extra.defaults(),

--- a/packages/remirror__extension-react-tables/src/table-plugins.ts
+++ b/packages/remirror__extension-react-tables/src/table-plugins.ts
@@ -56,12 +56,12 @@ export function getTableStyle(attrs: ControllerStateValues): string {
     `;
   } else if (attrs.preselectTable) {
     classNames = css`
-      & table.${ExtensionTablesTheme.TABLE} tbody tr {
+      &.${ExtensionTablesTheme.TABLE_PRESELECT_ALL} table.${ExtensionTablesTheme.TABLE} tbody tr {
         td,
         th {
           ${preselectClass};
         }
-        th.${ExtensionTablesTheme.TABLE_CONTROLLER}.${ExtensionTablesTheme.TABLE_CONTROLLER} {
+        th.${ExtensionTablesTheme.TABLE_CONTROLLER} {
           ${preselectControllerClass}
         }
       }
@@ -94,11 +94,15 @@ export function createTableControllerPlugin(): ProsemirrorPlugin<ControllerState
           return null;
         }
 
-        const { tableNodeResult, predelete } = controllerState.values;
+        const { tableNodeResult, predelete, preselectTable } = controllerState.values;
 
         if (tableNodeResult) {
           const styleClassName = getTableStyle(controllerState.values);
           let className = `${ExtensionTablesTheme.TABLE_SHOW_CONTROLLERS} ${styleClassName}`;
+
+          if (preselectTable) {
+            className += ` ${ExtensionTablesTheme.TABLE_PRESELECT_ALL}`;
+          }
 
           if (predelete) {
             className += ` ${ExtensionTablesTheme.TABLE_SHOW_PREDELETE}`;
@@ -162,4 +166,13 @@ class ControllerState {
 
 export function setControllerPluginMeta(tr: Transaction, props: ControllerStateProps): Transaction {
   return tr.setMeta(key, props);
+}
+
+export function resetControllerPluginMeta(tr: Transaction): Transaction {
+  return setControllerPluginMeta(tr, {
+    preselectRow: -1,
+    preselectColumn: -1,
+    preselectTable: false,
+    predelete: false,
+  });
 }

--- a/packages/remirror__extension-react-tables/src/utils/controller.ts
+++ b/packages/remirror__extension-react-tables/src/utils/controller.ts
@@ -29,6 +29,11 @@ export function injectControllers({
 
   const oldRows = oldTable.content;
   oldRows.forEach((oldRow) => {
+    if (oldRow.content.child(0).type === schema.nodes.tableControllerCell) {
+      newRowsArray.push(oldRow.copy());
+      return;
+    }
+
     const oldCells = oldRow.content;
     const newCells = Fragment.from(controllerCell).append(oldCells);
     const newRow = oldRow.copy(newCells);

--- a/packages/remirror__extension-react-tables/src/utils/controller.ts
+++ b/packages/remirror__extension-react-tables/src/utils/controller.ts
@@ -5,7 +5,7 @@ import { cellAround, CellSelection, TableMap } from '@remirror/pm/tables';
 
 import { domCellAround } from '../table-column-resizing';
 import { ReactTableNodeAttrs } from '../table-extensions';
-import { setControllerPluginMeta } from '../table-plugins';
+import { resetControllerPluginMeta, setControllerPluginMeta } from '../table-plugins';
 import { Events } from '../utils/jsx';
 import { cellSelectionToSelection } from '../utils/prosemirror';
 import { repeat } from './array';
@@ -91,7 +91,7 @@ export function createControllerEvents({
       }
     },
     onMouseLeave: () => {
-      resetControllerPluginMeta(view);
+      resetPreselection(view);
     },
   };
 }
@@ -171,15 +171,8 @@ export function setPredelete(view: EditorView, value: boolean): void {
   view.dispatch(setControllerPluginMeta(view.state.tr, { predelete: value }));
 }
 
-function resetControllerPluginMeta(view: EditorView): void {
-  view.dispatch(
-    setControllerPluginMeta(view.state.tr, {
-      preselectRow: -1,
-      preselectColumn: -1,
-      preselectTable: false,
-      predelete: false,
-    }),
-  );
+function resetPreselection(view: EditorView): void {
+  view.dispatch(resetControllerPluginMeta(view.state.tr));
 }
 
 function getCellIndex(map: TableMap, rowIndex: number, colIndex: number): number {

--- a/packages/remirror__extension-react-tables/src/utils/dom.ts
+++ b/packages/remirror__extension-react-tables/src/utils/dom.ts
@@ -14,7 +14,7 @@ export function stopEvent(e: Pick<MouseEvent, 'preventDefault' | 'stopPropagatio
  */
 export function mergeDOMRects(rect1: DOMRect, rect2: DOMRect): DOMRect {
   const left = Math.min(rect1.left, rect2.left);
-  const right = Math.min(rect1.right, rect2.right);
+  const right = Math.max(rect1.right, rect2.right);
   const top = Math.min(rect1.top, rect2.top);
   const bottom = Math.max(rect1.bottom, rect2.bottom);
   const width = right - left;

--- a/packages/remirror__extension-react-tables/src/views/table-view.tsx
+++ b/packages/remirror__extension-react-tables/src/views/table-view.tsx
@@ -47,7 +47,15 @@ export class TableView implements NodeView {
       { className: ExtensionTablesTheme.TABLE_COLGROUP },
       ...range(this.map.width).map(() => h('col')),
     );
-    this.table = h('table', { className: ExtensionTablesTheme.TABLE }, this.colgroup, this.tbody);
+    this.table = h(
+      'table',
+      {
+        className: ExtensionTablesTheme.TABLE,
+        dataset: { controllersInjected: '' },
+      },
+      this.colgroup,
+      this.tbody,
+    );
     this.insertButtonWrapper = h('div');
     this.root = h('div', null, this.table, this.insertButtonWrapper);
 

--- a/packages/remirror__extension-tables/src/index.ts
+++ b/packages/remirror__extension-tables/src/index.ts
@@ -1,6 +1,7 @@
 export type { TableOptions } from './table-extensions';
 export {
   TableCellExtension,
+  TableControllerCellExtension,
   TableExtension,
   TableHeaderCellExtension,
   TableRowExtension,

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -1,5 +1,4 @@
 import {
-  AnyExtension,
   ApplySchemaAttributes,
   command,
   CommandFunction,
@@ -91,7 +90,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
    * Create the table extensions. Set the priority to low so that they appear
    * lower down in the node list.
    */
-  createExtensions(): AnyExtension[] {
+  createExtensions() {
     return [new TableRowExtension({ priority: ExtensionPriority.Low })];
   }
 
@@ -337,7 +336,9 @@ export class TableRowExtension extends NodeExtension {
    * `TableHeaderCellExtension`. This is placed here so that this extension can
    * be tested independently from the `TableExtension`.
    */
-  createExtensions(): AnyExtension[] {
+  createExtensions(): Array<
+    TableCellExtension | TableHeaderCellExtension | TableControllerCellExtension
+  > {
     return [
       new TableCellExtension({ priority: ExtensionPriority.Low }),
       new TableHeaderCellExtension({ priority: ExtensionPriority.Low }),
@@ -374,6 +375,22 @@ export class TableHeaderCellExtension extends NodeExtension {
 
   createNodeSpec(extra: ApplySchemaAttributes, override: NodeSpecOverride): TableSchemaSpec {
     return createTableNodeSchema(extra, override).tableHeaderCell;
+  }
+}
+
+/**
+ * This is not used in the basic table extension, but is required for this React Tables extension that extends this
+ */
+@extension({ defaultPriority: ExtensionPriority.Low })
+export class TableControllerCellExtension extends NodeExtension {
+  get name() {
+    return 'tableControllerCell' as const;
+  }
+
+  createNodeSpec(_: ApplySchemaAttributes, __: NodeSpecOverride): TableSchemaSpec {
+    return {
+      tableRole: 'header_cell',
+    };
   }
 }
 

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -1,4 +1,5 @@
 import {
+  AnyExtension,
   ApplySchemaAttributes,
   command,
   CommandFunction,
@@ -90,7 +91,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
    * Create the table extensions. Set the priority to low so that they appear
    * lower down in the node list.
    */
-  createExtensions() {
+  createExtensions(): AnyExtension[] {
     return [new TableRowExtension({ priority: ExtensionPriority.Low })];
   }
 
@@ -336,7 +337,7 @@ export class TableRowExtension extends NodeExtension {
    * `TableHeaderCellExtension`. This is placed here so that this extension can
    * be tested independently from the `TableExtension`.
    */
-  createExtensions() {
+  createExtensions(): AnyExtension[] {
     return [
       new TableCellExtension({ priority: ExtensionPriority.Low }),
       new TableHeaderCellExtension({ priority: ExtensionPriority.Low }),

--- a/packages/remirror__extension-tables/src/table-utils.ts
+++ b/packages/remirror__extension-tables/src/table-utils.ts
@@ -111,7 +111,7 @@ export function createTableNodeSchema(
       tableRole: 'table',
       parseDOM: [{ tag: 'table', getAttrs: extra.parse }, ...(override.parseDOM ?? [])],
       toDOM(node) {
-        return ['table', ['tbody', extra.dom(node), 0]];
+        return ['table', extra.dom(node), ['tbody', 0]];
       },
     },
 

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -3868,9 +3868,9 @@ button:active .remirror-menu-pane-shortcut,
   fill: #ffffff;
 }
 
-.remirror-table-delete-row-column-inner-button {
-  top: calc(var(--remirror-table-delete-button-y) - 9px);
-  left: calc(var(--remirror-table-delete-button-x) - 9px);
+.remirror-table-delete-inner-button {
+  border: none;
+  padding: 0;
   width: 18px;
   height: 18px;
 
@@ -3882,13 +3882,24 @@ button:active .remirror-menu-pane-shortcut,
   transition: background-color 150ms ease;
 }
 
-.remirror-table-delete-row-column-inner-button:hover {
+.remirror-table-delete-inner-button:hover {
   background-color: #ff7884;
+}
+
+.remirror-table-delete-table-inner-button {
+  top: calc(var(--remirror-table-delete-button-y) - 9px);
+  left: calc(var(--remirror-table-delete-button-x) - 9px);
+}
+
+.remirror-table-delete-row-column-inner-button {
+  top: calc(var(--remirror-table-delete-row-column-button-y) - 9px);
+  left: calc(var(--remirror-table-delete-row-column-button-x) - 9px);
 }
 
 .remirror-table-with-controllers {
   /* Space for marks */
   margin-top: 40px;
+  margin-bottom: 40px;
 
   /* To make controller's 'height: 100%' works, table must set its own height. */
   height: 1px;
@@ -4102,16 +4113,29 @@ button:active .remirror-menu-pane-shortcut,
   background-color: var(--rmr-color-table-selected-controller);
 }
 
-/* Styles for predelete */
-
-.remirror-table-show-predelete th.selectedCell.selectedCell.remirror-table-controller {
-  background-color: var(--rmr-color-table-predelete-controller);
+.remirror-table-preselect-all {
 }
 
-.remirror-table-show-predelete th.selectedCell.selectedCell,
-.remirror-table-show-predelete td.selectedCell.selectedCell {
-  border-color: var(--rmr-color-table-predelete-border);
-  background-color: var(--rmr-color-table-predelete-cell);
+/* Styles for predelete */
+
+.remirror-table-show-predelete th.selectedCell.remirror-table-controller,
+.remirror-table-show-predelete td.selectedCell {
+  border-color: var(--rmr-color-table-predelete-border) !important;
+  background-color: var(--rmr-color-table-predelete-cell) !important;
+}
+
+.remirror-table-show-predelete th.selectedCell.remirror-table-controller {
+  background-color: var(--rmr-color-table-predelete-controller) !important;
+}
+
+.remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller,
+.remirror-table-show-predelete.remirror-table-preselect-all td {
+  border-color: var(--rmr-color-table-predelete-border) !important;
+  background-color: var(--rmr-color-table-predelete-cell) !important;
+}
+
+.remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller {
+  background-color: var(--rmr-color-table-predelete-controller) !important;
 }
 
 /**

--- a/packages/remirror__styles/extension-tables.css
+++ b/packages/remirror__styles/extension-tables.css
@@ -94,9 +94,9 @@
   fill: #ffffff;
 }
 
-.remirror-table-delete-row-column-inner-button {
-  top: calc(var(--remirror-table-delete-button-y) - 9px);
-  left: calc(var(--remirror-table-delete-button-x) - 9px);
+.remirror-table-delete-inner-button {
+  border: none;
+  padding: 0;
   width: 18px;
   height: 18px;
 
@@ -108,13 +108,24 @@
   transition: background-color 150ms ease;
 }
 
-.remirror-table-delete-row-column-inner-button:hover {
+.remirror-table-delete-inner-button:hover {
   background-color: #ff7884;
+}
+
+.remirror-table-delete-table-inner-button {
+  top: calc(var(--remirror-table-delete-button-y) - 9px);
+  left: calc(var(--remirror-table-delete-button-x) - 9px);
+}
+
+.remirror-table-delete-row-column-inner-button {
+  top: calc(var(--remirror-table-delete-row-column-button-y) - 9px);
+  left: calc(var(--remirror-table-delete-row-column-button-x) - 9px);
 }
 
 .remirror-table-with-controllers {
   /* Space for marks */
   margin-top: 40px;
+  margin-bottom: 40px;
 
   /* To make controller's 'height: 100%' works, table must set its own height. */
   height: 1px;
@@ -328,14 +339,27 @@
   background-color: var(--rmr-color-table-selected-controller);
 }
 
-/* Styles for predelete */
-
-.remirror-table-show-predelete th.selectedCell.selectedCell.remirror-table-controller {
-  background-color: var(--rmr-color-table-predelete-controller);
+.remirror-table-preselect-all {
 }
 
-.remirror-table-show-predelete th.selectedCell.selectedCell,
-.remirror-table-show-predelete td.selectedCell.selectedCell {
-  border-color: var(--rmr-color-table-predelete-border);
-  background-color: var(--rmr-color-table-predelete-cell);
+/* Styles for predelete */
+
+.remirror-table-show-predelete th.selectedCell.remirror-table-controller,
+.remirror-table-show-predelete td.selectedCell {
+  border-color: var(--rmr-color-table-predelete-border) !important;
+  background-color: var(--rmr-color-table-predelete-cell) !important;
+}
+
+.remirror-table-show-predelete th.selectedCell.remirror-table-controller {
+  background-color: var(--rmr-color-table-predelete-controller) !important;
+}
+
+.remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller,
+.remirror-table-show-predelete.remirror-table-preselect-all td {
+  border-color: var(--rmr-color-table-predelete-border) !important;
+  background-color: var(--rmr-color-table-predelete-cell) !important;
+}
+
+.remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller {
+  background-color: var(--rmr-color-table-predelete-controller) !important;
 }

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -3907,9 +3907,9 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     fill: #ffffff;
   }
 
-  .remirror-table-delete-row-column-inner-button {
-    top: calc(var(--remirror-table-delete-button-y) - 9px);
-    left: calc(var(--remirror-table-delete-button-x) - 9px);
+  .remirror-table-delete-inner-button {
+    border: none;
+    padding: 0;
     width: 18px;
     height: 18px;
 
@@ -3921,13 +3921,24 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     transition: background-color 150ms ease;
   }
 
-  .remirror-table-delete-row-column-inner-button:hover {
+  .remirror-table-delete-inner-button:hover {
     background-color: #ff7884;
+  }
+
+  .remirror-table-delete-table-inner-button {
+    top: calc(var(--remirror-table-delete-button-y) - 9px);
+    left: calc(var(--remirror-table-delete-button-x) - 9px);
+  }
+
+  .remirror-table-delete-row-column-inner-button {
+    top: calc(var(--remirror-table-delete-row-column-button-y) - 9px);
+    left: calc(var(--remirror-table-delete-row-column-button-x) - 9px);
   }
 
   .remirror-table-with-controllers {
     /* Space for marks */
     margin-top: 40px;
+    margin-bottom: 40px;
 
     /* To make controller's 'height: 100%' works, table must set its own height. */
     height: 1px;
@@ -4141,16 +4152,29 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     background-color: var(--rmr-color-table-selected-controller);
   }
 
-  /* Styles for predelete */
-
-  .remirror-table-show-predelete th.selectedCell.selectedCell.remirror-table-controller {
-    background-color: var(--rmr-color-table-predelete-controller);
+  .remirror-table-preselect-all {
   }
 
-  .remirror-table-show-predelete th.selectedCell.selectedCell,
-  .remirror-table-show-predelete td.selectedCell.selectedCell {
-    border-color: var(--rmr-color-table-predelete-border);
-    background-color: var(--rmr-color-table-predelete-cell);
+  /* Styles for predelete */
+
+  .remirror-table-show-predelete th.selectedCell.remirror-table-controller,
+  .remirror-table-show-predelete td.selectedCell {
+    border-color: var(--rmr-color-table-predelete-border) !important;
+    background-color: var(--rmr-color-table-predelete-cell) !important;
+  }
+
+  .remirror-table-show-predelete th.selectedCell.remirror-table-controller {
+    background-color: var(--rmr-color-table-predelete-controller) !important;
+  }
+
+  .remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller,
+  .remirror-table-show-predelete.remirror-table-preselect-all td {
+    border-color: var(--rmr-color-table-predelete-border) !important;
+    background-color: var(--rmr-color-table-predelete-cell) !important;
+  }
+
+  .remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller {
+    background-color: var(--rmr-color-table-predelete-controller) !important;
   }
 `;
 

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -3969,9 +3969,9 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     fill: #ffffff;
   }
 
-  .remirror-table-delete-row-column-inner-button {
-    top: calc(var(--remirror-table-delete-button-y) - 9px);
-    left: calc(var(--remirror-table-delete-button-x) - 9px);
+  .remirror-table-delete-inner-button {
+    border: none;
+    padding: 0;
     width: 18px;
     height: 18px;
 
@@ -3983,13 +3983,24 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     transition: background-color 150ms ease;
   }
 
-  .remirror-table-delete-row-column-inner-button:hover {
+  .remirror-table-delete-inner-button:hover {
     background-color: #ff7884;
+  }
+
+  .remirror-table-delete-table-inner-button {
+    top: calc(var(--remirror-table-delete-button-y) - 9px);
+    left: calc(var(--remirror-table-delete-button-x) - 9px);
+  }
+
+  .remirror-table-delete-row-column-inner-button {
+    top: calc(var(--remirror-table-delete-row-column-button-y) - 9px);
+    left: calc(var(--remirror-table-delete-row-column-button-x) - 9px);
   }
 
   .remirror-table-with-controllers {
     /* Space for marks */
     margin-top: 40px;
+    margin-bottom: 40px;
 
     /* To make controller's 'height: 100%' works, table must set its own height. */
     height: 1px;
@@ -4203,16 +4214,29 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     background-color: var(--rmr-color-table-selected-controller);
   }
 
-  /* Styles for predelete */
-
-  .remirror-table-show-predelete th.selectedCell.selectedCell.remirror-table-controller {
-    background-color: var(--rmr-color-table-predelete-controller);
+  .remirror-table-preselect-all {
   }
 
-  .remirror-table-show-predelete th.selectedCell.selectedCell,
-  .remirror-table-show-predelete td.selectedCell.selectedCell {
-    border-color: var(--rmr-color-table-predelete-border);
-    background-color: var(--rmr-color-table-predelete-cell);
+  /* Styles for predelete */
+
+  .remirror-table-show-predelete th.selectedCell.remirror-table-controller,
+  .remirror-table-show-predelete td.selectedCell {
+    border-color: var(--rmr-color-table-predelete-border) !important;
+    background-color: var(--rmr-color-table-predelete-cell) !important;
+  }
+
+  .remirror-table-show-predelete th.selectedCell.remirror-table-controller {
+    background-color: var(--rmr-color-table-predelete-controller) !important;
+  }
+
+  .remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller,
+  .remirror-table-show-predelete.remirror-table-preselect-all td {
+    border-color: var(--rmr-color-table-predelete-border) !important;
+    background-color: var(--rmr-color-table-predelete-cell) !important;
+  }
+
+  .remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller {
+    background-color: var(--rmr-color-table-predelete-controller) !important;
   }
 `;
 

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -3968,9 +3968,9 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     fill: #ffffff;
   }
 
-  .remirror-table-delete-row-column-inner-button {
-    top: calc(var(--remirror-table-delete-button-y) - 9px);
-    left: calc(var(--remirror-table-delete-button-x) - 9px);
+  .remirror-table-delete-inner-button {
+    border: none;
+    padding: 0;
     width: 18px;
     height: 18px;
 
@@ -3982,13 +3982,24 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     transition: background-color 150ms ease;
   }
 
-  .remirror-table-delete-row-column-inner-button:hover {
+  .remirror-table-delete-inner-button:hover {
     background-color: #ff7884;
+  }
+
+  .remirror-table-delete-table-inner-button {
+    top: calc(var(--remirror-table-delete-button-y) - 9px);
+    left: calc(var(--remirror-table-delete-button-x) - 9px);
+  }
+
+  .remirror-table-delete-row-column-inner-button {
+    top: calc(var(--remirror-table-delete-row-column-button-y) - 9px);
+    left: calc(var(--remirror-table-delete-row-column-button-x) - 9px);
   }
 
   .remirror-table-with-controllers {
     /* Space for marks */
     margin-top: 40px;
+    margin-bottom: 40px;
 
     /* To make controller's 'height: 100%' works, table must set its own height. */
     height: 1px;
@@ -4202,16 +4213,29 @@ export const extensionTablesStyledCss: ReturnType<typeof css> = css`
     background-color: var(--rmr-color-table-selected-controller);
   }
 
-  /* Styles for predelete */
-
-  .remirror-table-show-predelete th.selectedCell.selectedCell.remirror-table-controller {
-    background-color: var(--rmr-color-table-predelete-controller);
+  .remirror-table-preselect-all {
   }
 
-  .remirror-table-show-predelete th.selectedCell.selectedCell,
-  .remirror-table-show-predelete td.selectedCell.selectedCell {
-    border-color: var(--rmr-color-table-predelete-border);
-    background-color: var(--rmr-color-table-predelete-cell);
+  /* Styles for predelete */
+
+  .remirror-table-show-predelete th.selectedCell.remirror-table-controller,
+  .remirror-table-show-predelete td.selectedCell {
+    border-color: var(--rmr-color-table-predelete-border) !important;
+    background-color: var(--rmr-color-table-predelete-cell) !important;
+  }
+
+  .remirror-table-show-predelete th.selectedCell.remirror-table-controller {
+    background-color: var(--rmr-color-table-predelete-controller) !important;
+  }
+
+  .remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller,
+  .remirror-table-show-predelete.remirror-table-preselect-all td {
+    border-color: var(--rmr-color-table-predelete-border) !important;
+    background-color: var(--rmr-color-table-predelete-cell) !important;
+  }
+
+  .remirror-table-show-predelete.remirror-table-preselect-all th.remirror-table-controller {
+    background-color: var(--rmr-color-table-predelete-controller) !important;
   }
 `;
 

--- a/packages/remirror__theme/src/extension-tables-theme.ts
+++ b/packages/remirror__theme/src/extension-tables-theme.ts
@@ -269,9 +269,9 @@ export const TABLE_INSERT_BUTTON = css`
   }
 ` as `remirror-table-insert-button`;
 
-export const TABLE_DELETE_ROW_COLUMN_INNER_BUTTON = css`
-  top: calc(var(--remirror-table-delete-button-y) - 9px);
-  left: calc(var(--remirror-table-delete-button-x) - 9px);
+export const TABLE_DELETE_INNER_BUTTON = css`
+  border: none;
+  padding: 0;
   width: 18px;
   height: 18px;
 
@@ -284,11 +284,22 @@ export const TABLE_DELETE_ROW_COLUMN_INNER_BUTTON = css`
   &:hover {
     background-color: #ff7884;
   }
+` as 'remirror-table-delete-inner-button';
+
+export const TABLE_DELETE_TABLE_INNER_BUTTON = css`
+  top: calc(var(--remirror-table-delete-button-y) - 9px);
+  left: calc(var(--remirror-table-delete-button-x) - 9px);
+` as 'remirror-table-delete-row-column-inner-button';
+
+export const TABLE_DELETE_ROW_COLUMN_INNER_BUTTON = css`
+  top: calc(var(--remirror-table-delete-row-column-button-y) - 9px);
+  left: calc(var(--remirror-table-delete-row-column-button-x) - 9px);
 ` as 'remirror-table-delete-row-column-inner-button';
 
 export const TABLE_WITH_CONTROLLERS = css`
   /* Space for marks */
   margin-top: 40px;
+  margin-bottom: 40px;
 
   /* To make controller's 'height: 100%' works, table must set its own height. */
   height: 1px;
@@ -344,15 +355,29 @@ export const TABLE_TBODY_WITH_CONTROLLERS = css`
   }
 ` as 'remirror-table-tbody-with-controllers';
 
+export const TABLE_PRESELECT_ALL = css`
+  & {
+  }
+` as 'remirror-table-preselect-all';
+
 export const TABLE_SHOW_PREDELETE = css`
   /* Styles for predelete */
   & {
-    th.${SELECTED_CELL}.${SELECTED_CELL}.${TABLE_CONTROLLER} {
-      background-color: ${getThemeVar('color', 'table', 'predelete', 'controller')};
+    th.${SELECTED_CELL}.${TABLE_CONTROLLER}, td.${SELECTED_CELL} {
+      border-color: ${getThemeVar('color', 'table', 'predelete', 'border')} !important;
+      background-color: ${getThemeVar('color', 'table', 'predelete', 'cell')} !important;
     }
-    th.${SELECTED_CELL}.${SELECTED_CELL}, td.${SELECTED_CELL}.${SELECTED_CELL} {
-      border-color: ${getThemeVar('color', 'table', 'predelete', 'border')};
-      background-color: ${getThemeVar('color', 'table', 'predelete', 'cell')};
+    th.${SELECTED_CELL}.${TABLE_CONTROLLER} {
+      background-color: ${getThemeVar('color', 'table', 'predelete', 'controller')} !important;
+    }
+  }
+  &.${TABLE_PRESELECT_ALL} {
+    th.${TABLE_CONTROLLER}, td {
+      border-color: ${getThemeVar('color', 'table', 'predelete', 'border')} !important;
+      background-color: ${getThemeVar('color', 'table', 'predelete', 'cell')} !important;
+    }
+    th.${TABLE_CONTROLLER} {
+      background-color: ${getThemeVar('color', 'table', 'predelete', 'controller')} !important;
     }
   }
 ` as 'remirror-table-show-predelete';

--- a/packages/storybook-react/stories/extension-react-tables/basic.tsx
+++ b/packages/storybook-react/stories/extension-react-tables/basic.tsx
@@ -123,7 +123,7 @@ const Table = ({
   children?: React.ReactElement;
   extensions: () => AnyExtension[];
 }): JSX.Element => {
-  const { manager, state } = useRemirror({ extensions, core: { excludeExtensions: ['history'] } });
+  const { manager, state } = useRemirror({ extensions });
 
   return (
     <ThemeProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,7 +190,7 @@ importers:
       eslint-formatter-github: 1.0.11_eslint@8.1.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.1.0
       eslint-plugin-graphql: 4.0.0_4e9b1df3bf7ed4eb3e79f082030c8779
-      eslint-plugin-import: 2.25.2_eslint@8.1.0
+      eslint-plugin-import: 2.25.2_e2137ade58b543557c1b4cbce3ad1f4c
       eslint-plugin-jest: 26.5.3_e94fc532e2f762ba0849ef19dd45feab
       eslint-plugin-jest-formatting: 3.1.0_eslint@8.1.0
       eslint-plugin-jsx-a11y: 6.4.1_eslint@8.1.0
@@ -1247,6 +1247,7 @@ importers:
     specifiers:
       '@babel/runtime': ^7.13.10
       '@remirror/core': ^2.0.0-beta.9
+      '@remirror/extension-react-tables': ^2.0.0-beta.9
       '@remirror/messages': ^2.0.0-beta.9
       '@remirror/pm': ^2.0.0-beta.9
       '@types/marked': ^4.0.2
@@ -1264,6 +1265,7 @@ importers:
       turndown: 7.1.1
       turndown-plugin-gfm: 1.0.2
     devDependencies:
+      '@remirror/extension-react-tables': link:../remirror__extension-react-tables
       '@remirror/pm': link:../remirror__pm
 
   packages/remirror__extension-mention:
@@ -5891,7 +5893,6 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@ffmpeg-installer/darwin-arm64/4.1.5:
     resolution: {integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==}
@@ -6180,11 +6181,9 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@humanwhocodes/object-schema/1.2.0:
     resolution: {integrity: sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==}
-    dev: false
 
   /@iarna/toml/2.2.5:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -6916,6 +6915,8 @@ packages:
       semver: 6.3.0
       spawndamnit: 2.0.0
       validate-npm-package-name: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@manypkg/find-root/1.1.0:
@@ -8109,7 +8110,7 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6
+      fork-ts-checker-webpack-plugin: 4.1.6_179b813bcdfbf064b625c3011939f25a
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
@@ -8134,6 +8135,7 @@ packages:
       webpack-hot-middleware: 2.25.1
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
+      - bluebird
       - eslint
       - supports-color
       - vue-template-compiler
@@ -8268,12 +8270,14 @@ packages:
       update-notifier: 5.1.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
+      - bufferutil
       - encoding
       - eslint
       - react
       - react-dom
       - supports-color
       - typescript
+      - utf-8-validate
       - vue-template-compiler
       - webpack-cli
       - webpack-command
@@ -8612,6 +8616,7 @@ packages:
       x-default-browser: 0.4.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
+      - bluebird
       - bufferutil
       - encoding
       - eslint
@@ -8648,6 +8653,7 @@ packages:
       typescript: 4.5.5
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
+      - bluebird
       - bufferutil
       - encoding
       - eslint
@@ -8685,6 +8691,7 @@ packages:
       webpack: 5.73.0_@swc+core@1.2.204
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
+      - bluebird
       - bufferutil
       - encoding
       - eslint
@@ -8792,6 +8799,7 @@ packages:
       webpack-dev-middleware: 3.7.3_webpack@4.46.0
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
+      - bluebird
       - encoding
       - eslint
       - supports-color
@@ -9010,6 +9018,7 @@ packages:
       - '@storybook/mdx2-csf'
       - '@swc/core'
       - '@types/webpack'
+      - bluebird
       - bufferutil
       - encoding
       - esbuild
@@ -9347,7 +9356,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-android-arm64/1.2.204:
@@ -9356,7 +9364,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-arm64/1.2.204:
@@ -9365,7 +9372,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-darwin-x64/1.2.204:
@@ -9374,7 +9380,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-freebsd-x64/1.2.204:
@@ -9383,7 +9388,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm-gnueabihf/1.2.204:
@@ -9392,7 +9396,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-gnu/1.2.204:
@@ -9401,7 +9404,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-arm64-musl/1.2.204:
@@ -9410,7 +9412,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-gnu/1.2.204:
@@ -9419,7 +9420,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-linux-x64-musl/1.2.204:
@@ -9428,7 +9428,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-arm64-msvc/1.2.204:
@@ -9437,7 +9436,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-ia32-msvc/1.2.204:
@@ -9446,7 +9444,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core-win32-x64-msvc/1.2.204:
@@ -9455,7 +9452,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@swc/core/1.2.204:
@@ -9476,7 +9472,6 @@ packages:
       '@swc/core-win32-arm64-msvc': 1.2.204
       '@swc/core-win32-ia32-msvc': 1.2.204
       '@swc/core-win32-x64-msvc': 1.2.204
-    dev: false
 
   /@swc/jest/0.2.21_@swc+core@1.2.204:
     resolution: {integrity: sha512-/+NcExiZbxXANNhNPnIdFuGq62CeumulLS1bngwqIXd8H7d96LFUfrYzdt8tlTwLMel8tFtQ5aRjzVkyOTyPDw==}
@@ -10095,7 +10090,7 @@ packages:
     resolution: {integrity: sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.14
+      '@types/react': 18.0.15
     dev: true
 
   /@types/react-syntax-highlighter/11.0.5:
@@ -10324,7 +10319,6 @@ packages:
       - esbuild
       - uglify-js
       - webpack-cli
-    dev: false
 
   /@types/websocket/1.0.2:
     resolution: {integrity: sha512-B5m9aq7cbbD/5/jThEr33nUY8WEfVi6A2YKCTOvw5Ldy7mtsOkqRvGjnzy6g7iMMDsgu7xREuCzqATLDLQVKcQ==}
@@ -10900,7 +10894,6 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.5.0
-    dev: false
 
   /acorn-walk/6.2.0:
     resolution: {integrity: sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==}
@@ -11088,7 +11081,6 @@ packages:
   /ansi-colors/4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
-    dev: false
 
   /ansi-escapes/3.2.0:
     resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
@@ -11168,6 +11160,8 @@ packages:
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /anymatch/3.1.2:
@@ -11576,6 +11570,8 @@ packages:
     dependencies:
       follow-redirects: 1.5.10
       is-buffer: 2.0.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /axios/0.21.4:
@@ -11718,6 +11714,8 @@ packages:
       babel-template: 6.26.0
       resolve-from: 5.0.0
       svgo: 1.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /babel-plugin-istanbul/6.1.1:
@@ -11896,6 +11894,8 @@ packages:
       babel-types: 6.26.0
       babylon: 6.18.0
       lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /babel-traverse/6.26.0:
@@ -11910,6 +11910,8 @@ packages:
       globals: 9.18.0
       invariant: 2.2.4
       lodash: 4.17.21
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /babel-types/6.26.0:
@@ -12067,6 +12069,8 @@ packages:
       qs: 6.7.0
       raw-body: 2.4.0
       type-is: 1.6.18
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /body-parser/1.19.2:
@@ -12083,6 +12087,8 @@ packages:
       qs: 6.9.7
       raw-body: 2.4.3
       type-is: 1.6.18
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /body-scroll-lock/3.1.5:
@@ -12169,6 +12175,8 @@ packages:
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -12438,6 +12446,8 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
     dev: true
 
   /cacache/9.3.0:
@@ -12792,6 +12802,8 @@ packages:
       upath: 1.2.0
     optionalDependencies:
       fsevents: 1.2.13
+    transitivePeerDependencies:
+      - supports-color
     dev: true
     optional: true
 
@@ -13092,6 +13104,8 @@ packages:
       pacote: 2.7.38
       shortid: 2.2.16
       update-notifier: 2.5.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /collapse-white-space/1.0.6:
@@ -13284,6 +13298,8 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   /compute-scroll-into-view/1.0.17:
     resolution: {integrity: sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==}
@@ -13536,6 +13552,8 @@ packages:
     dependencies:
       cpy: 8.1.2
       meow: 6.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /cpy/8.1.2:
@@ -13551,6 +13569,8 @@ packages:
       p-all: 2.1.0
       p-filter: 2.1.0
       p-map: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /crc-32/1.2.0:
     resolution: {integrity: sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==}
@@ -14132,17 +14152,32 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
 
@@ -14422,6 +14457,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /detect-port/1.3.0:
@@ -14431,6 +14468,8 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
+    transitivePeerDependencies:
+      - supports-color
 
   /devtools-protocol/0.0.981744:
     resolution: {integrity: sha512-0cuGS8+jhR67Fy7qG3i3Pc7Aw494sb9yG9QgpG97SFVWwolgYjlhJg7n+UaHxOQT30d1TYu/EYe9k01ivLErIg==}
@@ -14851,7 +14890,6 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.1
-    dev: false
 
   /entities/1.1.2:
     resolution: {integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==}
@@ -15550,6 +15588,8 @@ packages:
     dependencies:
       debug: 2.6.9
       resolve: 1.20.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /eslint-import-resolver-node/0.3.6:
@@ -15557,15 +15597,35 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.20.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.1:
+  /eslint-module-utils/2.7.1_f5b339dce09b3a3d6cf14ed98a8b11b6:
     resolution: {integrity: sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.5.5
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
       pkg-dir: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /eslint-plugin-eslint-comments/3.2.0_eslint@8.1.0:
@@ -15597,19 +15657,24 @@ packages:
       - utf-8-validate
     dev: false
 
-  /eslint-plugin-import/2.25.2_eslint@8.1.0:
+  /eslint-plugin-import/2.25.2_e2137ade58b543557c1b4cbce3ad1f4c:
     resolution: {integrity: sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.5.5
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.1.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.1
+      eslint-module-utils: 2.7.1_f5b339dce09b3a3d6cf14ed98a8b11b6
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
@@ -15617,6 +15682,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.20.0
       tsconfig-paths: 3.11.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: false
 
   /eslint-plugin-jest-formatting/3.1.0_eslint@8.1.0:
@@ -15833,7 +15902,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: false
 
   /eslint-template-visitor/2.3.2_eslint@8.1.0:
     resolution: {integrity: sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==}
@@ -15858,17 +15926,14 @@ packages:
     dependencies:
       eslint: 8.1.0
       eslint-visitor-keys: 2.1.0
-    dev: false
 
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
-    dev: false
 
   /eslint-visitor-keys/3.3.0:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
 
   /eslint/8.1.0:
     resolution: {integrity: sha512-JZvNneArGSUsluHWJ8g8MMs3CfIEzwaLx9KyH4tZ2i+R2/rPWzL8c0zg3rHdwYVpN/1sB9gqnjHwz9HoeJpGHw==}
@@ -15915,7 +15980,6 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /esm/3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
@@ -15929,7 +15993,6 @@ packages:
       acorn: 8.5.0
       acorn-jsx: 5.3.2_acorn@8.5.0
       eslint-visitor-keys: 3.3.0
-    dev: false
 
   /esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -15941,7 +16004,6 @@ packages:
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
-    dev: false
 
   /esrecurse/4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -16140,6 +16202,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   /expand-template/2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -16213,6 +16277,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /express/4.17.3:
@@ -16249,6 +16315,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /ext/1.6.0:
@@ -16298,6 +16366,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   /extract-domain/2.2.1:
     resolution: {integrity: sha512-lOq1adCJha0tFFBci4quxC4XLa6+Rs2WgAwTo9qbO9OsElvJmGgCvOzmHo/yg5CiqeP4+sHjkXYGkrCcIEprMg==}
@@ -16316,6 +16386,8 @@ packages:
       debug: 2.6.9
       mkdirp: 0.5.5
       yauzl: 2.10.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /extract-zip/2.0.1:
@@ -16354,6 +16426,8 @@ packages:
       is-glob: 4.0.3
       merge2: 1.4.1
       micromatch: 3.1.10
+    transitivePeerDependencies:
+      - supports-color
 
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
@@ -16489,7 +16563,6 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.0.4
-    dev: false
 
   /file-loader/6.2.0_webpack@4.46.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
@@ -16573,6 +16646,8 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /find-cache-dir/2.1.0:
     resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
@@ -16665,6 +16740,8 @@ packages:
     dependencies:
       fs-extra: 4.0.3
       micromatch: 3.1.10
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /find-yarn-workspace-root2/1.2.16:
@@ -16740,6 +16817,8 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       debug: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /for-in/1.0.2:
@@ -16757,17 +16836,32 @@ packages:
     resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6:
+  /fork-ts-checker-webpack-plugin/4.1.6_179b813bcdfbf064b625c3011939f25a:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
+      eslint: 8.1.0
       micromatch: 3.1.10
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
+      typescript: 4.5.5
+      webpack: 4.46.0
       worker-rpc: 0.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /fork-ts-checker-webpack-plugin/6.5.1_179b813bcdfbf064b625c3011939f25a:
@@ -17055,7 +17149,6 @@ packages:
 
   /functional-red-black-tree/1.0.1:
     resolution: {integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=}
-    dev: false
 
   /functions-have-names/1.2.2:
     resolution: {integrity: sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==}
@@ -17194,6 +17287,8 @@ packages:
       fs-extra: 7.0.1
       globby: 9.2.0
       read-yaml-file: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /getpass/0.1.7:
@@ -17381,7 +17476,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
-    dev: false
 
   /globals/9.18.0:
     resolution: {integrity: sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==}
@@ -17455,6 +17549,8 @@ packages:
       ignore: 4.0.6
       pify: 4.0.1
       slash: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   /got/11.8.2:
     resolution: {integrity: sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==}
@@ -18033,6 +18129,8 @@ packages:
     dependencies:
       agent-base: 4.3.0
       debug: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /http-proxy-agent/4.0.1:
@@ -18117,6 +18215,8 @@ packages:
     dependencies:
       agent-base: 4.3.0
       debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /https-proxy-agent/4.0.0:
@@ -19410,6 +19510,8 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-haste-map/27.3.1:
@@ -20186,7 +20288,6 @@ packages:
 
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=}
-    dev: false
 
   /json-stringify-safe/5.0.1:
     resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
@@ -20438,7 +20539,6 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-    dev: false
 
   /lib0/0.2.43:
     resolution: {integrity: sha512-MJ1KLoz5p3gljIUBfdjjNuL/wlWHHK6+DrcIRhzSRLvtAu1XNdRtRGATYM51KSTI0P2nxJZFQM8rwCH6ga9KUw==}
@@ -20924,6 +21024,8 @@ packages:
       promise-retry: 1.1.1
       socks-proxy-agent: 3.0.1
       ssri: 5.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /make-plural/6.2.2:
@@ -21262,6 +21364,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   /micromatch/4.0.2:
     resolution: {integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==}
@@ -21632,6 +21736,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   /nanospinner/1.1.0:
     resolution: {integrity: sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==}
@@ -22165,7 +22271,6 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
-    dev: false
 
   /ora/1.4.0:
     resolution: {integrity: sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==}
@@ -22425,6 +22530,8 @@ packages:
       tar-stream: 1.6.2
       unique-filename: 1.1.1
       which: 1.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /pako/1.0.11:
@@ -23476,7 +23583,6 @@ packages:
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-    dev: false
 
   /prepend-http/1.0.4:
     resolution: {integrity: sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=}
@@ -23623,6 +23729,11 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}
@@ -23961,7 +24072,9 @@ packages:
       rimraf: 2.7.1
       ws: 6.2.2
     transitivePeerDependencies:
+      - bufferutil
       - supports-color
+      - utf-8-validate
     dev: true
 
   /pure-color/1.3.0:
@@ -24150,7 +24263,7 @@ packages:
       material-colors: 1.2.6
       prop-types: 15.8.1
       react: 18.0.0
-      reactcss: 1.2.3
+      reactcss: 1.2.3_react@18.0.0
       tinycolor2: 1.4.2
     dev: false
 
@@ -24184,6 +24297,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - eslint
+      - supports-color
       - typescript
       - vue-template-compiler
       - webpack
@@ -24331,6 +24445,9 @@ packages:
   /react-live/2.2.3_react-dom@18.0.0+react@18.0.0:
     resolution: {integrity: sha512-tpKruvfytNETuzO3o1mrQUj180GVrq35IE8F5gH1NJVPt4szYCx83/dOSCOyjgRhhc3gQvl0pQ3k/CjOjwJkKQ==}
     engines: {node: '>= 0.12.0', npm: '>= 2.0.0'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
     dependencies:
       buble: 0.19.6
       core-js: 2.6.12
@@ -24341,9 +24458,6 @@ packages:
       react-dom: 18.0.0_react@18.0.0
       react-simple-code-editor: 0.10.0_react-dom@18.0.0+react@18.0.0
       unescape: 1.0.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: true
 
   /react-loadable-ssr-addon-v5-slorber/1.0.1_7b827e45b1e51a8cc8793eccc648d09d:
@@ -24535,10 +24649,13 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /reactcss/1.2.3:
+  /reactcss/1.2.3_react@18.0.0:
     resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
+    peerDependencies:
+      react: '*'
     dependencies:
       lodash: 4.17.21
+      react: 18.0.0
     dev: false
 
   /read-cache/1.0.0:
@@ -24650,6 +24767,8 @@ packages:
       graceful-fs: 4.2.10
       micromatch: 3.1.10
       readable-stream: 2.3.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
     optional: true
 
@@ -24842,7 +24961,6 @@ packages:
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
-    dev: false
 
   /regexpu-core/4.8.0:
     resolution: {integrity: sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==}
@@ -25431,6 +25549,8 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.5
       walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /sanitize-html/2.5.2:
@@ -25607,6 +25727,8 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /send/0.17.2:
@@ -25626,6 +25748,8 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /serialize-javascript/4.0.0:
@@ -25680,6 +25804,8 @@ packages:
       http-errors: 1.6.3
       mime-types: 2.1.35
       parseurl: 1.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /serve-static/1.14.1:
@@ -25690,6 +25816,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.17.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /serve-static/1.14.2:
@@ -25700,6 +25828,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.17.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /set-blocking/2.0.0:
@@ -25961,6 +26091,8 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   /snapshot-diff/0.9.0_jest@28.1.1:
     resolution: {integrity: sha512-XF4TKCe3l1HWyBK7wsfzrQbCMupYkdDE+44++6D683hZXjHHQBSVRnBWu/SP5Nk5cj5vH5FbY47Z8hUbt7yq+Q==}
@@ -26951,6 +27083,8 @@ packages:
       terser: 5.12.1
       webpack: 4.46.0
       webpack-sources: 1.4.3
+    transitivePeerDependencies:
+      - bluebird
     dev: true
 
   /terser-webpack-plugin/5.3.1_@swc+core@1.2.204+webpack@5.73.0:
@@ -27421,7 +27555,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
-    dev: false
 
   /type-detect/4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -27502,7 +27635,6 @@ packages:
     resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /typescript/4.6.3:
     resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
@@ -27959,7 +28091,6 @@ packages:
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
-    dev: false
 
   /v8-to-istanbul/8.1.0:
     resolution: {integrity: sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==}
@@ -28272,6 +28403,8 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 2.1.8
+    transitivePeerDependencies:
+      - supports-color
     dev: true
     optional: true
 
@@ -28283,6 +28416,8 @@ packages:
     optionalDependencies:
       chokidar: 3.5.3
       watchpack-chokidar2: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /watchpack/2.3.1:
@@ -28496,6 +28631,8 @@ packages:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
     dependencies:
       debug: 3.2.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /webpack-virtual-modules/0.4.3:
@@ -28538,6 +28675,8 @@ packages:
       terser-webpack-plugin: 1.4.5_webpack@4.46.0
       watchpack: 1.7.5
       webpack-sources: 1.4.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /webpack/5.73.0_@swc+core@1.2.204:
@@ -28838,6 +28977,14 @@ packages:
 
   /ws/6.2.2:
     resolution: {integrity: sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dependencies:
       async-limiter: 1.0.1
     dev: true


### PR DESCRIPTION
### Description

Initialising editor content from HTML or Markdown, that included a React Table, did not initialise the table properly (tables controllers were never injected)

Additionally, copy and pasting a React table didn't check to see if controlled cells were already present. Leading them to be duplicated. (cc @ronnyroeller) 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
