### PR TITLE
fix(react-core): only re-create initialEditorState when re-mounting

### DIFF
--- a/.changeset/tidy-tips-sit.md
+++ b/.changeset/tidy-tips-sit.md
@@ -1,0 +1,9 @@
+---
+'@remirror/react-core': patch
+---
+
+Don't re-create `initialEditorState` when re-mounting the `<Remirror/>` component.
+
+Before this patch, for an uncontrolled editor, the `<Remirror/>` component would re-create the `initialEditorState` when it re-mounts. This will call `EditorState.create()` and call the [`init`](https://prosemirror.net/docs/ref/#state.StateField.init) method for every ProseMirror plugins with `initialEditorState`. This is problematic because the editor state passed to plugins is not the same as the current state.
+
+This patch fixes the issue by only creating `initialEditorState` when the editor is mounted for the first time.

--- a/packages/remirror__react-core/src/hooks/use-react-framework.tsx
+++ b/packages/remirror__react-core/src/hooks/use-react-framework.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AnyExtension, ErrorConstant, invariant, isArray, isNullOrUndefined } from '@remirror/core';
 import { ReactExtension } from '@remirror/preset-react';
 
@@ -45,13 +45,19 @@ export function useReactFramework<Extension extends AnyExtension>(
     manager.getExtension(ReactExtension).setOptions({ placeholder });
   }, [placeholder, manager]);
 
-  const fallback = manager.createEmptyDoc();
-  const [initialContent, initialSelection] = isArray(props.initialContent)
-    ? props.initialContent
-    : ([props.initialContent ?? fallback] as const);
-  const initialEditorState = state
-    ? state
-    : manager.createState({ content: initialContent, selection: initialSelection });
+  const [initialEditorState] = useState(() => {
+    if (state) {
+      return state;
+    }
+
+    const fallback = manager.createEmptyDoc();
+
+    const [initialContent, initialSelection] = isArray(props.initialContent)
+      ? props.initialContent
+      : ([props.initialContent ?? fallback] as const);
+
+    return manager.createState({ content: initialContent, selection: initialSelection });
+  });
 
   // Create the framework which manages the connection between the `@remirror/core`
   // and React.


### PR DESCRIPTION
### Description

Fixes https://github.com/remirror/remirror/issues/1814

Please check the Changeset file in this PR for details description. 
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
