### PR TITLE
feature(ext-link): optional link validation function

### DIFF
--- a/.changeset/fuzzy-houses-invite.md
+++ b/.changeset/fuzzy-houses-invite.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-link': patch
+---
+
+Feature: Optional auto link validation function #1730

--- a/.changeset/sharp-melons-switch.md
+++ b/.changeset/sharp-melons-switch.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-link': patch
+---
+
+Fix: Auto link not detecting adjacent text node #1732

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -1274,3 +1274,31 @@ describe('adjacent punctuations', () => {
     );
   });
 });
+
+describe('custom auto link validation function', () => {
+  it('should only validate "remirror-test.io"', () => {
+    const editor = renderEditor([
+      new LinkExtension({
+        autoLink: true,
+        autoLinkValidationFunction: (url) => url === 'remirror-test.io',
+      }),
+    ]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>'))).insertText('remirror.io test.com');
+
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('remirror.io test.com')));
+
+    editor.selectText(21).press('Enter').insertText('remirror-test.io');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(
+        p('remirror.io test.com'),
+        p(link({ auto: true, href: '//remirror-test.io' })('remirror-test.io')),
+      ),
+    );
+  });
+});

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -696,6 +696,26 @@ describe('autolinking', () => {
     );
   });
 
+  it('detects seperating two links', () => {
+    editor.add(doc(p('<cursor>'))).insertText('github.comremirror.io');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//github.comremirror.io' })('github.comremirror.io'))),
+    );
+
+    editor.selectText(11).insertText(' ');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(
+        p(
+          link({ auto: true, href: '//github.com' })('github.com'),
+          ' ',
+          link({ auto: true, href: '//remirror.io' })('remirror.io'),
+        ),
+      ),
+    );
+  });
+
   it('supports deleting selected to to invalidate the match', () => {
     editor
       .add(doc(p('<cursor>')))
@@ -720,6 +740,30 @@ describe('autolinking', () => {
 
     expect(editor.doc).toEqualRemirrorDocument(
       doc(p(link({ auto: true, href: '//test.com' })('test.com'))),
+    );
+  });
+
+  it('supports detecting added adjacent text nodes', () => {
+    editor.add(doc(p('window.co')));
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//window.co' })('window.co'))),
+    );
+
+    editor.insertText('nfirm');
+
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('window.confirm')));
+  });
+
+  it('supports detecting removed adjacent text nodes', () => {
+    editor.add(doc(p('window.confirm')));
+
+    expect(editor.doc).toEqualRemirrorDocument(doc(p('window.confirm')));
+
+    editor.backspace(5);
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//window.co' })('window.co'))),
     );
   });
 

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -1183,3 +1183,94 @@ describe('target', () => {
     expect(editor.doc).toEqualRemirrorDocument(doc(p(link('test'))));
   });
 });
+
+describe('adjacent punctuations', () => {
+  it('should not include trailing `?` in the link', () => {
+    const editor = renderEditor([
+      new LinkExtension({
+        autoLink: true,
+      }),
+    ]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>'))).insertText('remirror.io?test=true');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//remirror.io?test=true' })('remirror.io?test=true'))),
+    );
+
+    editor.selectText(23).backspace(10).insertText('?');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//remirror.io' })('remirror.io'), '?')),
+    );
+  });
+
+  it('should include trailing `?` in the link', () => {
+    const editor = renderEditor([
+      new LinkExtension({
+        autoLink: true,
+        adjacentPunctuations: ['.'],
+      }),
+    ]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>'))).insertText('remirror.io?test=true');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//remirror.io?test=true' })('remirror.io?test=true'))),
+    );
+
+    editor.selectText(23).backspace(10).insertText('?');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//remirror.io?' })('remirror.io?'))),
+    );
+  });
+
+  it('should not remove link if "." is added before link', () => {
+    const editor = renderEditor([
+      new LinkExtension({
+        autoLink: true,
+      }),
+    ]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor
+      .add(doc(p('<cursor>')))
+      .insertText('remirror.io')
+      .selectText(0)
+      .insertText('.');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p('.', link({ auto: true, href: '//remirror.io' })('remirror.io'))),
+    );
+  });
+
+  it('should not include surrounding `"` in the link', () => {
+    const editor = renderEditor([
+      new LinkExtension({
+        autoLink: true,
+      }),
+    ]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.add(doc(p('<cursor>'))).insertText('"remirror.io"');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p('"', link({ auto: true, href: '//remirror.io' })('remirror.io'), '"')),
+    );
+  });
+});

--- a/packages/remirror__extension-link/src/link-extension-utils.ts
+++ b/packages/remirror__extension-link/src/link-extension-utils.ts
@@ -53,3 +53,5 @@ export const TOP_50_TLDS = [
   'no',
   'cyou',
 ];
+
+export const DEFAULT_ADJACENT_PUNCTUATIONS = [',', '.', '!', '?', ':', ';', "'", '"'];

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -155,6 +155,25 @@ export interface LinkOptions {
   autoLinkRegex?: Static<RegExp>;
 
   /**
+   * Custom link validation function
+   *
+   * Replaces matching against the RegExp with the autoLinkRegex matcher
+   *
+   * ```ts
+   * import { LinkExtension } from 'remirror/extensions';
+   * import LinkifyIt from "linkify-it";
+   * const extensions = () => [
+   *   new LinkExtension({ autoLinkValidationFunction: (url?: string): boolean => {
+   *      return linkify.test(url)
+   *   }})
+   * ];
+   * ```
+   *
+   * @default null
+   */
+  autoLinkValidationFunction?: ((url?: string) => boolean) | null;
+
+  /**
    * An array of valid Top Level Domains (TLDs) to limit the scope of auto linking.
    *
    * @remarks
@@ -254,6 +273,7 @@ export type LinkAttributes = ProsemirrorAttributes<{
     selectTextOnClick: false,
     openLinkOnClick: false,
     autoLinkRegex: DEFAULT_AUTO_LINK_REGEX,
+    autoLinkValidationFunction: null,
     autoLinkAllowedTLDs: TOP_50_TLDS,
     adjacentPunctuations: DEFAULT_ADJACENT_PUNCTUATIONS,
     defaultTarget: null,
@@ -762,7 +782,11 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
   }
 
   private isValidUrl(url: string) {
-    return this._autoLinkRegexNonGlobal?.test(url);
+    if (typeof this.options.autoLinkValidationFunction !== 'function') {
+      return this._autoLinkRegexNonGlobal?.test(url);
+    }
+
+    return this.options.autoLinkValidationFunction(url);
   }
 
   private isValidTLD(str: string): boolean {


### PR DESCRIPTION
### Description
Ability to provide a custom link validation function for the Remirror link extension.

Opening as a draft, this feature is based on a branch with an open pull request #1743

closes #1730

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

