### PR TITLE
feat: add helper to get shortest entity reference

### DIFF
--- a/.changeset/good-apples-report.md
+++ b/.changeset/good-apples-report.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-entity-reference': patch
+---
+
+add helper to get shortest entity reference

--- a/packages/remirror__extension-entity-reference/__tests__/shortest-entity-reference.spec.ts
+++ b/packages/remirror__extension-entity-reference/__tests__/shortest-entity-reference.spec.ts
@@ -1,0 +1,11 @@
+import { getShortestEntityReference } from '../src/utils/shortest-entity-reference';
+
+describe('getShortestEntityReference', () => {
+  it('detects shortest highlight', () => {
+    const shortest = { text: 'short' };
+    const mark2 = { text: 'longer' };
+    const mark3 = { text: 'very long' };
+
+    expect(getShortestEntityReference([shortest, mark2, mark3])).toEqual(shortest);
+  });
+});

--- a/packages/remirror__extension-entity-reference/src/index.ts
+++ b/packages/remirror__extension-entity-reference/src/index.ts
@@ -2,3 +2,4 @@ export * from './entity-reference-extension';
 export { centeredEntityReferencePositioner } from './entity-reference-positioners';
 export type { EntityReferenceMetaData } from './types';
 export { findMinMaxRange } from './utils/ranges';
+export { getShortestEntityReference } from './utils/shortest-entity-reference';

--- a/packages/remirror__extension-entity-reference/src/utils/shortest-entity-reference.ts
+++ b/packages/remirror__extension-entity-reference/src/utils/shortest-entity-reference.ts
@@ -1,0 +1,17 @@
+import { EntityReferenceMetaData } from '../types';
+
+type EntityReferenceMarkText = Pick<EntityReferenceMetaData, 'text'>;
+
+/**
+ * This helper can be used when reacting to clicks on overlapping highlights.
+ * In that case, the app should show the shortest entity because longer entities
+ * typical have other click areas.
+ *
+ * @param entityReferences
+ * @returns entity references with the shortest text
+ */
+export const getShortestEntityReference = <T extends EntityReferenceMarkText>(
+  entityReferences: T[],
+): T | undefined => {
+  return entityReferences.sort(({ text: a }, { text: b }) => a.length - b.length)[0];
+};


### PR DESCRIPTION
### Description

This helper can be used when reacting to clicks on overlapping highlights. In that case, the app should show the shortest entity because longer entities typical have other click areas.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
