### PR TITLE
feat: support leafText 

### DIFF
--- a/.changeset/few-keys-float.md
+++ b/.changeset/few-keys-float.md
@@ -1,0 +1,9 @@
+---
+'prosemirror-paste-rules': patch
+'prosemirror-resizable-view': patch
+'prosemirror-suggest': patch
+'prosemirror-trailing-node': patch
+'@remirror/pm': patch
+---
+
+Update ProseMirror packages to latest versions.

--- a/.changeset/thin-starfishes-unite.md
+++ b/.changeset/thin-starfishes-unite.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-hard-break': patch
+---
+
+Transform a hard break into `\n` in `Node.textContent`.

--- a/packages/prosemirror-paste-rules/package.json
+++ b/packages/prosemirror-paste-rules/package.json
@@ -41,9 +41,9 @@
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {
-    "prosemirror-model": "^1.17.0",
+    "prosemirror-model": "^1.18.0",
     "prosemirror-state": "^1.4.0",
-    "prosemirror-view": "^1.24.1"
+    "prosemirror-view": "^1.26.0"
   },
   "peerDependencies": {
     "prosemirror-model": "^1",

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -43,8 +43,8 @@
     "@babel/runtime": "^7.13.10",
     "@remirror/core-helpers": "^2.0.0-beta.0",
     "@remirror/core-utils": "^2.0.0-beta.0",
-    "prosemirror-model": "^1.17.0",
-    "prosemirror-view": "^1.24.1"
+    "prosemirror-model": "^1.18.0",
+    "prosemirror-view": "^1.26.0"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/packages/prosemirror-suggest/package.json
+++ b/packages/prosemirror-suggest/package.json
@@ -42,9 +42,9 @@
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {
-    "prosemirror-model": "^1.17.0",
+    "prosemirror-model": "^1.18.0",
     "prosemirror-state": "^1.4.0",
-    "prosemirror-view": "^1.24.1"
+    "prosemirror-view": "^1.26.0"
   },
   "peerDependencies": {
     "prosemirror-model": "^1",

--- a/packages/prosemirror-trailing-node/package.json
+++ b/packages/prosemirror-trailing-node/package.json
@@ -41,9 +41,9 @@
     "escape-string-regexp": "^4.0.0"
   },
   "devDependencies": {
-    "prosemirror-model": "^1.17.0",
+    "prosemirror-model": "^1.18.0",
     "prosemirror-state": "^1.4.0",
-    "prosemirror-view": "^1.24.1"
+    "prosemirror-view": "^1.26.0"
   },
   "peerDependencies": {
     "prosemirror-model": "^1",

--- a/packages/remirror__core-types/src/core-types.ts
+++ b/packages/remirror__core-types/src/core-types.ts
@@ -211,6 +211,7 @@ export interface NodeExtensionSpec
       | 'parseDOM'
       | 'toDebugString'
       | 'allowGapCursor'
+      | 'leafText'
     >
   > {
   /**

--- a/packages/remirror__core/src/builtins/node-views-extension.ts
+++ b/packages/remirror__core/src/builtins/node-views-extension.ts
@@ -45,7 +45,6 @@ export class NodeViewsExtension extends PlainExtension {
     }
 
     return {
-      // @ts-expect-error: the `nodeViews` seems to get the wrong type. https://discuss.prosemirror.net/t/prosemirror-is-now-a-typescript-project/4624/26
       props: { nodeViews },
     };
   }

--- a/packages/remirror__extension-hard-break/__tests__/hard-break-extension.spec.ts
+++ b/packages/remirror__extension-hard-break/__tests__/hard-break-extension.spec.ts
@@ -5,6 +5,23 @@ import { HardBreakExtension } from '../';
 
 extensionValidityTest(HardBreakExtension);
 
+describe('schema', () => {
+  it('should return the correct textContent', () => {
+    const { add, nodes, view } = renderEditor([new HardBreakExtension()]);
+    const { doc, hardBreak: br, p } = nodes;
+
+    const firstParagraph = p('First line', br(), 'Second line');
+
+    expect(firstParagraph.textContent).toBe('First line\nSecond line');
+
+    add(doc(firstParagraph, p('Second paragraph')));
+
+    expect(view.state.doc.textBetween(0, view.state.doc.content.size, '\n\n')).toBe(
+      'First line\nSecond line\n\nSecond paragraph',
+    );
+  });
+});
+
 describe('commands', () => {
   it('insertHardBreak', () => {
     const { add, nodes, commands, view } = renderEditor([new HardBreakExtension()]);

--- a/packages/remirror__extension-hard-break/src/hard-break-extension.ts
+++ b/packages/remirror__extension-hard-break/src/hard-break-extension.ts
@@ -49,6 +49,9 @@ export class HardBreakExtension extends NodeExtension {
       inline: true,
       selectable: false,
       atom: true,
+      leafText: () => {
+        return '\n';
+      },
       ...override,
       attrs: extra.defaults(),
       parseDOM: [{ tag: 'br', getAttrs: extra.parse }, ...(override.parseDOM ?? [])],

--- a/packages/remirror__pm/package.json
+++ b/packages/remirror__pm/package.json
@@ -168,19 +168,19 @@
     "prosemirror-collab": "^1.3.0",
     "prosemirror-commands": "^1.3.0",
     "prosemirror-dropcursor": "^1.5.0",
-    "prosemirror-gapcursor": "^1.3.0",
+    "prosemirror-gapcursor": "^1.3.1",
     "prosemirror-history": "^1.3.0",
     "prosemirror-inputrules": "^1.2.0",
     "prosemirror-keymap": "^1.2.0",
-    "prosemirror-model": "^1.17.0",
+    "prosemirror-model": "^1.18.0",
     "prosemirror-paste-rules": "^2.0.0-beta.0",
     "prosemirror-schema-list": "^1.2.0",
     "prosemirror-state": "^1.4.0",
     "prosemirror-suggest": "^2.0.0-beta.0",
     "prosemirror-tables": "^1.1.1",
     "prosemirror-trailing-node": "^2.0.0-beta.0",
-    "prosemirror-transform": "^1.5.0",
-    "prosemirror-view": "^1.24.1"
+    "prosemirror-transform": "^1.6.0",
+    "prosemirror-view": "^1.26.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
       '@babel/runtime': 7.17.9
     devDependencies:
       '@testing-library/react': 13.1.1_react@18.0.0
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   packages/docusaurus-plugin-examples:
@@ -368,7 +368,7 @@ importers:
       w3c-keyname: 2.2.4
     devDependencies:
       '@testing-library/react': 13.1.1_react@18.0.0
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   packages/prosemirror-paste-rules:
@@ -377,32 +377,32 @@ importers:
       '@remirror/core-constants': ^2.0.0-beta.0
       '@remirror/core-helpers': ^2.0.0-beta.0
       escape-string-regexp: ^4.0.0
-      prosemirror-model: ^1.17.0
+      prosemirror-model: ^1.18.0
       prosemirror-state: ^1.4.0
-      prosemirror-view: ^1.24.1
+      prosemirror-view: ^1.26.0
     dependencies:
       '@babel/runtime': 7.17.9
       '@remirror/core-constants': link:../remirror__core-constants
       '@remirror/core-helpers': link:../remirror__core-helpers
       escape-string-regexp: 4.0.0
     devDependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-view: 1.24.1
+      prosemirror-view: 1.26.0
 
   packages/prosemirror-resizable-view:
     specifiers:
       '@babel/runtime': ^7.13.10
       '@remirror/core-helpers': ^2.0.0-beta.0
       '@remirror/core-utils': ^2.0.0-beta.0
-      prosemirror-model: ^1.17.0
-      prosemirror-view: ^1.24.1
+      prosemirror-model: ^1.18.0
+      prosemirror-view: ^1.26.0
     dependencies:
       '@babel/runtime': 7.17.9
       '@remirror/core-helpers': link:../remirror__core-helpers
       '@remirror/core-utils': link:../remirror__core-utils
-      prosemirror-model: 1.17.0
-      prosemirror-view: 1.24.1
+      prosemirror-model: 1.18.0
+      prosemirror-view: 1.26.0
 
   packages/prosemirror-suggest:
     specifiers:
@@ -411,9 +411,9 @@ importers:
       '@remirror/core-helpers': ^2.0.0-beta.0
       '@remirror/types': ^1.0.0-beta.0
       escape-string-regexp: ^4.0.0
-      prosemirror-model: ^1.17.0
+      prosemirror-model: ^1.18.0
       prosemirror-state: ^1.4.0
-      prosemirror-view: ^1.24.1
+      prosemirror-view: ^1.26.0
     dependencies:
       '@babel/runtime': 7.17.9
       '@remirror/core-constants': link:../remirror__core-constants
@@ -421,9 +421,9 @@ importers:
       '@remirror/types': link:../remirror__types
       escape-string-regexp: 4.0.0
     devDependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-view: 1.24.1
+      prosemirror-view: 1.26.0
 
   packages/prosemirror-trailing-node:
     specifiers:
@@ -431,18 +431,18 @@ importers:
       '@remirror/core-constants': ^2.0.0-beta.0
       '@remirror/core-helpers': ^2.0.0-beta.0
       escape-string-regexp: ^4.0.0
-      prosemirror-model: ^1.17.0
+      prosemirror-model: ^1.18.0
       prosemirror-state: ^1.4.0
-      prosemirror-view: ^1.24.1
+      prosemirror-view: ^1.26.0
     dependencies:
       '@babel/runtime': 7.17.9
       '@remirror/core-constants': link:../remirror__core-constants
       '@remirror/core-helpers': link:../remirror__core-helpers
       escape-string-regexp: 4.0.0
     devDependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-view: 1.24.1
+      prosemirror-view: 1.26.0
 
   packages/remirror:
     specifiers:
@@ -654,7 +654,7 @@ importers:
       figures: 3.2.0
       fs-extra: 10.1.0
       globby: 11.1.0
-      ink: 3.2.0_@types+react@18.0.6+react@18.0.0
+      ink: 3.2.0_@types+react@18.0.9+react@18.0.0
       ink-link: 2.0.0_ink@3.2.0+react@18.0.0
       ink-multi-select: 2.0.0
       ink-spinner: 4.0.3_ink@3.2.0+react@18.0.0
@@ -671,14 +671,14 @@ importers:
       update-notifier: 5.1.0
     devDependencies:
       '@remirror/core-types': link:../remirror__core-types
-      '@testing-library/react-hooks': 8.0.0_@types+react@18.0.6+react@18.0.0
+      '@testing-library/react-hooks': 8.0.0_@types+react@18.0.9+react@18.0.0
       '@types/ink-spinner': 3.0.1
       '@types/ink-testing-library': 1.0.1
       '@types/jsesc': 3.0.1
       '@types/node': 16.11.36
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/rimraf': 3.0.2
-      ink-testing-library: 2.1.0_@types+react@18.0.6
+      ink-testing-library: 2.1.0_@types+react@18.0.9
 
   packages/remirror__core:
     specifiers:
@@ -811,7 +811,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@testing-library/react': 13.1.1_react-dom@18.0.0+react@18.0.0
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1142,7 +1142,7 @@ importers:
       nanoevents: 5.1.13
     devDependencies:
       '@remirror/pm': link:../remirror__pm
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1443,7 +1443,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1468,7 +1468,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   packages/remirror__extension-react-tables:
@@ -1513,7 +1513,7 @@ importers:
       jsx-dom: 6.4.23
     devDependencies:
       '@remirror/pm': link:../remirror__pm
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1760,19 +1760,19 @@ importers:
       prosemirror-collab: ^1.3.0
       prosemirror-commands: ^1.3.0
       prosemirror-dropcursor: ^1.5.0
-      prosemirror-gapcursor: ^1.3.0
+      prosemirror-gapcursor: ^1.3.1
       prosemirror-history: ^1.3.0
       prosemirror-inputrules: ^1.2.0
       prosemirror-keymap: ^1.2.0
-      prosemirror-model: ^1.17.0
+      prosemirror-model: ^1.18.0
       prosemirror-paste-rules: ^2.0.0-beta.0
       prosemirror-schema-list: ^1.2.0
       prosemirror-state: ^1.4.0
       prosemirror-suggest: ^2.0.0-beta.0
       prosemirror-tables: ^1.1.1
       prosemirror-trailing-node: ^2.0.0-beta.0
-      prosemirror-transform: ^1.5.0
-      prosemirror-view: ^1.24.1
+      prosemirror-transform: ^1.6.0
+      prosemirror-view: ^1.26.0
     dependencies:
       '@babel/runtime': 7.17.9
       '@remirror/core-constants': link:../remirror__core-constants
@@ -1780,19 +1780,19 @@ importers:
       prosemirror-collab: 1.3.0
       prosemirror-commands: 1.3.0
       prosemirror-dropcursor: 1.5.0
-      prosemirror-gapcursor: 1.3.0
+      prosemirror-gapcursor: 1.3.1
       prosemirror-history: 1.3.0
       prosemirror-inputrules: 1.2.0
       prosemirror-keymap: 1.2.0
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-paste-rules: link:../prosemirror-paste-rules
       prosemirror-schema-list: 1.2.0
       prosemirror-state: 1.4.0
       prosemirror-suggest: link:../prosemirror-suggest
       prosemirror-tables: 1.1.1
       prosemirror-trailing-node: link:../prosemirror-trailing-node
-      prosemirror-transform: 1.5.0
-      prosemirror-view: 1.24.1
+      prosemirror-transform: 1.6.0
+      prosemirror-view: 1.26.0
 
   packages/remirror__preset-core:
     specifiers:
@@ -1880,7 +1880,7 @@ importers:
       '@remirror/react-utils': link:../remirror__react-utils
     devDependencies:
       '@remirror/pm': link:../remirror__pm
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1972,7 +1972,7 @@ importers:
       '@remirror/react-ssr': link:../remirror__react-ssr
       '@remirror/react-utils': link:../remirror__react-utils
     devDependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2034,12 +2034,12 @@ importers:
       reakit: 1.3.11_react-dom@18.0.0+react@18.0.0
       reakit-system-palette: 0.14.2_6ce68794d8a4199f38712f8527fc368a
       reakit-utils: 0.15.2_react-dom@18.0.0+react@18.0.0
-      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.6+react@18.0.0
-      use-previous: 1.1.0_@types+react@18.0.6+react@18.0.0
+      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.9+react@18.0.0
+      use-previous: 1.1.0_@types+react@18.0.9+react@18.0.0
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2089,12 +2089,12 @@ importers:
       fast-deep-equal: 3.1.3
       resize-observer-polyfill: 1.5.1
       tiny-warning: 1.0.3
-      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.6+react@18.0.0
-      use-previous: 1.1.0_@types+react@18.0.6+react@18.0.0
+      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.9+react@18.0.0
+      use-previous: 1.1.0_@types+react@18.0.9+react@18.0.0
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2133,7 +2133,7 @@ importers:
       svgmoji: 3.2.0
     devDependencies:
       '@emotion/css': 11.5.0_@babel+core@7.17.9
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2174,12 +2174,12 @@ importers:
       '@remirror/react-core': link:../remirror__react-core
       '@remirror/react-utils': link:../remirror__react-utils
       multishift: link:../multishift
-      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.6+react@18.0.0
-      use-previous: 1.1.0_@types+react@18.0.6+react@18.0.0
+      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.9+react@18.0.0
+      use-previous: 1.1.0_@types+react@18.0.9+react@18.0.0
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2195,7 +2195,7 @@ importers:
       '@babel/runtime': 7.17.9
       '@remirror/core': link:../remirror__core
     devDependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   packages/remirror__react-ssr:
@@ -2216,7 +2216,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2235,7 +2235,7 @@ importers:
       '@remirror/core-helpers': link:../remirror__core-helpers
       '@remirror/core-types': link:../remirror__core-types
     devDependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   packages/remirror__styles:
@@ -2252,9 +2252,9 @@ importers:
       '@babel/runtime': 7.17.9
     devDependencies:
       '@emotion/css': 11.5.0_@babel+core@7.17.9
-      '@emotion/react': 11.9.0_e7c53be29d0cf33e05dfabbe0af5a24f
-      '@emotion/styled': 11.3.0_0f162aecff6af21058626542244d3733
-      '@types/react': 18.0.6
+      '@emotion/react': 11.9.0_eda947fd5a55b17fd69c83da1929b3a4
+      '@emotion/styled': 11.3.0_ef8491be20d813eca7db8878a18b1d4d
+      '@types/react': 18.0.9
       '@types/styled-components': 5.1.15
       react: 18.0.0
       styled-components: 5.3.3_react@18.0.0
@@ -2273,7 +2273,7 @@ importers:
       '@remirror/core-types': link:../remirror__core-types
       case-anything: 1.1.3
       color2k: 1.2.4
-      csstype: 3.0.9
+      csstype: 3.1.0
 
   packages/remirror__types:
     specifiers:
@@ -2362,16 +2362,16 @@ importers:
       '@remirror/react': link:../remirror__react
       '@remirror/react-editors': link:../remirror__react-editors
       '@remirror/styles': link:../remirror__styles
-      '@storybook/addon-controls': 6.3.12_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/addon-controls': 6.3.12_77eee59412d5eb5eea5ef01c6d864380
       '@storybook/addons': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/cli': 6.3.12_jest@27.3.1
-      '@storybook/components': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
-      '@storybook/core': 6.4.22_5bb03eb0be3b22f9f120849ffcbff03a
-      '@storybook/react': 6.4.22_01d5d70fa5f48551d596f656aa33618b
+      '@storybook/components': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
+      '@storybook/core': 6.4.22_8494059f644d5cab60dfecbef0d4272e
+      '@storybook/react': 6.4.22_c7dd8bca00ef433f4855eb9df2b9cbe6
       '@storybook/theming': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@svgmoji/blob': 3.2.0
       '@types/codemirror': 5.60.5
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       '@types/refractor': 3.0.2
       '@types/webpack': 5.28.0
@@ -2454,7 +2454,7 @@ importers:
       '@remirror/preset-core': link:../remirror__preset-core
       '@remirror/react': link:../remirror__react
       '@testing-library/react': 13.1.1_react@18.0.0
-      '@testing-library/react-hooks': 8.0.0_a7a2262d07adc554448c121b1d666f8e
+      '@testing-library/react-hooks': 8.0.0_7c14a543275bb8b7a05e66b5669597c6
       '@types/fluent-ffmpeg': 2.1.18
       '@types/min-document': 2.19.0
       '@types/react-test-renderer': 18.0.0
@@ -2478,7 +2478,7 @@ importers:
       signal-exit: 3.0.5
       test-keyboard: link:../test-keyboard
     devDependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   support:
@@ -2753,8 +2753,8 @@ importers:
     dependencies:
       '@babel/runtime': 7.17.9
       '@emotion/css': 11.5.0_@babel+core@7.17.9
-      '@emotion/react': 11.9.0_e7c53be29d0cf33e05dfabbe0af5a24f
-      '@emotion/styled': 11.3.0_0f162aecff6af21058626542244d3733
+      '@emotion/react': 11.9.0_eda947fd5a55b17fd69c83da1929b3a4
+      '@emotion/styled': 11.3.0_ef8491be20d813eca7db8878a18b1d4d
       '@fontsource/fira-code': 4.5.1
       '@fontsource/rubik': 4.5.0
       '@mdx-js/react': 1.6.22_react@18.0.0
@@ -2782,13 +2782,13 @@ importers:
       '@docusaurus/plugin-content-docs': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/plugin-ideal-image': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/plugin-sitemap': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
-      '@docusaurus/preset-classic': 2.0.0-beta.18_5bb03eb0be3b22f9f120849ffcbff03a
+      '@docusaurus/preset-classic': 2.0.0-beta.18_8494059f644d5cab60dfecbef0d4272e
       '@docusaurus/theme-classic': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/theme-common': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/theme-live-codeblock': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/types': 2.0.0-beta.18
       '@tsconfig/docusaurus': 1.0.5
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-dom': 18.0.2
       '@types/react-helmet': 6.1.5
       '@types/react-router-dom': 5.3.3
@@ -4817,7 +4817,7 @@ packages:
     resolution: {integrity: sha512-1kkV7tkAsiuEd0shunYRByKJe3xQDG2q7wYg24SOw1nV9/2lwEd4WrUYRJC/ukGTl2/kHeFxsaUvtiOy0y6fFA==}
     dev: true
 
-  /@docsearch/react/3.0.0_8fc472ebaf0018fcdf7cf55b2750c96e:
+  /@docsearch/react/3.0.0_77eee59412d5eb5eea5ef01c6d864380:
     resolution: {integrity: sha512-yhMacqS6TVQYoBh/o603zszIb5Bl8MIXuOc6Vy617I74pirisDzzcNh0NEaYQt50fVVR3khUbeEhUEWEWipESg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 18.0.0'
@@ -4827,7 +4827,7 @@ packages:
       '@algolia/autocomplete-core': 1.5.2
       '@algolia/autocomplete-preset-algolia': 1.5.2_algoliasearch@4.13.0
       '@docsearch/css': 3.0.0
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       algoliasearch: 4.13.0
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -5129,7 +5129,7 @@ packages:
       react-dom: '*'
     dependencies:
       '@docusaurus/types': 2.0.0-beta.18
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-router-config': 5.0.3
       '@types/react-router-dom': 5.3.3
       react: 18.0.0
@@ -5288,7 +5288,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-debug/2.0.0-beta.18_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@docusaurus/plugin-debug/2.0.0-beta.18_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-inLnLERgG7q0WlVmK6nYGHwVqREz13ivkynmNygEibJZToFRdgnIPW+OwD8QzgC5MpQTJw7+uYjcitpBumy1Gw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -5300,7 +5300,7 @@ packages:
       fs-extra: 10.1.0
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
-      react-json-view: 1.21.3_8fc472ebaf0018fcdf7cf55b2750c96e
+      react-json-view: 1.21.3_77eee59412d5eb5eea5ef01c6d864380
       tslib: 2.3.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -5447,7 +5447,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/preset-classic/2.0.0-beta.18_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@docusaurus/preset-classic/2.0.0-beta.18_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-TfDulvFt/vLWr/Yy7O0yXgwHtJhdkZ739bTlFNwEkRMAy8ggi650e52I1I0T79s67llecb4JihgHPW+mwiVkCQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -5458,13 +5458,13 @@ packages:
       '@docusaurus/plugin-content-blog': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/plugin-content-docs': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/plugin-content-pages': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
-      '@docusaurus/plugin-debug': 2.0.0-beta.18_5bb03eb0be3b22f9f120849ffcbff03a
+      '@docusaurus/plugin-debug': 2.0.0-beta.18_8494059f644d5cab60dfecbef0d4272e
       '@docusaurus/plugin-google-analytics': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/plugin-google-gtag': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/plugin-sitemap': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/theme-classic': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/theme-common': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
-      '@docusaurus/theme-search-algolia': 2.0.0-beta.18_5bb03eb0be3b22f9f120849ffcbff03a
+      '@docusaurus/theme-search-algolia': 2.0.0-beta.18_8494059f644d5cab60dfecbef0d4272e
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
     transitivePeerDependencies:
@@ -5632,14 +5632,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-search-algolia/2.0.0-beta.18_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@docusaurus/theme-search-algolia/2.0.0-beta.18_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-2w97KO/gnjI49WVtYQqENpQ8iO1Sem0yaTxw7/qv/ndlmIAQD0syU4yx6GsA7bTQCOGwKOWWzZSetCgUmTnWgA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.0.0_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@docsearch/react': 3.0.0_77eee59412d5eb5eea5ef01c6d864380
       '@docusaurus/core': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
       '@docusaurus/logger': 2.0.0-beta.18
       '@docusaurus/plugin-content-docs': 2.0.0-beta.18_d0ef1faf74c0bfca284634bf69606dc0
@@ -5854,7 +5854,7 @@ packages:
   /@emotion/memoize/0.7.5:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
 
-  /@emotion/react/11.9.0_e7c53be29d0cf33e05dfabbe0af5a24f:
+  /@emotion/react/11.9.0_eda947fd5a55b17fd69c83da1929b3a4:
     resolution: {integrity: sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5873,7 +5873,7 @@ packages:
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
       '@emotion/weak-memoize': 0.2.5
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       hoist-non-react-statics: 3.3.2
       react: 18.0.0
 
@@ -5894,7 +5894,7 @@ packages:
       '@emotion/memoize': 0.7.5
       '@emotion/unitless': 0.7.5
       '@emotion/utils': 1.1.0
-      csstype: 3.0.9
+      csstype: 3.1.0
 
   /@emotion/sheet/0.9.4:
     resolution: {integrity: sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==}
@@ -5929,7 +5929,7 @@ packages:
       react: 18.0.0
     dev: false
 
-  /@emotion/styled/11.3.0_0f162aecff6af21058626542244d3733:
+  /@emotion/styled/11.3.0_ef8491be20d813eca7db8878a18b1d4d:
     resolution: {integrity: sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5946,10 +5946,10 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/babel-plugin': 11.9.2_@babel+core@7.17.9
       '@emotion/is-prop-valid': 1.1.0
-      '@emotion/react': 11.9.0_e7c53be29d0cf33e05dfabbe0af5a24f
+      '@emotion/react': 11.9.0_eda947fd5a55b17fd69c83da1929b3a4
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
   /@emotion/stylis/0.8.5:
@@ -7970,7 +7970,7 @@ packages:
       highcharts: 9.3.0
     dev: false
 
-  /@storybook/addon-controls/6.3.12_8fc472ebaf0018fcdf7cf55b2750c96e:
+  /@storybook/addon-controls/6.3.12_77eee59412d5eb5eea5ef01c6d864380:
     resolution: {integrity: sha512-WO/PbygE4sDg3BbstJ49q0uM3Xu5Nw4lnHR5N4hXSvRAulZt1d1nhphRTHjfX+CW+uBcfzkq9bksm6nKuwmOyw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -7984,7 +7984,7 @@ packages:
       '@storybook/addons': 6.3.12_react-dom@18.0.0+react@18.0.0
       '@storybook/api': 6.3.12_react-dom@18.0.0+react@18.0.0
       '@storybook/client-api': 6.3.12_react-dom@18.0.0+react@18.0.0
-      '@storybook/components': 6.3.12_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/components': 6.3.12_77eee59412d5eb5eea5ef01c6d864380
       '@storybook/node-logger': 6.3.12
       '@storybook/theming': 6.3.12_react-dom@18.0.0+react@18.0.0
       core-js: 3.22.2
@@ -8092,7 +8092,7 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /@storybook/builder-webpack4/6.4.22_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@storybook/builder-webpack4/6.4.22_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-A+GgGtKGnBneRFSFkDarUIgUTI8pYFdLmUVKEAGdh2hL+vLXAz9A46sEY7C8LQ85XWa8TKy3OTDxqR4+4iWj3A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -8129,7 +8129,7 @@ packages:
       '@storybook/channels': 6.4.22
       '@storybook/client-api': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/components': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
       '@storybook/core-common': 6.4.22_d0ef1faf74c0bfca284634bf69606dc0
       '@storybook/core-events': 6.4.22
       '@storybook/node-logger': 6.4.22
@@ -8138,7 +8138,7 @@ packages:
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/theming': 6.4.22_react-dom@18.0.0+react@18.0.0
-      '@storybook/ui': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/ui': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
       '@types/node': 14.18.18
       '@types/webpack': 4.41.31
       autoprefixer: 9.8.8
@@ -8363,7 +8363,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/components/6.3.12_8fc472ebaf0018fcdf7cf55b2750c96e:
+  /@storybook/components/6.3.12_77eee59412d5eb5eea5ef01c6d864380:
     resolution: {integrity: sha512-kdQt8toUjynYAxDLrJzuG7YSNL6as1wJoyzNUaCfG06YPhvIAlKo7le9tS2mThVFN5e9nbKrW3N1V1sp6ypZXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -8391,7 +8391,7 @@ packages:
       react-dom: 18.0.0_react@18.0.0
       react-popper-tooltip: 3.1.1_react-dom@18.0.0+react@18.0.0
       react-syntax-highlighter: 13.5.3_react@18.0.0
-      react-textarea-autosize: 8.3.3_@types+react@18.0.6+react@18.0.0
+      react-textarea-autosize: 8.3.3_@types+react@18.0.9+react@18.0.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -8399,7 +8399,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /@storybook/components/6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e:
+  /@storybook/components/6.4.22_77eee59412d5eb5eea5ef01c6d864380:
     resolution: {integrity: sha512-dCbXIJF9orMvH72VtAfCQsYbe57OP7fAADtR6YTwfCw9Sm1jFuZr8JbblQ1HcrXEoJG21nOyad3Hm5EYVb/sBw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -8427,7 +8427,7 @@ packages:
       react-dom: 18.0.0_react@18.0.0
       react-popper-tooltip: 3.1.1_react-dom@18.0.0+react@18.0.0
       react-syntax-highlighter: 13.5.3_react@18.0.0
-      react-textarea-autosize: 8.3.3_@types+react@18.0.6+react@18.0.0
+      react-textarea-autosize: 8.3.3_@types+react@18.0.9+react@18.0.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
@@ -8435,7 +8435,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /@storybook/core-client/6.4.22_7cce79bf6659ca77be1d36bc8b074cdd:
+  /@storybook/core-client/6.4.22_a1643b1892b9a61077bf9f1209f6b15b:
     resolution: {integrity: sha512-uHg4yfCBeM6eASSVxStWRVTZrAnb4FT6X6v/xDqr4uXCpCttZLlBzrSDwPBLNNLtCa7ntRicHM8eGKIOD5lMYQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -8455,7 +8455,7 @@ packages:
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/preview-web': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/store': 6.4.22_react-dom@18.0.0+react@18.0.0
-      '@storybook/ui': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/ui': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.22.2
@@ -8474,7 +8474,7 @@ packages:
       - '@types/react'
     dev: false
 
-  /@storybook/core-client/6.4.22_eb46fc05e3953caed40e036b4570df28:
+  /@storybook/core-client/6.4.22_a3ae26858b399f9109c9a928ad0f8a3d:
     resolution: {integrity: sha512-uHg4yfCBeM6eASSVxStWRVTZrAnb4FT6X6v/xDqr4uXCpCttZLlBzrSDwPBLNNLtCa7ntRicHM8eGKIOD5lMYQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -8494,7 +8494,7 @@ packages:
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/preview-web': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/store': 6.4.22_react-dom@18.0.0+react@18.0.0
-      '@storybook/ui': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/ui': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
       core-js: 3.22.2
@@ -8594,7 +8594,7 @@ packages:
       core-js: 3.22.2
     dev: false
 
-  /@storybook/core-server/6.4.22_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@storybook/core-server/6.4.22_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-wFh3e2fa0un1d4+BJP+nd3FVWUO7uHTqv3OGBfOmzQMKp4NU1zaBNdSQG7Hz6mw0fYPBPZgBjPfsJRwIYLLZyw==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -8611,13 +8611,13 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.5
-      '@storybook/builder-webpack4': 6.4.22_5bb03eb0be3b22f9f120849ffcbff03a
-      '@storybook/core-client': 6.4.22_7cce79bf6659ca77be1d36bc8b074cdd
+      '@storybook/builder-webpack4': 6.4.22_8494059f644d5cab60dfecbef0d4272e
+      '@storybook/core-client': 6.4.22_a1643b1892b9a61077bf9f1209f6b15b
       '@storybook/core-common': 6.4.22_d0ef1faf74c0bfca284634bf69606dc0
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.22
-      '@storybook/manager-webpack4': 6.4.22_5bb03eb0be3b22f9f120849ffcbff03a
+      '@storybook/manager-webpack4': 6.4.22_8494059f644d5cab60dfecbef0d4272e
       '@storybook/node-logger': 6.4.22
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.22_react-dom@18.0.0+react@18.0.0
@@ -8666,7 +8666,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/core/6.4.22_01222bffe0e8c444eaab2f795f276d95:
+  /@storybook/core/6.4.22_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-KZYJt7GM5NgKFXbPRZZZPEONZ5u/tE/cRbMdkn/zWN3He8+VP+65/tz8hbriI/6m91AWVWkBKrODSkeq59NgRA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -8680,12 +8680,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.4.22_7cce79bf6659ca77be1d36bc8b074cdd
-      '@storybook/core-server': 6.4.22_5bb03eb0be3b22f9f120849ffcbff03a
+      '@storybook/core-client': 6.4.22_a3ae26858b399f9109c9a928ad0f8a3d
+      '@storybook/core-server': 6.4.22_8494059f644d5cab60dfecbef0d4272e
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       typescript: 4.5.5
-      webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
@@ -8698,7 +8697,7 @@ packages:
       - webpack-command
     dev: false
 
-  /@storybook/core/6.4.22_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@storybook/core/6.4.22_8cb335d3eeab7ef8a6d75698ec351df5:
     resolution: {integrity: sha512-KZYJt7GM5NgKFXbPRZZZPEONZ5u/tE/cRbMdkn/zWN3He8+VP+65/tz8hbriI/6m91AWVWkBKrODSkeq59NgRA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -8712,11 +8711,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.4.22_eb46fc05e3953caed40e036b4570df28
-      '@storybook/core-server': 6.4.22_5bb03eb0be3b22f9f120849ffcbff03a
+      '@storybook/core-client': 6.4.22_a1643b1892b9a61077bf9f1209f6b15b
+      '@storybook/core-server': 6.4.22_8494059f644d5cab60dfecbef0d4272e
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       typescript: 4.5.5
+      webpack: 4.46.0
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
       - '@types/react'
@@ -8787,7 +8787,7 @@ packages:
       lodash: 4.17.21
     dev: false
 
-  /@storybook/manager-webpack4/6.4.22_5bb03eb0be3b22f9f120849ffcbff03a:
+  /@storybook/manager-webpack4/6.4.22_8494059f644d5cab60dfecbef0d4272e:
     resolution: {integrity: sha512-nzhDMJYg0vXdcG0ctwE6YFZBX71+5NYaTGkxg3xT7gbgnP1YFXn9gVODvgq3tPb3gcRapjyOIxUa20rV+r8edA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -8801,11 +8801,11 @@ packages:
       '@babel/plugin-transform-template-literals': 7.16.7_@babel+core@7.17.9
       '@babel/preset-react': 7.16.7_@babel+core@7.17.9
       '@storybook/addons': 6.4.22_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-client': 6.4.22_7cce79bf6659ca77be1d36bc8b074cdd
+      '@storybook/core-client': 6.4.22_a1643b1892b9a61077bf9f1209f6b15b
       '@storybook/core-common': 6.4.22_d0ef1faf74c0bfca284634bf69606dc0
       '@storybook/node-logger': 6.4.22
       '@storybook/theming': 6.4.22_react-dom@18.0.0+react@18.0.0
-      '@storybook/ui': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/ui': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
       '@types/node': 14.18.18
       '@types/webpack': 4.41.31
       babel-loader: 8.2.5_598a497cebab8e15ee8f9e5632178e63
@@ -8910,7 +8910,7 @@ packages:
       - supports-color
     dev: false
 
-  /@storybook/react/6.4.22_01d5d70fa5f48551d596f656aa33618b:
+  /@storybook/react/6.4.22_c7dd8bca00ef433f4855eb9df2b9cbe6:
     resolution: {integrity: sha512-5BFxtiguOcePS5Ty/UoH7C6odmvBYIZutfiy4R3Ua6FYmtxac5vP9r5KjCz1IzZKT8mCf4X+PuK1YvDrPPROgQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -8930,7 +8930,7 @@ packages:
       '@babel/preset-react': 7.16.7_@babel+core@7.17.9
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_47d2d3d1054d6699878275f581b09465
       '@storybook/addons': 6.4.22_react-dom@18.0.0+react@18.0.0
-      '@storybook/core': 6.4.22_01222bffe0e8c444eaab2f795f276d95
+      '@storybook/core': 6.4.22_8cb335d3eeab7ef8a6d75698ec351df5
       '@storybook/core-common': 6.4.22_d0ef1faf74c0bfca284634bf69606dc0
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.22
@@ -9091,7 +9091,7 @@ packages:
       ts-dedent: 2.2.0
     dev: false
 
-  /@storybook/ui/6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e:
+  /@storybook/ui/6.4.22_77eee59412d5eb5eea5ef01c6d864380:
     resolution: {integrity: sha512-UVjMoyVsqPr+mkS1L7m30O/xrdIEgZ5SCWsvqhmyMUok3F3tRB+6M+OA5Yy+cIVfvObpA7MhxirUT1elCGXsWQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -9102,7 +9102,7 @@ packages:
       '@storybook/api': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/channels': 6.4.22
       '@storybook/client-logger': 6.4.22
-      '@storybook/components': 6.4.22_8fc472ebaf0018fcdf7cf55b2750c96e
+      '@storybook/components': 6.4.22_77eee59412d5eb5eea5ef01c6d864380
       '@storybook/core-events': 6.4.22
       '@storybook/router': 6.4.22_react-dom@18.0.0+react@18.0.0
       '@storybook/semver': 7.3.2
@@ -9377,7 +9377,7 @@ packages:
       react-error-boundary: 3.1.4
     dev: false
 
-  /@testing-library/react-hooks/8.0.0_@types+react@18.0.6+react@18.0.0:
+  /@testing-library/react-hooks/8.0.0_7c14a543275bb8b7a05e66b5669597c6:
     resolution: {integrity: sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -9394,33 +9394,33 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.17.9
-      '@types/react': 18.0.6
-      react: 18.0.0
-      react-error-boundary: 3.1.4_react@18.0.0
-    dev: true
-
-  /@testing-library/react-hooks/8.0.0_a7a2262d07adc554448c121b1d666f8e:
-    resolution: {integrity: sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0
-      react: ^16.9.0 || ^17.0.0
-      react-dom: ^16.9.0 || ^17.0.0
-      react-test-renderer: ^16.9.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react-dom:
-        optional: true
-      react-test-renderer:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.17.9
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
       react-error-boundary: 3.1.4_react@18.0.0
       react-test-renderer: 18.0.0_react@18.0.0
     dev: false
+
+  /@testing-library/react-hooks/8.0.0_@types+react@18.0.9+react@18.0.0:
+    resolution: {integrity: sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0
+      react: ^16.9.0 || ^17.0.0
+      react-dom: ^16.9.0 || ^17.0.0
+      react-test-renderer: ^16.9.0 || ^17.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@types/react': 18.0.9
+      react: 18.0.0
+      react-error-boundary: 3.1.4_react@18.0.0
+    dev: true
 
   /@testing-library/react/13.1.1_react-dom@18.0.0+react@18.0.0:
     resolution: {integrity: sha512-8mirlAa0OKaUvnqnZF6MdAh2tReYA2KtWVw1PKvaF5EcCZqgK5pl8iF+3uW90JdG5Ua2c2c2E2wtLdaug3dsVg==}
@@ -9687,7 +9687,7 @@ packages:
   /@types/hoist-non-react-statics/3.3.1:
     resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       hoist-non-react-statics: 3.3.2
     dev: true
 
@@ -9715,7 +9715,7 @@ packages:
     resolution: {integrity: sha512-LevFtWOB2VxxHqzAywf5uC5DXlwUU+rNcgMRanp9uJlzUc5D15wVOMQRN7ANrMPUmfmb+nL8JI2OACOo3eAf3Q==}
     dependencies:
       '@types/cli-spinners': 1.3.0
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: true
 
   /@types/ink-testing-library/1.0.1:
@@ -9728,7 +9728,7 @@ packages:
     resolution: {integrity: sha512-yEuhWTRMXJkIWiaM58c5kuRot5HFccv9kjjgy0fBZG0+tYb+sMBaxHNPVqyZXspGGlmwDOQ1d3BsygWpWlW17w==}
     dependencies:
       '@types/node': 17.0.26
-      '@types/prop-types': 15.7.4
+      '@types/prop-types': 15.7.5
     dev: true
 
   /@types/inquirer/8.1.3:
@@ -9960,9 +9960,6 @@ packages:
     resolution: {integrity: sha512-dTvnamRITNqNkqhlBd235kZl3KfVJQQoT5jkXeiWSBK7i4/TLKBNLV0S1wOt8gy4E2TY722KLtdmv2xc6+Wevg==}
     dev: false
 
-  /@types/prop-types/15.7.4:
-    resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
 
@@ -9983,32 +9980,32 @@ packages:
   /@types/reach__router/1.3.9:
     resolution: {integrity: sha512-N6rqQqTTAV/zKLfK3iq9Ww3wqCEhTZvsilhl0zI09zETdVq1QGmJH6+/xnj8AFUWIrle2Cqo+PGM/Ltr1vBb9w==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: false
 
   /@types/react-color/3.0.6:
     resolution: {integrity: sha512-OzPIO5AyRmLA7PlOyISlgabpYUa3En74LP8mTMa0veCA719SvYQov4WLMsHvCgXP+L+KI9yGhYnqZafVGG0P4w==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/reactcss': 1.2.6
     dev: false
 
   /@types/react-dom/18.0.2:
     resolution: {integrity: sha512-UxeS+Wtj5bvLRREz9tIgsK4ntCuLDo0EcAcACgw3E+9wE8ePDr9uQpq53MfcyxyIS55xJ+0B6mDS8c4qkkHLBg==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
 
   /@types/react-helmet/6.1.5:
     resolution: {integrity: sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: true
 
   /@types/react-router-config/5.0.3:
     resolution: {integrity: sha512-38vpjXic0+E2sIBEKUe+RrCmbc8RqcQhNV8OmU3KUcwgy/yzTeo67MhllP+0zjZWNr7Lhw+RnUkL0hzkf63nUQ==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-router': 5.1.17
     dev: true
 
@@ -10016,7 +10013,7 @@ packages:
     resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       '@types/react-router': 5.1.17
     dev: true
 
@@ -10024,33 +10021,26 @@ packages:
     resolution: {integrity: sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: true
 
   /@types/react-syntax-highlighter/11.0.5:
     resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: false
 
   /@types/react-syntax-highlighter/13.5.2:
     resolution: {integrity: sha512-sRZoKZBGKaE7CzMvTTgz+0x/aVR58ZYUTfB7HN76vC+yQnvo1FWtzNARBt0fGqcLGEVakEzMu/CtPzssmanu8Q==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: false
 
   /@types/react-test-renderer/18.0.0:
     resolution: {integrity: sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: false
-
-  /@types/react/18.0.6:
-    resolution: {integrity: sha512-bPqwzJRzKtfI0mVYr5R+1o9BOE8UEXefwc1LwcBtfnaAn6OoqMhLa/91VA8aeWfDPJt1kHvYKI8RHcQybZLHHA==}
-    dependencies:
-      '@types/prop-types': 15.7.4
-      '@types/scheduler': 0.16.2
-      csstype: 3.0.9
 
   /@types/react/18.0.9:
     resolution: {integrity: sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==}
@@ -10062,7 +10052,7 @@ packages:
   /@types/reactcss/1.2.6:
     resolution: {integrity: sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==}
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: false
 
   /@types/refractor/3.0.2:
@@ -10162,8 +10152,8 @@ packages:
     resolution: {integrity: sha512-4evch8BRI3AKgb0GAZ/sn+mSeB+Dq7meYtMi7J/0Mg98Dt1+r8fySOek7Sjw1W+Wskyjc93565o5xWAT/FdY0Q==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 18.0.6
-      csstype: 3.0.9
+      '@types/react': 18.0.9
+      csstype: 3.1.0
     dev: true
 
   /@types/tapable/1.0.8:
@@ -13924,9 +13914,6 @@ packages:
   /csstype/2.6.18:
     resolution: {integrity: sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==}
     dev: false
-
-  /csstype/3.0.9:
-    resolution: {integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==}
 
   /csstype/3.1.0:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
@@ -17765,7 +17752,7 @@ packages:
       ink: '>=3.0.0'
       react: '>=16.8.0'
     dependencies:
-      ink: 3.2.0_@types+react@18.0.6+react@18.0.0
+      ink: 3.2.0_@types+react@18.0.9+react@18.0.0
       prop-types: 15.8.1
       react: 18.0.0
       terminal-link: 2.1.1
@@ -17789,11 +17776,11 @@ packages:
       react: '>=16.8.2'
     dependencies:
       cli-spinners: 2.6.1
-      ink: 3.2.0_@types+react@18.0.6+react@18.0.0
+      ink: 3.2.0_@types+react@18.0.9+react@18.0.0
       react: 18.0.0
     dev: false
 
-  /ink-testing-library/2.1.0_@types+react@18.0.6:
+  /ink-testing-library/2.1.0_@types+react@18.0.9:
     resolution: {integrity: sha512-7TNlOjJlJXB33vG7yVa+MMO7hCjaC1bCn+zdpSjknWoLbOWMaFdKc7LJvqVkZ0rZv2+akhjXPrcR/dbxissjUw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -17802,10 +17789,10 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
     dev: true
 
-  /ink/3.2.0_@types+react@18.0.6+react@18.0.0:
+  /ink/3.2.0_@types+react@18.0.9+react@18.0.0:
     resolution: {integrity: sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -17815,7 +17802,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       ansi-escapes: 4.3.2
       auto-bind: 4.0.0
       chalk: 4.1.2
@@ -19646,7 +19633,7 @@ packages:
   /jsx-dom/6.4.23:
     resolution: {integrity: sha512-Y0ax82xa4nzqFdbUXs3ma2haDZy4pB638kMZsGRzZqdmtyzY2nAKs7Bh3DrLn0vqMuxmvZQ3g9hq3NtnI5yXtQ==}
     dependencies:
-      csstype: 3.0.9
+      csstype: 3.1.0
     dev: false
 
   /junk/3.1.0:
@@ -20933,7 +20920,7 @@ packages:
       react-dom: '*'
     dependencies:
       css-tree: 1.1.3
-      csstype: 3.0.9
+      csstype: 3.1.0
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 6.0.1
       react: 18.0.0
@@ -21328,7 +21315,7 @@ packages:
     dev: false
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   /object-copy/0.1.0:
@@ -22989,16 +22976,16 @@ packages:
   /prosemirror-commands/1.3.0:
     resolution: {integrity: sha512-BwBbZ5OAScPcm0x7H8SPbqjuEJnCU2RJT9LDyOiiIl/3NbL1nJZI4SFNHwU2e/tRr2Xe7JsptpzseqvZvToLBQ==}
     dependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
+      prosemirror-transform: 1.6.0
     dev: false
 
   /prosemirror-dev-toolkit/0.0.11:
     resolution: {integrity: sha512-opNxZ2WlPPrHb6ugZa9y+4H4zpYuHdgyFHMbEO2vmdRPhA+fYJUeQJ1DNJg/guLwF7vJL39DuykJJ5RQGWwFVg==}
     dependencies:
       html: 1.0.0
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       svelte-tree-view: 1.3.0
     dev: false
 
@@ -23006,24 +22993,24 @@ packages:
     resolution: {integrity: sha512-vy7i77ddKyXlu8kKBB3nlxLBnsWyKUmQIPB5x8RkYNh01QNp/qqGmdd5yZefJs0s3rtv5r7Izfu2qbtr+tYAMQ==}
     dependencies:
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
-      prosemirror-view: 1.24.1
+      prosemirror-transform: 1.6.0
+      prosemirror-view: 1.26.0
     dev: false
 
-  /prosemirror-gapcursor/1.3.0:
-    resolution: {integrity: sha512-9Tdx83xB2W4Oqchm12FtCkSizbqvi64cjs1I9TRPblqdA5TUWoVZ4ZI+t71Jh6HSEh4cDMPzx3UwfryJtKlb/w==}
+  /prosemirror-gapcursor/1.3.1:
+    resolution: {integrity: sha512-GKTeE7ZoMsx5uVfc51/ouwMFPq0o8YrZ7Hx4jTF4EeGbXxBveUV8CGv46mSHuBBeXGmvu50guoV2kSnOeZZnUA==}
     dependencies:
       prosemirror-keymap: 1.2.0
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-view: 1.24.1
+      prosemirror-view: 1.26.0
     dev: false
 
   /prosemirror-history/1.3.0:
     resolution: {integrity: sha512-qo/9Wn4B/Bq89/YD+eNWFbAytu6dmIM85EhID+fz9Jcl9+DfGEo8TTSrRhP15+fFEoaPqpHSxlvSzSEbmlxlUA==}
     dependencies:
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
+      prosemirror-transform: 1.6.0
       rope-sequence: 1.3.2
     dev: false
 
@@ -23031,7 +23018,7 @@ packages:
     resolution: {integrity: sha512-eAW/M/NTSSzpCOxfR8Abw6OagdG0MiDAiWHQMQveIsZtoKVYzm0AflSPq/ymqJd56/Su1YPbwy9lM13wgHOFmQ==}
     dependencies:
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
+      prosemirror-transform: 1.6.0
     dev: false
 
   /prosemirror-keymap/1.2.0:
@@ -23041,60 +23028,60 @@ packages:
       w3c-keyname: 2.2.4
     dev: false
 
-  /prosemirror-model/1.17.0:
-    resolution: {integrity: sha512-RJBDgZs/W26yyx1itrk5b3H9FxIro3K7Xjc2QWJI99Gu1nxYAnIggqI3fIOD8Jd/6QZfM+t6elZFJPycVexMTA==}
+  /prosemirror-model/1.18.0:
+    resolution: {integrity: sha512-EZLl0mvVIixEL1V538GsPP4Iw+D83gBRdLcjL7VouzoPPWlhhv/0Y0V9ttT5lUhF7jieIrNHOa3XNFs1FwgrOw==}
     dependencies:
       orderedmap: 1.1.1
 
   /prosemirror-schema-basic/1.2.0:
     resolution: {integrity: sha512-JMN/ammP94ObOUS6cpIy121r0MEDN9V95mAxFVALwC4bbmhpWXGjBGHTA5LHPPdbqZKyR6Jar1Akv4Z5k9CNLw==}
     dependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
     dev: false
 
   /prosemirror-schema-list/1.2.0:
     resolution: {integrity: sha512-8PT/9xOx1HHdC7fDNNfhQ50Z8Mzu7nKyA1KCDltSpcZVZIbB0k7KtsHrnXyuIhbLlScoymBiLZ00c5MH6wdFsA==}
     dependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
+      prosemirror-transform: 1.6.0
     dev: false
 
   /prosemirror-state/1.4.0:
     resolution: {integrity: sha512-mVDZdjNX/YT5FvypiwbphJe9psA5h+j9apsSszVRFc6oKFoIInvzdujh8QW9f9lwHtSYajLxNiM1hPhd0Sl1XA==}
     dependencies:
-      prosemirror-model: 1.17.0
-      prosemirror-transform: 1.5.0
+      prosemirror-model: 1.18.0
+      prosemirror-transform: 1.6.0
 
   /prosemirror-tables/1.1.1:
     resolution: {integrity: sha512-LmCz4jrlqQZRsYRDzCRYf/pQ5CUcSOyqZlAj5kv67ZWBH1SVLP2U9WJEvQfimWgeRlIz0y0PQVqO1arRm1+woA==}
     dependencies:
       prosemirror-keymap: 1.2.0
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
-      prosemirror-view: 1.24.1
+      prosemirror-transform: 1.6.0
+      prosemirror-view: 1.26.0
     dev: false
 
   /prosemirror-test-builder/1.1.0:
     resolution: {integrity: sha512-8fHiArJ5U3GyIjEriC02d9AcfFVYRKOarlV2aehdN5qEVO0YFFPCHoeaFeneInA29ubHycNQua7HqgykWHqr+w==}
     dependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-schema-basic: 1.2.0
       prosemirror-schema-list: 1.2.0
     dev: false
 
-  /prosemirror-transform/1.5.0:
-    resolution: {integrity: sha512-uYbTiuY7KMeBG2WprTD1Qz7ge4enD0ZD84Vg7rHqHT6U9LmyKLSETovWNSdikq+LVYOejc+7P8/a1pdmiWV4Pw==}
+  /prosemirror-transform/1.6.0:
+    resolution: {integrity: sha512-MAp7AjsjEGEqQY0sSMufNIUuEyB1ZR9Fqlm8dTwwWwpEJRv/plsKjWXBbx52q3Ml8MtaMcd7ic14zAHVB3WaMw==}
     dependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
 
-  /prosemirror-view/1.24.1:
-    resolution: {integrity: sha512-7XYxzdeN2s/y3lSs0vmU57r/fIqC/Ee61qGhdo9kN0vf6k83ISE0ioGx9fjtbNaiyiZ8dntJm2l1RGxixvqwqg==}
+  /prosemirror-view/1.26.0:
+    resolution: {integrity: sha512-tT8ICUAw6YfOTRIwVQJoCdF65BYxoWFjAqmv44Kn4phYjdLJ8Vc92dhL3LnmwAQuZ9yfPHzRR6Lfb3/5EVJHWg==}
     dependencies:
-      prosemirror-model: 1.17.0
+      prosemirror-model: 1.18.0
       prosemirror-state: 1.4.0
-      prosemirror-transform: 1.5.0
+      prosemirror-transform: 1.6.0
 
   /protoduck/4.0.0:
     resolution: {integrity: sha1-/kh02MeRM2bP2erRJFOiLNNlf44=}
@@ -23609,7 +23596,7 @@ packages:
     resolution: {integrity: sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==}
     dev: false
 
-  /react-json-view/1.21.3_8fc472ebaf0018fcdf7cf55b2750c96e:
+  /react-json-view/1.21.3_77eee59412d5eb5eea5ef01c6d864380:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -23620,7 +23607,7 @@ packages:
       react-base16-styling: 0.6.0
       react-dom: 18.0.0_react@18.0.0
       react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 8.3.3_@types+react@18.0.6+react@18.0.0
+      react-textarea-autosize: 8.3.3_@types+react@18.0.9+react@18.0.0
     transitivePeerDependencies:
       - '@types/react'
     dev: true
@@ -23871,7 +23858,7 @@ packages:
       scheduler: 0.21.0
     dev: false
 
-  /react-textarea-autosize/8.3.3_@types+react@18.0.6+react@18.0.0:
+  /react-textarea-autosize/8.3.3_@types+react@18.0.9+react@18.0.0:
     resolution: {integrity: sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -23880,7 +23867,7 @@ packages:
       '@babel/runtime': 7.17.9
       react: 18.0.0
       use-composed-ref: 1.1.0_react@18.0.0
-      use-latest: 1.2.0_@types+react@18.0.6+react@18.0.0
+      use-latest: 1.2.0_@types+react@18.0.9+react@18.0.0
     transitivePeerDependencies:
       - '@types/react'
 
@@ -27222,7 +27209,7 @@ packages:
       react: 18.0.0
       ts-essentials: 2.0.12
 
-  /use-isomorphic-layout-effect/1.1.1_@types+react@18.0.6+react@18.0.0:
+  /use-isomorphic-layout-effect/1.1.1_@types+react@18.0.9+react@18.0.0:
     resolution: {integrity: sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==}
     peerDependencies:
       '@types/react': '*'
@@ -27231,10 +27218,10 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
 
-  /use-latest/1.2.0_@types+react@18.0.6+react@18.0.0:
+  /use-latest/1.2.0_@types+react@18.0.9+react@18.0.0:
     resolution: {integrity: sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==}
     peerDependencies:
       '@types/react': '*'
@@ -27243,17 +27230,17 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.6
+      '@types/react': 18.0.9
       react: 18.0.0
-      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.6+react@18.0.0
+      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.9+react@18.0.0
 
-  /use-previous/1.1.0_@types+react@18.0.6+react@18.0.0:
+  /use-previous/1.1.0_@types+react@18.0.9+react@18.0.0:
     resolution: {integrity: sha512-t6ltKuYIpvcqD+VBnlUOaT+N94bN7HwUdB1u7rSpCIh9XvMJQIjsw/G8DoJlSDh029khFQ2L8q88oUWfKoWy5w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       react: 18.0.0
-      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.6+react@18.0.0
+      use-isomorphic-layout-effect: 1.1.1_@types+react@18.0.9+react@18.0.0
     transitivePeerDependencies:
       - '@types/react'
     dev: false

--- a/support/actions/pnpm/action.yml
+++ b/support/actions/pnpm/action.yml
@@ -22,5 +22,5 @@ runs:
       shell: bash
 
     - name: install dependencies
-      run: pnpm install
+      run: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm install
       shell: bash


### PR DESCRIPTION
### Description

`NodeSpec.leafText` is a new property in [prosemirror-model@1.18.0](https://github.com/ProseMirror/prosemirror-model/pull/66). This property allows a leaf node to customize its `textContent` when using `Node.textContent` or `Node.textBetween(...)`. 

This is especially useful for HardBreakExtension.

Before this PR, if a paragraph contains a `hardBreak` node, the length of its `textContent` is smaller than the size of this paragraph node, because a `hardBreak` node has size as 1, but output empty string in `node.textContent`. This difference between ProseMirror node size and `textContent` string length causes some errors when calculating position. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
