### PR TITLE
fix(theme): wrap end-of-lines spaces

### DIFF
--- a/.changeset/seven-timers-prove.md
+++ b/.changeset/seven-timers-prove.md
@@ -1,0 +1,6 @@
+---
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Set style `white-space` as `break-spaces` to wrap end-of-lines spaces.

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -594,14 +594,6 @@ button:active .remirror-menu-pane-shortcut,
   position: relative;
 }
 
-.remirror-editor.ProseMirror[contenteditable='false'] {
-  white-space: normal;
-}
-
-.remirror-editor.ProseMirror[contenteditable='true'] {
-  white-space: pre-wrap;
-}
-
 .remirror-editor.ProseMirror hr {
   border-color: #2e2e2e;
 }

--- a/packages/remirror__styles/core.css
+++ b/packages/remirror__styles/core.css
@@ -19,14 +19,6 @@
   position: relative;
 }
 
-.remirror-editor.ProseMirror[contenteditable='false'] {
-  white-space: normal;
-}
-
-.remirror-editor.ProseMirror[contenteditable='true'] {
-  white-space: pre-wrap;
-}
-
 .remirror-editor.ProseMirror hr {
   border-color: #2e2e2e;
 }

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -605,14 +605,6 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     position: relative;
   }
 
-  .remirror-editor.ProseMirror[contenteditable='false'] {
-    white-space: normal;
-  }
-
-  .remirror-editor.ProseMirror[contenteditable='true'] {
-    white-space: pre-wrap;
-  }
-
   .remirror-editor.ProseMirror hr {
     border-color: #2e2e2e;
   }

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -611,14 +611,6 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     position: relative;
   }
 
-  .remirror-editor.ProseMirror[contenteditable='false'] {
-    white-space: normal;
-  }
-
-  .remirror-editor.ProseMirror[contenteditable='true'] {
-    white-space: pre-wrap;
-  }
-
   .remirror-editor.ProseMirror hr {
     border-color: #2e2e2e;
   }

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -610,14 +610,6 @@ export const coreStyledCss: ReturnType<typeof css> = css`
     position: relative;
   }
 
-  .remirror-editor.ProseMirror[contenteditable='false'] {
-    white-space: normal;
-  }
-
-  .remirror-editor.ProseMirror[contenteditable='true'] {
-    white-space: pre-wrap;
-  }
-
   .remirror-editor.ProseMirror hr {
     border-color: #2e2e2e;
   }

--- a/packages/remirror__theme/src/core-theme.ts
+++ b/packages/remirror__theme/src/core-theme.ts
@@ -23,14 +23,6 @@ export const EDITOR = css`
       position: relative;
     }
 
-    &[contenteditable='false'] {
-      white-space: normal;
-    }
-
-    &[contenteditable='true'] {
-      white-space: pre-wrap;
-    }
-
     hr {
       border-color: #2e2e2e;
     }

--- a/website/extension-examples/extension-entity-reference/scroll-to-highlight.tsx
+++ b/website/extension-examples/extension-entity-reference/scroll-to-highlight.tsx
@@ -1,0 +1,31 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-entity-reference/scroll-to-highlight.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-entity-reference/scroll-to-highlight').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;
+  


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->




Don't set `white-space` as `pre-wrap`, because this will hang end-of-lines spaces, which make the content inside a `<p>` element have more width than the `<p>` element. 

At the top of `core-theme.ts`, we already have [`white-space: break-spaces;`](https://github.com/remirror/remirror/blob/remirror%402.0.0-beta.5/packages/remirror__theme/src/core-theme.ts#L11-L12
). So I just delete these override styles. I don't see the potential uses of these styles anyway. 

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

https://user-images.githubusercontent.com/24715727/177761259-f8d93125-67d8-4d81-9e93-f096f2f545a7.mp4





<!-- Delete this section if not applicable -->
