### PR TITLE
fix: export entity-reference positioner

### DIFF
--- a/packages/remirror__extension-entity-reference/src/index.ts
+++ b/packages/remirror__extension-entity-reference/src/index.ts
@@ -1,3 +1,4 @@
 export * from './entity-reference-extension';
+export { centeredEntityReferencePositioner } from './entity-reference-positioners';
 export type { EntityReferenceMetaData } from './types';
 export { findMinMaxRange } from './utils/ranges';


### PR DESCRIPTION
### Description

There is a positioner for entity-reference-extension but it's not properly exported. This makes it difficult to use.

See here an example from annotation-extension that does export the positioner: https://github.com/remirror/remirror/blob/1bc49d747b693146bb320017de506aa92efcbc74/packages/remirror__extension-annotation/src/index.ts#L2

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
