### PR TITLE
feat(extension-codemirror6): add two commands 

### DIFF
--- a/.changeset/wise-buses-eat.md
+++ b/.changeset/wise-buses-eat.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-codemirror6': minor
+---
+
+`@remirror/extension-codemirror6` now includes two new commands: `createCodeMirror` and `updateCodeMirror`, which allows you to create and update a CodeMirror block.

--- a/packages/remirror__extension-codemirror6/__tests__/codemirror-extension.spec.ts
+++ b/packages/remirror__extension-codemirror6/__tests__/codemirror-extension.spec.ts
@@ -1,0 +1,55 @@
+import { renderEditor } from 'jest-remirror';
+
+import { CodeMirrorExtension } from '../';
+
+function create() {
+  const renderEditorReturn = renderEditor([new CodeMirrorExtension()]);
+
+  const {
+    add,
+    nodes: { doc, p },
+    commands,
+    view,
+    attributeNodes: { codeMirror },
+  } = renderEditorReturn;
+  const { dom } = view;
+  const plainBlock = codeMirror();
+  const pyBlock = codeMirror({ language: 'python' });
+  const jsBlock = codeMirror({ language: 'javascript' });
+  return {
+    add,
+    view,
+    doc,
+    p,
+    codeMirror,
+    plainBlock,
+    pyBlock,
+    jsBlock,
+    dom,
+    commands,
+  };
+}
+
+describe('commands', () => {
+  describe('createCodeMirror', () => {
+    const { view, add, jsBlock, doc, p, commands } = create();
+
+    it('creates the codeBlock', () => {
+      add(doc(p(`<cursor>`)));
+      commands.createCodeMirror({ language: 'javascript' });
+      expect(view.state).toEqualRemirrorState(doc(jsBlock('<cursor>')));
+    });
+  });
+
+  describe('updateCodeMirror', () => {
+    const { add, view, doc, jsBlock, pyBlock, commands } = create();
+
+    it('updates the language', () => {
+      add(doc(pyBlock('aaa'), pyBlock('bb<cursor>b'), pyBlock('ccc')));
+      commands.updateCodeMirror({ language: 'javascript' });
+      expect(view.state).toEqualRemirrorState(
+        doc(pyBlock('aaa'), jsBlock('bb<cursor>b'), pyBlock('ccc')),
+      );
+    });
+  });
+});

--- a/packages/remirror__extension-codemirror6/__tests__/tsconfig.json
+++ b/packages/remirror__extension-codemirror6/__tests__/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "__AUTO_GENERATED__": [
+    "To update the configuration edit the following field.",
+    "`package.json > @remirror > tsconfigs > '__tests__'`",
+    "",
+    "Then run: `pnpm -w generate:ts`"
+  ],
+  "extends": "../../../support/tsconfig.base.json",
+  "compilerOptions": {
+    "types": [
+      "jest",
+      "jest-extended",
+      "jest-axe",
+      "@testing-library/jest-dom",
+      "snapshot-diff",
+      "node"
+    ],
+    "declaration": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove"
+  },
+  "include": ["./"],
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../testing/src"
+    },
+    {
+      "path": "../../remirror/src"
+    },
+    {
+      "path": "../../remirror__core/src"
+    },
+    {
+      "path": "../../remirror__pm/src"
+    }
+  ]
+}

--- a/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
@@ -1,11 +1,15 @@
 import type { LanguageDescription, LanguageSupport } from '@codemirror/language';
 import {
   ApplySchemaAttributes,
+  command,
+  CommandFunction,
   EditorView,
   extension,
+  findParentNodeOfType,
   GetAttributes,
   InputRule,
   isElementDomNode,
+  isEqual,
   isTextSelection,
   keyBinding,
   KeyBindingProps,
@@ -16,11 +20,12 @@ import {
   NodeViewMethod,
   PrioritizedKeyBindings,
   ProsemirrorNode,
+  setBlockType,
 } from '@remirror/core';
 import { TextSelection } from '@remirror/pm/state';
 
 import { CodeMirror6NodeView } from './codemirror-node-view';
-import { CodeMirrorExtensionOptions } from './codemirror-types';
+import { CodeMirrorExtensionAttributes, CodeMirrorExtensionOptions } from './codemirror-types';
 import { arrowHandler } from './codemirror-utils';
 
 @extension<CodeMirrorExtensionOptions>({
@@ -182,5 +187,48 @@ export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOption
     }
 
     return language.support || language.load();
+  }
+
+  /**
+   * Creates a CodeMirror block at the current position.
+   *
+   * ```ts
+   * commands.createCodeMirror({ language: 'js' });
+   * ```
+   */
+  @command()
+  createCodeMirror(attributes: CodeMirrorExtensionAttributes): CommandFunction {
+    return setBlockType(this.type, attributes);
+  }
+
+  /**
+   * Update the code block at the current position. Primarily this is used
+   * to change the language.
+   *
+   * ```ts
+   * if (commands.updateCodeMirror.isEnabled()) {
+   *   commands.updateCodeMirror({ language: 'markdown' });
+   * }
+   * ```
+   */
+  @command()
+  updateCodeMirror(attributes: CodeMirrorExtensionAttributes): CommandFunction {
+    const type = this.type;
+    return ({ state, dispatch, tr }) => {
+      const parent = findParentNodeOfType({ types: type, selection: state.selection });
+
+      if (!parent || isEqual(attributes, parent.node.attrs)) {
+        // Do nothing since the attrs are the same
+        return false;
+      }
+
+      tr.setNodeMarkup(parent.pos, type, { ...parent.node.attrs, ...attributes });
+
+      if (dispatch) {
+        dispatch(tr);
+      }
+
+      return true;
+    };
   }
 }

--- a/packages/remirror__extension-codemirror6/src/codemirror-types.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-types.ts
@@ -1,5 +1,6 @@
 import type { LanguageDescription } from '@codemirror/language';
 import { Extension as CodeMirrorExtension } from '@codemirror/state';
+import { ProsemirrorAttributes } from '@remirror/core';
 
 export interface CodeMirrorExtensionOptions {
   /**
@@ -34,4 +35,14 @@ export interface CodeMirrorExtensionOptions {
    * @default "paragraph"
    */
   toggleName?: string;
+}
+
+export interface CodeMirrorExtensionAttributes extends ProsemirrorAttributes {
+  /**
+   * A string to represent the language matching the language name or alias in
+   * [`LanguageDescription`](https://codemirror.net/docs/ref/#language.LanguageDescription)
+   *
+   * @default ''
+   */
+  language?: string;
 }

--- a/packages/remirror__extension-codemirror6/src/index.ts
+++ b/packages/remirror__extension-codemirror6/src/index.ts
@@ -1,2 +1,2 @@
-export { CodeMirrorExtension as CodeMirrorExtension } from './codemirror-extension';
-export type { CodeMirrorExtensionOptions } from './codemirror-types';
+export { CodeMirrorExtension } from './codemirror-extension';
+export type { CodeMirrorExtensionAttributes, CodeMirrorExtensionOptions } from './codemirror-types';

--- a/packages/storybook-react/stories/extension-codemirror6/basic.tsx
+++ b/packages/storybook-react/stories/extension-codemirror6/basic.tsx
@@ -5,7 +5,7 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import React from 'react';
 import { ProsemirrorDevTools } from '@remirror/dev';
 import { CodeMirrorExtension } from '@remirror/extension-codemirror6';
-import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+import { Remirror, ThemeProvider, useRemirror, useRemirrorContext } from '@remirror/react';
 
 const extensions = () => [new CodeMirrorExtension({ languages, extensions: [oneDark] })];
 
@@ -23,6 +23,15 @@ const jsonCode = `{
 const content = {
   type: 'doc',
   content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: 'Press the button to insert a new CodeMirror block.',
+        },
+      ],
+    },
     {
       type: 'codeMirror',
       attrs: {
@@ -74,12 +83,30 @@ const content = {
   ],
 };
 
+const CreateCodeMirrorButton = ({ language }: { language: string }) => {
+  const { commands } = useRemirrorContext<CodeMirrorExtension>({ autoUpdate: true });
+  const { createCodeMirror } = commands;
+  const enabled = createCodeMirror.enabled({ language });
+
+  return (
+    <button
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => createCodeMirror({ language })}
+      disabled={!enabled}
+    >
+      Create a {language} block
+    </button>
+  );
+};
+
 const Basic = (): JSX.Element => {
   const { manager, state } = useRemirror({ extensions, content });
 
   return (
     <ThemeProvider>
-      <Remirror manager={manager} initialContent={state} autoRender>
+      <Remirror manager={manager} initialContent={state} autoRender='end'>
+        <CreateCodeMirrorButton language='JavaScript' />
+        <CreateCodeMirrorButton language='Markdown' />
         <ProsemirrorDevTools />
       </Remirror>
     </ThemeProvider>

--- a/support/root/tsconfig.json
+++ b/support/root/tsconfig.json
@@ -153,6 +153,9 @@
       "path": "packages/remirror__extension-codemirror5/src"
     },
     {
+      "path": "packages/remirror__extension-codemirror6/__tests__"
+    },
+    {
       "path": "packages/remirror__extension-codemirror6/src"
     },
     {

--- a/website/src/tsconfig.json
+++ b/website/src/tsconfig.json
@@ -21,6 +21,9 @@
   "include": ["./"],
   "references": [
     {
+      "path": "../../packages/remirror__core/src"
+    },
+    {
       "path": "../../packages/remirror__dev/src"
     },
     {


### PR DESCRIPTION

### Description

`@remirror/extension-codemirror6` now includes two new commands: `createCodeMirror` and `updateCodeMirror`, which allows you to create and update a CodeMirror block.


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
