### PR TITLE
Fix(entity-reference): Add helper and command to entity-reference extension 

### DIFF
--- a/packages/remirror__extension-entity-reference/__tests__/entity-reference-extension.spec.ts
+++ b/packages/remirror__extension-entity-reference/__tests__/entity-reference-extension.spec.ts
@@ -211,4 +211,21 @@ describe('EntityReference marks', () => {
       expect(entityReferences).toHaveLength(2);
     });
   });
+
+  describe('getEntityReferenceId', () => {
+    it('Returns entityReference by Id', () => {
+      add(doc(p('testing text')));
+      const entityReference = {
+        id: 'testId',
+        from: 1,
+        to: 8,
+        text: 'testing',
+      };
+      selectText({ from: entityReference.from, to: entityReference.to });
+      commands.addEntityReference(entityReference.id);
+      const entityReferenceFromDoc = helpers.getEntityReferenceById(entityReference.id);
+
+      expect(entityReferenceFromDoc).toEqual(entityReference);
+    });
+  });
 });

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -21,7 +21,7 @@ import {
   within,
 } from '@remirror/core';
 import { Node } from '@remirror/pm/model';
-import { EditorStateConfig } from '@remirror/pm/state';
+import { EditorStateConfig, TextSelection } from '@remirror/pm/state';
 import { DecorationSet } from '@remirror/pm/view';
 
 import { EntityReferenceMetaData, EntityReferenceOptions } from './types';
@@ -170,6 +170,34 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
   }
 
   /**
+   * Dispatch a transaction that selects the range of the entity reference then scrolls to it.
+   *
+   * @param entityReferenceId - The entity's reference Id.
+   *
+   * @returns True if the scrolling was applied, else it returns false
+   *
+   */
+  @command()
+  scrollToEntityReference(entityReferenceId: string): CommandFunction {
+    return ({ tr, dispatch }) => {
+      const entityReference = this.store.helpers.getEntityReferenceById(entityReferenceId);
+
+      if (!entityReference) {
+        return false;
+      }
+
+      const { doc } = tr;
+      const resolvedFrom = doc.resolve(entityReference.from);
+      const resolvedTo = doc.resolve(entityReference.to);
+      const entityReferenceSelection = new TextSelection(resolvedFrom, resolvedTo);
+      // Select range and scroll into it
+      tr.setSelection(entityReferenceSelection).scrollIntoView();
+      dispatch?.(tr);
+      return true;
+    };
+  }
+
+  /**
    * Get all disjoined entityReference attributes from the document.
    */
   @helper()
@@ -210,6 +238,23 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
       state: this.store.getState(),
     }).flat();
     return joinDisjoinedEntityReferences(entityReferences);
+  }
+
+  /**
+   * @param entityReferenceId - The entity's reference Id.
+   *
+   * @returns EntityReference attributes from the editor's content, undefined if it doesn't exist.
+   *
+   */
+  @helper()
+  getEntityReferenceById(entityReferenceId: string): Helper<EntityReferenceMetaData | undefined> {
+    const entityReferences = getEntityReferencesFromPluginState({
+      extension: this,
+      state: this.store.getState(),
+    }).flat();
+    return joinDisjoinedEntityReferences(entityReferences).find(
+      (entityReference) => entityReference.id === entityReferenceId,
+    );
   }
 
   /**


### PR DESCRIPTION
### Description

Add `getEntityReferenceById` helper: return an entity reference from the document by its Id.
Add `scrollToEntityReference` command: Selects the range of the entity reference in the document and scrolls to it. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [] My code follows the code style of this project and `pnpm fix` completed successfully.
- [] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
