### PR TITLE
fix(link): treat links with same href and text content as auto link

### DIFF
--- a/.changeset/bright-forks-perform.md
+++ b/.changeset/bright-forks-perform.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-link': patch
+---
+
+fix(ext-link): unable to edit links
+
+When href equals text content there is no reason why a link should not be editable.

--- a/.changeset/bright-forks-perform.md
+++ b/.changeset/bright-forks-perform.md
@@ -2,6 +2,4 @@
 '@remirror/extension-link': patch
 ---
 
-fix(ext-link): unable to edit links
-
-When href equals text content there is no reason why a link should not be editable.
+When href equals text content, treat the link as an auto link (if enabled)

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -696,6 +696,38 @@ describe('autolinking', () => {
     );
   });
 
+  it('should create auto link if href equals text content', () => {
+    const editor = renderEditor([new LinkExtension({ autoLink: true })]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.chain.insertHtml('<a href="//test.com">test.com</a>').run();
+
+    editor.selectText(5).insertText('er');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: true, href: '//tester.com' })('tester.com'))),
+    );
+  });
+
+  it('should not create auto link if href does not equal text content', () => {
+    const editor = renderEditor([new LinkExtension({ autoLink: true })]);
+    const {
+      attributeMarks: { link },
+      nodes: { doc, p },
+    } = editor;
+
+    editor.chain.insertHtml('<a href="//test.com">test</a>').run();
+
+    editor.selectText(5).insertText('er');
+
+    expect(editor.doc).toEqualRemirrorDocument(
+      doc(p(link({ auto: false, href: '//test.com' })('test'), 'er')),
+    );
+  });
+
   it('supports deleting selected to to invalidate the match', () => {
     editor
       .add(doc(p('<cursor>')))

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -296,9 +296,10 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
             // e.g [test](//test.com) - not "auto link"
             // e.g [test.com](//test.com) - "auto link"
             const auto =
-              node.hasAttribute(AUTO_ATTRIBUTE) ||
-              href === text ||
-              href?.replace(`${this.options.defaultProtocol}//`, '') === text;
+              this.options.autoLink &&
+              (node.hasAttribute(AUTO_ATTRIBUTE) ||
+                href === text ||
+                href?.replace(`${this.options.defaultProtocol}//`, '') === text);
 
             return {
               ...extra.parse(node),

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -290,7 +290,16 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
             }
 
             const href = node.getAttribute('href');
-            const auto = node.hasAttribute(AUTO_ATTRIBUTE);
+            const text = node.textContent;
+
+            // If link text content equals href value we "auto link"
+            // e.g [test](//test.com) - not "auto link"
+            // e.g [test.com](//test.com) - "auto link"
+            const auto =
+              node.hasAttribute(AUTO_ATTRIBUTE) ||
+              href === text ||
+              href?.replace(`${this.options.defaultProtocol}//`, '') === text;
+
             return {
               ...extra.parse(node),
               href,


### PR DESCRIPTION
### Description

When href equals text content there is no reason why a link
should not be editable.

closes #1740

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

