### PR TITLE
feat: add support for optional clickmark handler

### DIFF
--- a/.changeset/popular-donuts-yawn.md
+++ b/.changeset/popular-donuts-yawn.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-entity-reference': minor
+---
+
+Add an optional onclickmark handler to handle clicks on entity reference

--- a/packages/remirror__extension-entity-reference/__tests__/entity-reference-extension.spec.ts
+++ b/packages/remirror__extension-entity-reference/__tests__/entity-reference-extension.spec.ts
@@ -1,16 +1,18 @@
+import { jest } from '@jest/globals';
 import { pmBuild } from 'jest-prosemirror';
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import { createCoreManager } from 'remirror/extensions';
 import { prosemirrorNodeToHtml, uniqueArray } from '@remirror/core';
 
 import { EntityReferenceExtension } from '../';
+import { EntityReferenceOptions } from '../src/types';
 
 extensionValidityTest(EntityReferenceExtension);
 
 const DUMMY_TEXT = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.';
 
-function create() {
-  return renderEditor([new EntityReferenceExtension()]);
+function create(options: EntityReferenceOptions = {}) {
+  return renderEditor([new EntityReferenceExtension(options)]);
 }
 
 let {
@@ -19,6 +21,7 @@ let {
   selectText,
   commands,
   helpers,
+  view,
 } = create();
 
 beforeEach(() => {
@@ -28,6 +31,7 @@ beforeEach(() => {
     selectText,
     helpers,
     commands,
+    view,
   } = create());
 });
 
@@ -252,6 +256,57 @@ describe('EntityReference marks', () => {
       expect(selected).toBeTrue();
       expect(editor.state.selection.from).toBe(entityReference.from);
       expect(editor.state.selection.to).toBe(entityReference.to);
+    });
+  });
+
+  describe('onClickMark', () => {
+    const onClickMark: any = jest.fn(() => false);
+
+    beforeEach(() => {
+      ({
+        add,
+        nodes: { doc, p },
+        selectText,
+        helpers,
+        commands,
+        view,
+      } = create({ onClickMark }));
+    });
+
+    it('responds to mark clicks and passes mark id if click is a mark', () => {
+      const node = doc(p('testing text'));
+      add(node);
+      const entityReference = {
+        id: 'testId',
+        from: 1,
+        to: 8,
+        text: 'testing',
+      };
+
+      selectText({ from: entityReference.from, to: entityReference.to });
+      commands.addEntityReference(entityReference.id);
+
+      view.someProp('handleClickOn', (fn) => fn(view, 2, node, 1, {} as MouseEvent, false));
+      expect(onClickMark).toHaveBeenCalledTimes(1);
+      expect(onClickMark).toHaveBeenCalledWith(entityReference.id);
+    });
+
+    it('responds to clicks and passes no argument if click is not a mark', () => {
+      const node = doc(p('testing text'));
+      add(node);
+      const entityReference = {
+        id: 'testId',
+        from: 1,
+        to: 8,
+        text: 'testing',
+      };
+
+      selectText({ from: entityReference.from, to: entityReference.to });
+      commands.addEntityReference(entityReference.id);
+
+      view.someProp('handleClickOn', (fn) => fn(view, 9, node, 1, {} as MouseEvent, false));
+      expect(onClickMark).toHaveBeenCalledTimes(1);
+      expect(onClickMark).toHaveBeenCalledWith();
     });
   });
 });

--- a/packages/remirror__extension-entity-reference/package.json
+++ b/packages/remirror__extension-entity-reference/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "^2.0.0-beta.9",
+    "@remirror/extension-events": "^2.0.0-beta.9",
     "@remirror/extension-positioner": "^2.0.0-beta.9"
   },
   "devDependencies": {

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -62,6 +62,7 @@ const createDecorationSet = (props: StateProps) => {
   defaultOptions: {
     getStyle: decorateEntityReferences,
     blockSeparator: undefined,
+    onClickMark: () => {},
   },
 })
 export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptions> {

--- a/packages/remirror__extension-entity-reference/src/types.ts
+++ b/packages/remirror__extension-entity-reference/src/types.ts
@@ -24,6 +24,7 @@ export interface EntityReferenceOptions {
    */
   getStyle?: (entityReferences: EntityReferenceMetaData[][]) => Decoration[];
   blockSeparator?: AcceptUndefined<string>;
+  onClickMark?: (id: string) => void;
 }
 
 export interface EntityReferencePluginState extends Required<EntityReferenceOptions> {

--- a/packages/remirror__extension-entity-reference/src/types.ts
+++ b/packages/remirror__extension-entity-reference/src/types.ts
@@ -24,7 +24,7 @@ export interface EntityReferenceOptions {
    */
   getStyle?: (entityReferences: EntityReferenceMetaData[][]) => Decoration[];
   blockSeparator?: AcceptUndefined<string>;
-  onClickMark?: (id: string) => void;
+  onClickMark?: (id?: string) => void;
 }
 
 export interface EntityReferencePluginState extends Required<EntityReferenceOptions> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1021,9 +1021,10 @@ importers:
   packages/remirror__extension-entity-reference:
     specifiers:
       '@babel/runtime': ^7.13.10
-      '@remirror/core': ^2.0.0-beta.8
-      '@remirror/extension-positioner': ^2.0.0-beta.8
-      '@remirror/pm': ^2.0.0-beta.8
+      '@remirror/core': ^2.0.0-beta.9
+      '@remirror/extension-events': ^2.0.0-beta.9
+      '@remirror/extension-positioner': ^2.0.0-beta.9
+      '@remirror/pm': ^2.0.0-beta.9
     dependencies:
       '@babel/runtime': 7.18.3
       '@remirror/core': link:../remirror__core
@@ -12398,7 +12399,7 @@ packages:
       mississippi: 2.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 5.3.0
       unique-filename: 1.1.1
@@ -12418,7 +12419,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12462,7 +12463,7 @@ packages:
       mississippi: 1.3.1
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 4.1.6
       unique-filename: 1.1.1
@@ -16709,6 +16710,13 @@ packages:
     dev: true
     optional: true
 
+  /find-up/2.1.0:
+    resolution: {integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=}
+    engines: {node: '>=4'}
+    dependencies:
+      locate-path: 2.0.0
+    dev: false
+
   /find-up/3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
@@ -20655,6 +20663,14 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: true
 
+  /locate-path/2.0.0:
+    resolution: {integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=}
+    engines: {node: '>=4'}
+    dependencies:
+      p-locate: 2.0.0
+      path-exists: 3.0.0
+    dev: false
+
   /locate-path/3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -22354,6 +22370,13 @@ packages:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
 
+  /p-limit/1.3.0:
+    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
+    engines: {node: '>=4'}
+    dependencies:
+      p-try: 1.0.0
+    dev: false
+
   /p-limit/2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -22365,6 +22388,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+
+  /p-locate/2.0.0:
+    resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
+    engines: {node: '>=4'}
+    dependencies:
+      p-limit: 1.3.0
+    dev: false
 
   /p-locate/3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
@@ -22413,6 +22443,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
+
+  /p-try/1.0.0:
+    resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}
+    engines: {node: '>=4'}
+    dev: false
 
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -22487,7 +22522,7 @@ packages:
       npm-package-arg: 5.1.2
       npm-pick-manifest: 1.0.4
       osenv: 0.1.5
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       promise-retry: 1.1.1
       protoduck: 4.0.0
       safe-buffer: 5.2.1
@@ -22849,6 +22884,13 @@ packages:
   /pirates/4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
+
+  /pkg-dir/2.0.0:
+    resolution: {integrity: sha512-ojakdnUgL5pzJYWw2AIDEupaQCX5OPbM688ZevubICjdIX01PRSYKqm33fJoCOJBRseYCTUlQRnBNX+Pchaejw==}
+    engines: {node: '>=4'}
+    dependencies:
+      find-up: 2.1.0
+    dev: false
 
   /pkg-dir/3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
@@ -23694,6 +23736,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1021,12 +1021,13 @@ importers:
   packages/remirror__extension-entity-reference:
     specifiers:
       '@babel/runtime': ^7.13.10
-      '@remirror/core': ^2.0.0-beta.9
-      '@remirror/extension-positioner': ^2.0.0-beta.9
-      '@remirror/pm': ^2.0.0-beta.9
+      '@remirror/core': ^2.0.0-beta.8
+      '@remirror/extension-positioner': ^2.0.0-beta.8
+      '@remirror/pm': ^2.0.0-beta.8
     dependencies:
       '@babel/runtime': 7.18.3
       '@remirror/core': link:../remirror__core
+      '@remirror/extension-events': link:../remirror__extension-events
       '@remirror/extension-positioner': link:../remirror__extension-positioner
     devDependencies:
       '@remirror/pm': link:../remirror__pm
@@ -16708,13 +16709,6 @@ packages:
     dev: true
     optional: true
 
-  /find-up/2.1.0:
-    resolution: {integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=}
-    engines: {node: '>=4'}
-    dependencies:
-      locate-path: 2.0.0
-    dev: false
-
   /find-up/3.0.0:
     resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
     engines: {node: '>=6'}
@@ -20661,14 +20655,6 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: true
 
-  /locate-path/2.0.0:
-    resolution: {integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=}
-    engines: {node: '>=4'}
-    dependencies:
-      p-locate: 2.0.0
-      path-exists: 3.0.0
-    dev: false
-
   /locate-path/3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -22368,13 +22354,6 @@ packages:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
 
-  /p-limit/1.3.0:
-    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
-    engines: {node: '>=4'}
-    dependencies:
-      p-try: 1.0.0
-    dev: false
-
   /p-limit/2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -22386,13 +22365,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-
-  /p-locate/2.0.0:
-    resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=}
-    engines: {node: '>=4'}
-    dependencies:
-      p-limit: 1.3.0
-    dev: false
 
   /p-locate/3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
@@ -22441,11 +22413,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
-
-  /p-try/1.0.0:
-    resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}
-    engines: {node: '>=4'}
-    dev: false
 
   /p-try/2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -22882,13 +22849,6 @@ packages:
   /pirates/4.0.5:
     resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
-
-  /pkg-dir/2.0.0:
-    resolution: {integrity: sha512-ojakdnUgL5pzJYWw2AIDEupaQCX5OPbM688ZevubICjdIX01PRSYKqm33fJoCOJBRseYCTUlQRnBNX+Pchaejw==}
-    engines: {node: '>=4'}
-    dependencies:
-      find-up: 2.1.0
-    dev: false
 
   /pkg-dir/3.0.0:
     resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}


### PR DESCRIPTION
This helps to pass an optional callback to handle clicks on highlight marks

### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
