### PR TITLE
feat: autolink trigger character

### DIFF
--- a/.changeset/hungry-penguins-move.md
+++ b/.changeset/hungry-penguins-move.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-link': patch
+'storybook-react': patch
+---
+
+Add new logic to allow link mark creation only after a trigger character or a combination was found

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -14,13 +14,11 @@ import {
   BoldExtension,
   createCoreManager,
   extractHref,
-  //LinkExtension,
-  //LinkOptions,
+  LinkExtension,
+  LinkOptions,
   OrderedListExtension,
   TOP_50_TLDS,
 } from 'remirror/extensions';
-
-import { LinkExtension, LinkOptions } from '../src/link-extension';
 
 extensionValidityTest(LinkExtension);
 

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -892,7 +892,7 @@ describe('more auto link cases', () => {
   });
 });
 
-describe('autolinking after special trigger character detected', () => {
+describe('autolinking after one special trigger character detected', () => {
   const editor = create({
     autoLink: true,
     autoLinkAllowedTLDs: TOP_50_TLDS,
@@ -901,9 +901,9 @@ describe('autolinking after special trigger character detected', () => {
   const { link } = editor.attributeMarks;
   const { doc, p } = editor.nodes;
 
-  it('should just create a link mark after one of the trigger character is detected', () => {
+  it('should only create a link mark if a trigger character is detected', () => {
     editor.add(doc(p('google'))).insertText('.com');
-    expect(editor.doc).toEqualRemirrorDocument(doc(p('google', '.com')));
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com')));
 
     editor.add(doc(p('google'))).insertText('.com ');
     expect(editor.doc).toEqualRemirrorDocument(
@@ -920,11 +920,6 @@ describe('autolinking after special trigger character detected', () => {
       doc(p(link({ auto: true, href: '//google.com' })('google.com'), ',')),
     );
 
-    editor.add(doc(p('google'))).insertText('.com ');
-    expect(editor.doc).toEqualRemirrorDocument(
-      doc(p(link({ auto: true, href: '//google.com' })('google.com'), ' ')),
-    );
-
     editor.add(doc(p('google'))).insertText('.com)');
     expect(editor.doc).toEqualRemirrorDocument(
       doc(p(link({ auto: true, href: '//google.com' })('google.com'), ')')),
@@ -936,6 +931,9 @@ describe('autolinking after special trigger character detected', () => {
     );
 
     editor.add(doc(p('google'))).insertText('.com.]');
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//google.com' })('google.com'), '.]')),
+    );
 
     editor.add(doc(p('window.co'))).insertText('mmand');
     expect(editor.doc).toEqualRemirrorDocument(doc(p('window.command')));
@@ -955,10 +953,65 @@ describe('autolinking after special trigger character detected', () => {
     );
   });
 
-  it('shouldnt affect link detection while pasting links with the new `autoLinkAfter` property', () => {
+  it('should not affect link detection while pasting links with `autoLinkAfter` property', () => {
     editor.add(doc(p('<cursor>'))).paste('google.com');
     expect(editor.doc).toEqualRemirrorDocument(
       doc(p(link({ auto: true, href: '//google.com' })('google.com'))),
+    );
+  });
+});
+
+describe('autolinking after more than one special trigger character was found', () => {
+  const editor = create({
+    autoLink: true,
+    autoLinkAllowedTLDs: TOP_50_TLDS,
+    autoLinkAfter: /(] )/g,
+  });
+  const { link } = editor.attributeMarks;
+  const { doc, p } = editor.nodes;
+
+  it('should only create a link mark if more than one of the trigger character is detected', () => {
+    editor.add(doc(p('google'))).insertText('.com');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com')));
+
+    editor.add(doc(p('google'))).insertText('.com]');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com]')));
+
+    editor.add(doc(p('google'))).insertText('.com ');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com ')));
+
+    editor.add(doc(p('google'))).insertText('.com] ');
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//google.com' })('google.com'), '] ')),
+    );
+  });
+});
+
+describe('autolinking after more than one special trigger character was found (More examples)', () => {
+  const editor = create({
+    autoLink: true,
+    autoLinkAllowedTLDs: TOP_50_TLDS,
+    autoLinkAfter: /(]. )/g,
+  });
+  const { link } = editor.attributeMarks;
+  const { doc, p } = editor.nodes;
+
+  it('should only create a link mark if more than one of the trigger character is detected', () => {
+    editor.add(doc(p('google'))).insertText('.com');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com')));
+
+    editor.add(doc(p('google'))).insertText('.com]');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com]')));
+
+    editor.add(doc(p('google'))).insertText('.com ');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com ')));
+
+    editor.add(doc(p('google'))).insertText('.com].');
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('google.com].')));
+
+    editor.add(doc(p('google'))).insertText('.com]. ');
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//google.com' })('google.com'), ']. ')),
     );
   });
 });

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -188,8 +188,7 @@ export interface LinkOptions {
 
   /**
    * A regex that will be placed at the end of `autoLinkRegex` in order to create the link mark
-   * only after finding a `trigger character`, this is useful for those users who don't want to have the link style applied
-   * while writing but after pressing a special key or combination of keys.
+   * only after finding a `trigger character`, this is useful for those users who don't want to have the link * style applied while writing but after pressing a special key or combination of keys.
    *
    * ```ts
    *  import { LinkExtension } from 'remirror/extensions;

--- a/packages/storybook-react/stories/extension-link/link-extension.stories.tsx
+++ b/packages/storybook-react/stories/extension-link/link-extension.stories.tsx
@@ -1,7 +1,8 @@
 import Basic from './basic';
 import ClickHandler from './click-handler';
 import EditDialog from './edit-dialog';
+import TriggerCharacter from './trigger-character';
 import WithTelephoneSupport from './with-telephone-support';
 
-export { Basic, ClickHandler, EditDialog, WithTelephoneSupport };
+export { Basic, ClickHandler, EditDialog, TriggerCharacter, WithTelephoneSupport };
 export default { title: 'Extensions / Link' };

--- a/packages/storybook-react/stories/extension-link/trigger-character.tsx
+++ b/packages/storybook-react/stories/extension-link/trigger-character.tsx
@@ -1,0 +1,20 @@
+import { LinkExtension, PlaceholderExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const TriggerCharacter = (): JSX.Element => {
+  const { manager, state } = useRemirror({
+    extensions: () => [
+      new LinkExtension({ autoLink: true, autoLinkAfter: /[\t\n ),.\]]/g }),
+      new PlaceholderExtension({ placeholder: 'autoLinkAfter property is set to /[\\t\\n ),.]]/' }),
+    ],
+    stringHandler: 'html',
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} initialContent={state} />
+    </ThemeProvider>
+  );
+};
+
+export default TriggerCharacter;

--- a/packages/storybook-react/stories/extension-link/trigger-character.tsx
+++ b/packages/storybook-react/stories/extension-link/trigger-character.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
+
 import { LinkExtension, PlaceholderExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-const TriggerCharacter = (): JSX.Element => {
+const TriggerCharacter = (): React.ReactNode => {
   const { manager, state } = useRemirror({
     extensions: () => [
       new LinkExtension({ autoLink: true, autoLinkAfter: /[\t\n ),.\]]/g }),

--- a/website/extension-examples/extension-link/trigger-character.tsx
+++ b/website/extension-examples/extension-link/trigger-character.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-link/trigger-character.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-link/trigger-character').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;
+  


### PR DESCRIPTION
### Description

Issue: There are some cases where link marks are created by `autolink` in undesired situations, for example in `window.confirm` => `window.co` is a link followed by the text `nfirm`, this is specially annoying while writing code. 

Proposed solution: One way to fix this is to have a trigger character or a set of them and only create the mark if it's at the end of the string. In order to achieve this, I added a new optional property to `LinkExtension` that receives a regex, it'll be placed at the end of `autoLinkRegex` and the implementation will depend on each user/team needs. You can either define a single trigger character or a combination of them.

A bit more of context: It was possible to do this by passing a custom `autoLinkRegex` but we lost that after the TLD validations since `.com ` is not a valid TLD.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Without `autoLinkAfter`:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/22713458/174830284-bdeac4d9-432a-43c6-8b60-bd33167e1e55.gif)

With `autoLinkAfter`:

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/22713458/174832183-3818b81f-b840-44ee-b0d6-61a44ac202c8.gif)

