### PR TITLE
fix(extension-react-component): use Array.from for portals.entries()

### DIFF
--- a/packages/remirror__extension-react-component/src/portals/react-portals.tsx
+++ b/packages/remirror__extension-react-component/src/portals/react-portals.tsx
@@ -36,13 +36,15 @@ export interface RemirrorPortalsProps {
  * passed through to the `RemirrorPortals` component.
  */
 export function usePortals(portalContainer: PortalContainer): Array<[HTMLElement, MountedPortal]> {
-  const [portals, setPortals] = useState(() => [...portalContainer.portals.entries()]);
+  // eslint-disable-next-line unicorn/prefer-spread
+  const [portals, setPortals] = useState(() => Array.from(portalContainer.portals.entries()));
 
   // Dispose of all portals.
   useEffect(() => {
     // Auto disposed when the component un-mounts.
     return portalContainer.on((portalMap) => {
-      setPortals([...portalMap.entries()]);
+      // eslint-disable-next-line unicorn/prefer-spread
+      setPortals(Array.from(portalMap.entries()));
     });
   }, [portalContainer]);
 


### PR DESCRIPTION
Closes #1700

### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test extension-react-component`.

### Screenshots

<!-- Delete this section if not applicable -->
