### PR TITLE
fix: try to find valid endpoint for text selection

### DIFF
--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -199,7 +199,9 @@ interface DispatchTextSelectionProps extends TestEditorViewProps {
 export function dispatchTextSelection(props: DispatchTextSelectionProps): void {
   const { view, start, end } = props;
   const { state } = view;
-  const tr = state.tr.setSelection(TextSelection.create(state.doc, start, end));
+  const tr = state.tr.setSelection(
+    TextSelection.between(state.doc.resolve(start), state.doc.resolve(end ?? start)),
+  );
 
   view.dispatch(tr);
 }
@@ -212,7 +214,9 @@ interface DispatchAnchorTextSelectionProps extends TestEditorViewProps, AnchorHe
 export function dispatchAnchorTextSelection(props: DispatchAnchorTextSelectionProps): void {
   const { view, anchor, head } = props;
   const { state } = view;
-  const tr = state.tr.setSelection(TextSelection.create(state.doc, anchor, head));
+  const tr = state.tr.setSelection(
+    TextSelection.between(state.doc.resolve(anchor), state.doc.resolve(head)),
+  );
 
   view.dispatch(tr);
 }

--- a/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
@@ -45,7 +45,7 @@ interface CreateTextSelectionProps extends TaggedDocProps {
 function createTextSelection({ taggedDoc, start, end }: CreateTextSelectionProps) {
   const $start = taggedDoc.resolve(start);
   const $end = end && start <= end ? taggedDoc.resolve(end) : taggedDoc.resolve($start.end());
-  return new TextSelection($start, $end);
+  return TextSelection.between($start, $end);
 }
 
 const supportedTags = new Set(['cursor', 'node', 'start', 'end', 'anchor', 'all', 'gap']);
@@ -81,7 +81,7 @@ export function initSelection(taggedDoc: ProsemirrorNode): Selection | undefined
   }
 
   if (isNumber(cursor)) {
-    return new TextSelection(taggedDoc.resolve(cursor));
+    return TextSelection.near(taggedDoc.resolve(cursor));
   }
 
   if (isNumber(gap)) {
@@ -90,7 +90,7 @@ export function initSelection(taggedDoc: ProsemirrorNode): Selection | undefined
   }
 
   if (isNumber(anchor) && isNumber(head)) {
-    return TextSelection.create(taggedDoc, anchor, head);
+    return TextSelection.between(taggedDoc.resolve(anchor), taggedDoc.resolve(head));
   }
 
   if (isNumber(start)) {

--- a/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
@@ -81,7 +81,7 @@ export function initSelection(taggedDoc: ProsemirrorNode): Selection | undefined
   }
 
   if (isNumber(cursor)) {
-    return new TextSelection(taggedDoc.resolve(cursor));
+    return TextSelection.near(taggedDoc.resolve(cursor));
   }
 
   if (isNumber(gap)) {

--- a/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
@@ -81,7 +81,7 @@ export function initSelection(taggedDoc: ProsemirrorNode): Selection | undefined
   }
 
   if (isNumber(cursor)) {
-    return TextSelection.near(taggedDoc.resolve(cursor));
+    return new TextSelection(taggedDoc.resolve(cursor));
   }
 
   if (isNumber(gap)) {

--- a/packages/remirror__core-utils/__tests__/command-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/command-utils.spec.ts
@@ -199,12 +199,10 @@ describe('replaceText', () => {
   });
 
   it('can append text', () => {
-    const from = doc(p('Ignore'), '<cursor>');
+    const from = doc(p('Ignore'), p('<cursor>'));
     const to = doc(p('Ignore'), p('Content '));
 
-    expect(
-      replaceText({ appendText: ' ', type: schema.nodes.paragraph, content: 'Content' }),
-    ).toTransform({
+    expect(replaceText({ appendText: ' ', content: 'Content' })).toTransform({
       from,
       to,
     });

--- a/packages/remirror__core-utils/__tests__/command-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/command-utils.spec.ts
@@ -184,15 +184,13 @@ describe('replaceText', () => {
   });
 
   it('can specify from and to', () => {
-    const from = doc(p('Ignore'), '<cursor>');
-    const to = doc(p('Ignore'), h1('Content'));
-
+    const from = doc(p('<cursor>Ignore'), p(''));
+    const to = doc(p('Ignore'), p('Content'));
     expect(
       replaceText({
         appendText: '',
-        type: schema.nodes.heading,
         content: 'Content',
-        range: { from: 8, to: 8 },
+        range: { from: 9, to: 9 },
       }),
     ).toTransform({
       from,
@@ -266,8 +264,8 @@ describe('toggleWrap', () => {
   });
 
   it('lifts the node when already wrapped', () => {
-    const from = doc(p(blockquote('Lift <cursor>me')));
-    const to = doc(blockquote('Lift me'));
+    const from = doc(blockquote(blockquote(p('Lift <cursor>me'))));
+    const to = doc(blockquote(p('Lift me')));
 
     expect(toggleWrap(schema.nodes.blockquote)).toTransform({ from, to });
   });

--- a/packages/remirror__core-utils/__tests__/prosemirror-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/prosemirror-utils.spec.ts
@@ -72,106 +72,6 @@ describe('removeNodeAtPosition', () => {
   });
 });
 
-describe('removeNodeBefore', () => {
-  it('does nothing if there is no nodeBefore', () => {
-    const {
-      state: { tr },
-    } = createEditor(doc(p('<cursor>')));
-    const steps = tr.steps;
-
-    removeNodeBefore(tr);
-    expect(steps).toBe(tr.steps);
-  });
-
-  it('supports removing tables', () => {
-    const {
-      state: { tr },
-    } = createEditor(doc(p('one'), table(row(tdEmpty), row(tdEmpty)), '<cursor>', p('two')));
-    removeNodeBefore(tr);
-
-    expect(tr.doc).toEqualProsemirrorNode(doc(p('one'), p('two')));
-  });
-
-  it('supports removing blockquotes', () => {
-    const {
-      state: { tr },
-    } = createEditor(doc(p('one'), blockquote(p('')), '<cursor>', p('two')));
-    removeNodeBefore(tr);
-
-    expect(tr.doc).toEqualProsemirrorNode(doc(p('one'), p('two')));
-  });
-
-  it('supports removing leaf nodes (atom)', () => {
-    const {
-      state: { tr },
-    } = createEditor(doc(p('one'), atomBlock(), '<cursor>', p('two')));
-    removeNodeBefore(tr);
-
-    expect(tr.doc).toEqualProsemirrorNode(doc(p('one'), p('two')));
-  });
-});
-
-describe('findPositionOfNodeBefore', () => {
-  it('returns `undefined` when none exists', () => {
-    const {
-      state: { selection },
-    } = createEditor(doc(p('<cursor>')));
-    const result = findPositionOfNodeBefore(selection);
-
-    expect(result).toBeUndefined();
-  });
-
-  it('supports tables', () => {
-    const node = table(row(tdEmpty), row(tdEmpty));
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), node, '<cursor>'));
-    const result = findPositionOfNodeBefore(selection);
-
-    expect(result).toEqual({ pos: 6, start: 7, end: 20, depth: 1, node });
-  });
-
-  it('supports blockquotes', () => {
-    const node = blockquote(p(''));
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), node, '<cursor>'));
-    const position = findPositionOfNodeBefore(selection);
-
-    expect(position).toEqual({ pos: 6, start: 7, end: 10, depth: 1, node });
-  });
-
-  it('supports nested leaf nodes', () => {
-    const node = atomBlock();
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), table(row(td(p('1'), node, '<cursor>')))));
-    const position = findPositionOfNodeBefore(selection);
-
-    expect(position).toEqual({ pos: 12, start: 13, end: 13, depth: 4, node });
-  });
-
-  it('supports non-nested leaf nodes', () => {
-    const node = atomBlock();
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), node, '<cursor>'));
-    const position = findPositionOfNodeBefore(selection);
-
-    expect(position).toEqual({ pos: 6, start: 7, end: 7, depth: 1, node });
-  });
-
-  it('supports leaf nodes with with nested inline atom nodes', () => {
-    const node = atomContainer(atomBlock());
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), node, '<cursor>'));
-    const position = findPositionOfNodeBefore(selection);
-
-    expect(position).toEqual({ pos: 6, start: 7, end: 9, depth: 1, node });
-  });
-});
-
 describe('findPositionOfNodeAfter', () => {
   it('returns `undefined` when none exists', () => {
     const {
@@ -184,20 +84,16 @@ describe('findPositionOfNodeAfter', () => {
 
   it('supports tables', () => {
     const node = table(row(tdEmpty), row(tdEmpty));
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), '<cursor>', node));
-    const result = findPositionOfNodeAfter(selection);
+    const { state } = createEditor(doc(p('abcd'), node));
+    const position = findPositionOfNodeAfter(state.doc.resolve(6));
 
-    expect(result).toEqual({ pos: 6, start: 7, end: 20, depth: 1, node });
+    expect(position).toEqual({ pos: 6, start: 7, end: 20, depth: 1, node });
   });
 
   it('supports blockquotes', () => {
     const node = blockquote(p(''));
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), '<cursor>', node));
-    const position = findPositionOfNodeAfter(selection);
+    const { state } = createEditor(doc(p('abcd'), node));
+    const position = findPositionOfNodeAfter(state.doc.resolve(6));
 
     expect(position).toEqual({ pos: 6, start: 7, end: 10, depth: 1, node });
   });
@@ -214,20 +110,16 @@ describe('findPositionOfNodeAfter', () => {
 
   it('supports non-nested leaf nodes', () => {
     const node = atomBlock();
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), '<cursor>', node));
-    const position = findPositionOfNodeAfter(selection);
+    const { state } = createEditor(doc(p('abcd'), node));
+    const position = findPositionOfNodeAfter(state.doc.resolve(6));
 
     expect(position).toEqual({ pos: 6, start: 7, end: 7, depth: 1, node });
   });
 
   it('supports leaf nodes with with nested inline atom nodes', () => {
     const node = atomContainer(atomBlock());
-    const {
-      state: { selection },
-    } = createEditor(doc(p('abcd'), '<cursor>', node));
-    const position = findPositionOfNodeAfter(selection);
+    const { state } = createEditor(doc(p('abcd'), node));
+    const position = findPositionOfNodeAfter(state.doc.resolve(6));
 
     expect(position).toEqual({ pos: 6, start: 7, end: 9, depth: 1, node });
   });
@@ -483,7 +375,7 @@ describe('findParentNodeOfType', () => {
 describe('nodeActive', () => {
   it('shows active when within an active region', () => {
     const { state, schema: sch } = createEditor(
-      doc(p('Something', blockquote('is <cursor>in blockquote'))),
+      doc(p('Something', blockquote(p('is <cursor>in blockquote')))),
     );
 
     expect(isNodeActive({ state, type: sch.nodes.blockquote })).toBeTrue();

--- a/packages/remirror__core-utils/__tests__/prosemirror-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/prosemirror-utils.spec.ts
@@ -29,14 +29,12 @@ import {
   findParentNode,
   findParentNodeOfType,
   findPositionOfNodeAfter,
-  findPositionOfNodeBefore,
   findSelectedNodeOfType,
   hasTransactionChanged,
   isNodeActive,
   isNodeOfType,
   isSelectionEmpty,
   removeNodeAtPosition,
-  removeNodeBefore,
   schemaToJSON,
 } from '../';
 

--- a/packages/remirror__core-utils/src/command-utils.ts
+++ b/packages/remirror__core-utils/src/command-utils.ts
@@ -50,7 +50,9 @@ export interface UpdateMarkProps extends Partial<RangeProps>, Partial<Attributes
 export function updateMark(props: UpdateMarkProps): CommandFunction {
   return ({ dispatch, tr }) => {
     const { type, attrs = object(), appendText, range } = props;
-    const selection = range ? TextSelection.create(tr.doc, range.from, range.to) : tr.selection;
+    const selection = range
+      ? TextSelection.between(tr.doc.resolve(range.from), tr.doc.resolve(range.to))
+      : tr.selection;
     const { $from, from, to } = selection;
     let applicable = $from.depth === 0 ? tr.doc.type.allowsMarkType(type) : false;
 
@@ -327,9 +329,9 @@ export function preserveSelection(selection: Selection, tr: Transaction): void {
 
   if (empty) {
     // Update the transaction with the new text selection.
-    tr.setSelection(TextSelection.create(tr.doc, head));
+    tr.setSelection(TextSelection.near(tr.doc.resolve(head)));
   } else {
-    tr.setSelection(TextSelection.create(tr.doc, anchor, head));
+    tr.setSelection(TextSelection.between(tr.doc.resolve(anchor), tr.doc.resolve(head)));
   }
 }
 

--- a/packages/remirror__core-utils/src/core-utils.ts
+++ b/packages/remirror__core-utils/src/core-utils.ts
@@ -828,7 +828,9 @@ export function getSelectedGroup(
   let { from, to } = state.selection;
 
   const getChar = (start: number, end: number) =>
-    getTextContentFromSlice(TextSelection.create(state.doc, start, end).content());
+    getTextContentFromSlice(
+      TextSelection.between(state.doc.resolve(start), state.doc.resolve(end)).content(),
+    );
 
   for (
     let char = getChar(from - 1, from);
@@ -1072,7 +1074,7 @@ export function getTextSelection(selection: PrimitiveSelection, doc: Prosemirror
     const anchor = clampToDocument(pos.anchor);
     const head = clampToDocument(pos.head);
 
-    return TextSelection.create(doc, anchor, head);
+    return TextSelection.between(doc.resolve(anchor), doc.resolve(head));
   }
 
   // In this case assume that `from` is the fixed anchor and `to` is the movable
@@ -1080,7 +1082,7 @@ export function getTextSelection(selection: PrimitiveSelection, doc: Prosemirror
   const anchor = clampToDocument(pos.from);
   const head = clampToDocument(pos.to);
 
-  return TextSelection.create(doc, anchor, head);
+  return TextSelection.between(doc.resolve(anchor), doc.resolve(head));
 }
 
 /**

--- a/packages/remirror__core-utils/src/prosemirror-utils.ts
+++ b/packages/remirror__core-utils/src/prosemirror-utils.ts
@@ -304,6 +304,8 @@ export function findParentNodeOfType(
  * ```
  *
  * @param selection - the prosemirror selection
+ *
+ * @deprecated This util is hard to use and not that useful
  */
 export function findPositionOfNodeBefore(
   value: Selection | ResolvedPos | EditorState | Transaction,
@@ -347,6 +349,8 @@ export function findPositionOfNodeBefore(
  * ```
  *
  * @param tr
+ *
+ * @deprecated This util is hard to use and not that useful
  */
 export function removeNodeBefore(tr: Transaction): Transaction {
   const result = findPositionOfNodeBefore(tr.selection);
@@ -433,6 +437,8 @@ interface FindParentNodeProps extends StateSelectionPosProps {
  * ```
  *
  * @param selection - the prosemirror selection
+ *
+ * @deprecated This util is hard to use and not that useful
  */
 export function findPositionOfNodeAfter(
   value: Selection | ResolvedPos | EditorState,
@@ -475,6 +481,8 @@ export function findPositionOfNodeAfter(
  * ```
  *
  * @param tr
+ *
+ * @deprecated This util is hard to use and not that useful
  */
 export function removeNodeAfter(tr: Transaction): Transaction {
   const result = findPositionOfNodeAfter(tr.selection);

--- a/packages/remirror__core/src/builtins/commands-extension.ts
+++ b/packages/remirror__core/src/builtins/commands-extension.ts
@@ -425,7 +425,7 @@ export class CommandsExtension extends PlainExtension<CommandOptions> {
    * commands.selectText(10);
    *
    * // Use a ProseMirror selection
-   * commands.selectText(new TextSelection(state.doc.resolve(10)))
+   * commands.selectText(TextSelection.near(state.doc.resolve(10)))
    * ```
    *
    * Although this is called `selectText` you can provide your own selection
@@ -602,7 +602,7 @@ export class CommandsExtension extends PlainExtension<CommandOptions> {
         return false;
       }
 
-      dispatch?.(tr.setSelection(TextSelection.create(tr.doc, tr.selection.anchor)));
+      dispatch?.(tr.setSelection(TextSelection.near(tr.selection.$anchor)));
       return true;
     };
   }

--- a/packages/remirror__extension-callout/src/callout-extension.ts
+++ b/packages/remirror__extension-callout/src/callout-extension.ts
@@ -140,7 +140,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
         type: this.type,
         beforeDispatch: ({ tr, start }) => {
           const $pos = tr.doc.resolve(start);
-          tr.setSelection(new TextSelection($pos));
+          tr.setSelection(TextSelection.near($pos));
         },
         getAttributes: (match) => {
           const { defaultType, validTypes } = this.options;
@@ -222,7 +222,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
       tr.replace(pos, end, slice);
 
       // Set the selection to within the callout
-      tr.setSelection(TextSelection.create(tr.doc, pos + 1));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(pos + 1)));
       dispatch(tr);
     }
 
@@ -270,7 +270,7 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
     if (node.type !== this.type && previousNode.type === this.type) {
       const { content, nodeSize } = node;
       tr.delete(pos, pos + nodeSize);
-      tr.setSelection(TextSelection.create(tr.doc, previousPosition - 1));
+      tr.setSelection(TextSelection.near(tr.doc.resolve(previousPosition - 1)));
       tr.insert(previousPosition - 1, content);
 
       if (dispatch) {

--- a/packages/remirror__extension-code-block/src/code-block-extension.ts
+++ b/packages/remirror__extension-code-block/src/code-block-extension.ts
@@ -173,7 +173,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
         type: this.type,
         beforeDispatch: ({ tr, start }) => {
           const $pos = tr.doc.resolve(start);
-          tr.setSelection(new TextSelection($pos));
+          tr.setSelection(TextSelection.near($pos));
         },
         getAttributes: getAttributes,
       }),
@@ -421,7 +421,7 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
     tr.replaceWith(pos, end, this.type.create({ language }));
 
     // Set the selection to within the codeBlock
-    tr.setSelection(TextSelection.create(tr.doc, pos + 1));
+    tr.setSelection(TextSelection.near(tr.doc.resolve(pos + 1)));
 
     if (dispatch) {
       dispatch(tr);

--- a/packages/remirror__extension-code-block/src/code-block-utils.ts
+++ b/packages/remirror__extension-code-block/src/code-block-utils.ts
@@ -320,7 +320,9 @@ export function formatCodeBlockFactory(props: FormatCodeBlockFactoryProps) {
       const anchor = start + cursorOffset;
       const head = formatEnd ? start + formatEnd.cursorOffset : undefined;
 
-      tr.setSelection(TextSelection.create(tr.doc, anchor, head));
+      tr.setSelection(
+        TextSelection.between(tr.doc.resolve(anchor), tr.doc.resolve(head ?? anchor)),
+      );
 
       if (dispatch) {
         dispatch(tr);

--- a/packages/remirror__extension-codemirror5/src/codemirror-node-view.ts
+++ b/packages/remirror__extension-codemirror5/src/codemirror-node-view.ts
@@ -141,11 +141,11 @@ export class CodeMirrorNodeView implements NodeView {
    * ProseMirror selection. Because CodeMirror uses a line/column based indexing
    * system, `indexFromPos` is used to convert to an actual character index.
    */
-  asProseMirrorSelection(doc: ProsemirrorNode): TextSelection {
+  asProseMirrorSelection(doc: ProsemirrorNode): Selection {
     const offset = this.#getPos() + 1;
     const anchor = this.#cm.indexFromPos(this.#cm.getCursor('anchor')) + offset;
     const head = this.#cm.indexFromPos(this.#cm.getCursor('head')) + offset;
-    return TextSelection.create(doc, anchor, head);
+    return TextSelection.between(doc.resolve(anchor), doc.resolve(head));
   }
 
   /**

--- a/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
@@ -103,7 +103,7 @@ export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOption
         type: this.type,
         beforeDispatch: ({ tr, start }) => {
           const $pos = tr.doc.resolve(start);
-          tr.setSelection(new TextSelection($pos));
+          tr.setSelection(TextSelection.near($pos));
         },
         getAttributes: getAttributes,
       }),
@@ -144,7 +144,7 @@ export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOption
     tr.replaceWith(pos, end, this.type.create({ language }));
 
     // Set the selection to within the codeBlock
-    tr.setSelection(TextSelection.create(tr.doc, pos + 1));
+    tr.setSelection(TextSelection.near(tr.doc.resolve(pos + 1)));
 
     if (dispatch) {
       dispatch(tr);

--- a/packages/remirror__extension-codemirror6/src/codemirror-node-view.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-node-view.ts
@@ -191,7 +191,7 @@ export class CodeMirror6NodeView implements NodeView {
   private asProseMirrorSelection(doc: ProsemirrorNode) {
     const start = this.getPos() + 1;
     const { anchor, head } = this.cm.state.selection.main;
-    return TextSelection.create(doc, anchor + start, head + start);
+    return TextSelection.between(doc.resolve(anchor + start), doc.resolve(head + start));
   }
 
   /**

--- a/packages/remirror__extension-font-size/src/font-size-extension.ts
+++ b/packages/remirror__extension-font-size/src/font-size-extension.ts
@@ -182,7 +182,7 @@ export class FontSizeExtension extends MarkExtension<FontSizeOptions> {
    */
   @command()
   removeFontSize(options?: SizeCommandOptions): CommandFunction {
-    return this.store.commands.removeMark.original({ type: this.type, ...options });
+    return this.store.commands.removeMark.original({ type: this.type, expand: false, ...options });
   }
 
   /**

--- a/packages/remirror__extension-horizontal-rule/src/horizontal-rule-extension.ts
+++ b/packages/remirror__extension-horizontal-rule/src/horizontal-rule-extension.ts
@@ -142,7 +142,7 @@ export class HorizontalRuleExtension extends NodeExtension<HorizontalRuleOptions
     tr.insert(pos, node);
 
     // Set the new selection to be inside the inserted node.
-    tr.setSelection(TextSelection.create(tr.doc, pos + 1));
+    tr.setSelection(TextSelection.near(tr.doc.resolve(pos + 1)));
   }
 }
 

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -516,7 +516,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
           if (this.options.selectTextOnClick) {
             const $start = doc.resolve(range.from);
             const $end = doc.resolve(range.to);
-            const transaction = tr.setSelection(new TextSelection($start, $end));
+            const transaction = tr.setSelection(TextSelection.between($start, $end));
 
             view.dispatch(transaction);
           }

--- a/packages/remirror__extension-list/src/list-command-indent.ts
+++ b/packages/remirror__extension-list/src/list-command-indent.ts
@@ -137,8 +137,8 @@ export function indentList(tr: Transaction): boolean {
 
   tr.setSelection(
     previousList === selectedList
-      ? TextSelection.create(tr.doc, $from.pos, $to.pos)
-      : TextSelection.create(tr.doc, $from.pos - 2, $to.pos - 2),
+      ? TextSelection.between(tr.doc.resolve($from.pos), tr.doc.resolve($to.pos))
+      : TextSelection.between(tr.doc.resolve($from.pos - 2), tr.doc.resolve($to.pos - 2)),
   );
 
   return true;

--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -181,7 +181,7 @@ export function splitListItem(
 
         if (newListItem) {
           tr.insert(newListItemStartPos, newListItem);
-          tr.setSelection(TextSelection.create(tr.doc, newListItemStartPos + 1));
+          tr.setSelection(TextSelection.near(tr.doc.resolve(newListItemStartPos + 1)));
         }
 
         tr.delete($from.pos, $to.pos);
@@ -458,7 +458,7 @@ export function wrapSelectedItems({
   }
 
   tr.setSelection(
-    new TextSelection(
+    TextSelection.between(
       tr.doc.resolve(atStart ? from : from + 2),
       tr.doc.resolve(atStart ? to : to + 2),
     ),


### PR DESCRIPTION
### Description

This PR uses `TextSelection.between()` and `TextSelection.near()` to replace `TextSelection.create()` and `new TextSelection()`. This will add an extra step before creating a `TextSelection` to make sure that the endpoint positions are valid for a `TextSelection`. 

This PR fixes the following warning during unit tests:

```
  console.warn
    TextSelection endpoint not pointing into a node with inline content (doc)
```

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
