### PR TITLE
fix(paste-rules): handle adjacent inline matches correctly

### DIFF
--- a/.changeset/nice-ties-raise.md
+++ b/.changeset/nice-ties-raise.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+When pasting some text that should be transformed into multiple adjacent inline nodes, avoid creating an empty text node.

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -322,7 +322,7 @@ describe('pasteRules', () => {
         });
     });
 
-    it('can transform multiple nodes', () => {
+    it('can transform multiple block nodes', () => {
       const plugin = pasteRules([
         {
           regexp: /^# ([\s\w]+)$/,
@@ -346,6 +346,35 @@ describe('pasteRules', () => {
         .callback((content) => {
           expect(content.doc).toEqualProsemirrorNode(
             doc(p('Hello '), h1('This is a heading'), h2('This is another heading')),
+          );
+        });
+    });
+
+    it('can transform multiple inline nodes', () => {
+      const inlineEmoji = schema.nodes.atomInline;
+      const plugin = pasteRules([
+        {
+          regexp: /[😊😠😢😂]/u,
+          type: 'node',
+          nodeType: inlineEmoji,
+          getContent: () => {},
+          getAttributes: (match) => {
+            return { code: match[0] };
+          },
+        },
+      ]);
+      createEditor(doc(p('<cursor>')), { plugins: [plugin] })
+        .paste('A😊B😠C')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(
+            doc(p('A', inlineEmoji.create(), 'B', inlineEmoji.create(), 'C')),
+          );
+        });
+      createEditor(doc(p('<cursor>')), { plugins: [plugin] })
+        .paste('😊😠')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(
+            doc(p(inlineEmoji.create(), inlineEmoji.create())),
           );
         });
     });

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -467,7 +467,7 @@ function createPasteRuleHandler<Rule extends RegexPasteRule>(
         const start = match.index;
         const end = start + fullValue.length;
 
-        if (start > 0) {
+        if (start > pos) {
           nodes.push(child.cut(pos, start));
         }
 

--- a/packages/storybook-react/stories/react-components/emoji-popup.stories.tsx
+++ b/packages/storybook-react/stories/react-components/emoji-popup.stories.tsx
@@ -1,3 +1,5 @@
+import 'remirror/styles/all.css';
+
 import React, { useCallback } from 'react';
 import { EmojiExtension, PlaceholderExtension } from 'remirror/extensions';
 import data from 'svgmoji/emoji.json';


### PR DESCRIPTION
### Description

When pasting some text that should be transformed into multiple adjacent inline nodes, avoid creating an empty text node.



Let's say I want to add a node paste rule to `EmojiExtension`. 

```ts
export class EmojiExtension extends NodeExtension<EmojiOptions> {
  ... 
  createPasteRules(): NodePasteRule {
    return {
      type: 'node',
      nodeType: this.type,
      regexp: /[🍎🥭🍉]/gu,
      getAttributes: (match) => {
        return { code: match[0] };
      },
      getContent: () => {},
    };
  }
}
```



If I paste two adjacent emojis, then `prosemirror-paste-rules` will try to create an empty text node, which lead to a RangeError. This PR fixes this issue. 




<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Before:


https://user-images.githubusercontent.com/24715727/179515748-f76eed6c-fb7a-4fb9-971a-3d31f0294144.mp4


After:

https://user-images.githubusercontent.com/24715727/179515900-d08a8a73-b86d-4d64-b0b1-a53ad896a1c6.mp4

