### PR TITLE
fix(ext-link): not auto detecting adjacent text

### DIFF
--- a/.changeset/sharp-melons-switch.md
+++ b/.changeset/sharp-melons-switch.md
@@ -1,0 +1,25 @@
+---
+'@remirror/extension-link': patch
+---
+
+# fix(ext-link): not auto detecting adjacent text
+
+Closes issue [1732](https://github.com/remirror/remirror/issues/1732)
+
+## Before this change:
+
+Auto link detection did not detect adjacent text.
+
+### Example:
+
+Insert "window.confirm" results in "[window.co](//window.co)nfirm"
+
+## After this change:
+
+Adjacent text is detected and possibly removes invalid link or creates a link
+
+### Example:
+
+Insert "window.confirm" results in "window.confirm"
+
+Added "adjacentPunctuations" option to configure which adjacent punctuation are excluded from links

--- a/packages/remirror__extension-link/src/link-extension-utils.ts
+++ b/packages/remirror__extension-link/src/link-extension-utils.ts
@@ -53,3 +53,43 @@ export const TOP_50_TLDS = [
   'no',
   'cyou',
 ];
+
+export const DEFAULT_ADJACENT_PUNCTUATIONS = [
+  ',',
+  '.',
+  '!',
+  '?',
+  ':',
+  ';',
+  "'",
+  '"',
+  '(',
+  ')',
+  '[',
+  ']',
+];
+
+export const isBalanced = (input: string) => {
+  const brackets = '[]{}()<>';
+  const stack = [];
+
+  for (const bracket of input) {
+    const index = brackets.indexOf(bracket);
+
+    if (index === -1) {
+      continue;
+    }
+
+    if (index % 2 === 0) {
+      stack.push(index + 1);
+
+      continue;
+    }
+
+    if (stack.length === 0 || stack.pop() !== index) {
+      return false;
+    }
+  }
+
+  return stack.length === 0;
+};


### PR DESCRIPTION
### Description

#### Before this change:

Auto link detection did not detect adjacent text.

**Example:**

Insert "window.confirm" results in "[window.co](//window.co)nfirm"

#### After this change:

Adjacent text is detected and possibly removes invalid link or creates a link

**Example**:

Insert "window.confirm" results in "window.confirm"

Added "adjacentPunctuations" option to configure which adjacent punctuation are excluded from links

Closes #1732



### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots


https://user-images.githubusercontent.com/3860298/174903466-bcac9fea-e4cb-4233-989f-7c87600b1659.mov


