### PR TITLE
feat(link): improve autolink behaviour with adjacent text

### DIFF
--- a/.changeset/curvy-tomatoes-beam.md
+++ b/.changeset/curvy-tomatoes-beam.md
@@ -1,0 +1,8 @@
+---
+'@remirror/extension-link': minor
+'@remirror/core-utils': patch
+---
+
+Remove auto link if link becomes invalid. I.e. window.co -> window.confirm
+
+Prevent trailing punctuation being included in link URL


### PR DESCRIPTION
### Description

cc @marcoSven please could you provide thoughts on this implementation.

Prevent trailing punctuation being included in the the autolink URL.

Remove a link, if a URL becomes invalid i.e. `window.co` -> `window.confirm`

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
