### PR TITLE
fix(extension-entity-reference): correct import and typo

### DIFF
--- a/packages/remirror__extension-entity-reference/CHANGELOG.md
+++ b/packages/remirror__extension-entity-reference/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @remirror/entity-reference
+# @remirror/extension-entity-reference
 
 ## 1.0.1
 

--- a/packages/remirror__extension-entity-reference/package.json
+++ b/packages/remirror__extension-entity-reference/package.json
@@ -47,7 +47,7 @@
     "@remirror/pm": "^2.0.0-beta.0"
   },
   "peerDependencies": {
-    "@remirror/pm": "^1.0.1"
+    "@remirror/pm": "^2.0.0-beta.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remirror__extension-entity-reference/readme.md
+++ b/packages/remirror__extension-entity-reference/readme.md
@@ -1,28 +1,28 @@
-# @remirror/entity-reference
+# @remirror/extension-entity-reference
 
 > **Allow users to highlight important content**
 
 [![Version][version]][npm] [![Weekly Downloads][downloads-badge]][npm] [![Bundled size][size-badge]][size] [![Typed Codebase][typescript]](#) [![MIT License][license]](#)
 
-[version]: https://flat.badgen.net/npm/v/@remirror/entity-reference
-[npm]: https://npmjs.com/package/@remirror/entity-reference
+[version]: https://flat.badgen.net/npm/v/@remirror/extension-entity-reference
+[npm]: https://npmjs.com/package/@remirror/extension-entity-reference
 [license]: https://flat.badgen.net/badge/license/MIT/purple
-[size]: https://bundlephobia.com/result?p=@remirror/entity-reference
-[size-badge]: https://flat.badgen.net/bundlephobia/minzip/@remirror/entity-reference
+[size]: https://bundlephobia.com/result?p=@remirror/extension-entity-reference
+[size-badge]: https://flat.badgen.net/bundlephobia/minzip/@remirror/extension-entity-reference
 [typescript]: https://flat.badgen.net/badge/icon/TypeScript?icon=typescript&label
-[downloads-badge]: https://badgen.net/npm/dw/@remirror/entity-reference/red?icon=npm
+[downloads-badge]: https://badgen.net/npm/dw/@remirror/extension-entity-reference/red?icon=npm
 
 ## Installation
 
 ```bash
 # yarn
-yarn add @remirror/entity-reference
+yarn add @remirror/extension-entity-reference
 
 # pnpm
-pnpm add @remirror/entity-reference
+pnpm add @remirror/extension-entity-reference
 
 # npm
-npm install @remirror/entity-reference
+npm install @remirror/extension-entity-reference
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ npm install @remirror/entity-reference
 The following code creates an instance of this extension.
 
 ```ts
-import { HighlightExtension } from '@remirror/entity-reference';
+import { EntityReferenceExtension } from '@remirror/extension-entity-reference';
 
-const extension = new HighlightExtension();
+const extension = new EntityReferenceExtension();
 ```

--- a/packages/remirror__extension-entity-reference/src/types.ts
+++ b/packages/remirror__extension-entity-reference/src/types.ts
@@ -1,5 +1,4 @@
-import { Decoration, FromToProps } from 'remirror';
-import type { AcceptUndefined } from '@remirror/core';
+import type { AcceptUndefined, Decoration, FromToProps } from '@remirror/core';
 
 export interface EntityReferenceMetaData extends FromToProps {
   /**

--- a/packages/remirror__extension-entity-reference/src/utils/disjoined-entity-references.ts
+++ b/packages/remirror__extension-entity-reference/src/utils/disjoined-entity-references.ts
@@ -1,5 +1,4 @@
-import { Mark } from 'remirror';
-import { Node } from '@remirror/pm/model';
+import type { Mark, Node } from '@remirror/pm/model';
 
 import { EntityReferenceMetaData } from '../types';
 


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

`@remirror/extension-entity-reference` doesn't include the dependency `remirror` in its `package.json`, so it shouldn't import anything from `remirror`. 

Fix some typos too in this PR.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
 