### PR TITLE
fix(annotation): update the store after mapping annotation positions

### DIFF
--- a/packages/remirror__extension-annotation/src/annotation-plugin.ts
+++ b/packages/remirror__extension-annotation/src/annotation-plugin.ts
@@ -123,6 +123,8 @@ export class AnnotationState<Type extends Annotation = Annotation> {
         }))
         // Remove annotations for which all containing content was deleted
         .filter((annotation) => annotation.to !== annotation.from);
+      // Update the store with the updated annotation positions, and the remove ones
+      this.store.setAnnotations(this.annotations);
       this.decorationSet = this.decorationSet.map(tr.mapping, tr.doc);
     }
 


### PR DESCRIPTION
### Description

Fixes #1655.

The internal annotation store was not updated on non annotation actions.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
