### PR TITLE
feat(link): auto link adjacent character detection

### DIFF
--- a/.changeset/olive-kiwis-attack.md
+++ b/.changeset/olive-kiwis-attack.md
@@ -1,0 +1,36 @@
+---
+'@remirror/extension-link': patch
+---
+
+Auto link adjacent character detection.
+
+Remove auto link if the link becomes invalid.
+
+**Before:**
+
+"window.confirm" results in "[window.co](//window.co)nfirm"
+
+**After:**
+
+"window.confirm" results in "window.confirm"
+
+New options `findAutoLinks` and `isValidUrl` that if provided are used instead of `autoLinkAllowedTLDs` and `autoLinkRegex` to find and validate a link.
+
+URLs are very ambiguous the new options allow to find valid auto links without adding additional complexity to the link extension.
+
+Library examples to find URLs in text.
+
+- [linkify-it](https://www.npmjs.com/package/linkify-it)
+- [linkifyjs](https://www.npmjs.com/package/linkifyjs)
+
+It is worth mentioning that the `autoLinkRegex` can be modified to exclude adjacent punctuations from an auto link.
+
+Regex suggestion from @whawker
+
+`/(?:(?:(?:https?|ftp):)?\/\/)?(?:\S+(?::\S*)?@)?(?:(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)*(?:(?:\d(?!\.)|[a-z\u00A1-\uFFFF])(?:[\da-z\u00A1-\uFFFF][\w\u00A1-\uFFFF-]{0,62})?[\da-z\u00A1-\uFFFF]\.)+[a-z\u00A1-\uFFFF]{2,}(?::\d{2,5})?(?:[#/?](?:(?! |[!"'(),.;?[\]{}-]).|-+|\((?:(?![ )]).)*\)|\[(?:(?![ \]]).)*]|'(?=\w)|\.(?! |\.|$)|,(?! |,|$)|;(?! |;|$)|!(?! |!|$)|\?(?! |\?|$))+|\/)?/gi;`
+
+**Examples**
+
+- [www.remirror.io/test](www.remirror.io/test)? - excluding sentence punctuation
+- "[www.remirror.io/test](www.remirror.io/test)" - surround link with quotation marks
+- ([www.remirror.io/(test)](<www.remirror.io/(test)>))- link with balanced parentheses in path surrounded by parentheses

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -1834,6 +1834,28 @@ describe('adjacent punctuations', () => {
           ),
         );
       });
+
+      it('detects email and excludes surrounding parentheses', () => {
+        const editor = renderEditor([
+          new LinkExtension({
+            autoLink: true,
+            findAutoLinks,
+            isValidUrl,
+          }),
+        ]);
+        const {
+          attributeMarks: { link },
+          nodes: { doc, p },
+        } = editor;
+
+        editor.add(doc(p('<cursor>'))).insertText('(user@exmaple.com)');
+
+        expect(editor.doc).toEqualRemirrorDocument(
+          doc(
+            p('(', link({ auto: true, href: 'mailto:user@exmaple.com' })('user@exmaple.com'), ')'),
+          ),
+        );
+      });
     });
 
     describe('regex supporting balanced brackets', () => {

--- a/packages/remirror__extension-link/package.json
+++ b/packages/remirror__extension-link/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "@remirror/pm": "^2.0.0-beta.15",
-    "@types/extract-domain": "2.2.0"
+    "@types/extract-domain": "2.2.0",
+    "linkifyjs": "^3.0.5"
   },
   "peerDependencies": {
     "@remirror/pm": "^2.0.0-beta.15"

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -37,7 +37,6 @@ import {
   removeMark,
   Static,
   updateMark,
-  within,
 } from '@remirror/core';
 import type { CreateEventHandlers } from '@remirror/extension-events';
 import { undoDepth } from '@remirror/pm/history';
@@ -58,11 +57,20 @@ const DEFAULT_AUTO_LINK_REGEX =
  */
 export type DefaultProtocol = 'http:' | 'https:' | '' | string;
 
-interface FoundAutoLink {
+export interface FoundAutoLink {
+  /** link href */
   href: string;
+  /** link text */
   text: string;
+  /** offset of matched text */
   start: number;
+  /** index of next char after match end */
   end: number;
+}
+
+interface LinkWithProperties extends Omit<FoundAutoLink, 'href'> {
+  range: FromToProps;
+  attrs: LinkAttributes;
 }
 
 interface EventMeta {
@@ -186,6 +194,37 @@ export interface LinkOptions {
   autoLinkAllowedTLDs?: Static<string[]>;
 
   /**
+   * Returns a list of links found in string where each element is a hash
+   * with properties { href: string; text: string; start: number; end: number; }
+   *
+   * @remarks
+   *
+   * This function is used instead of matching links with the autoLinkRegex option.
+   *
+   * @default null
+   *
+   * @param {string} input
+   * @param {string} defaultProtocol
+   * @returns {array} FoundAutoLink[]
+   */
+  findAutoLinks?: ((input: string, defaultProtocol: string) => FoundAutoLink[]) | null;
+
+  /**
+   * Check if the given string is a link
+   *
+   * @remarks
+   *
+   * Used instead of validating a link with the autoLinkRegex and autoLinkAllowedTLDs option.
+   *
+   * @default null
+   *
+   * @param {string} input
+   * @param {string} defaultProtocol
+   * @returns {boolean}
+   */
+  isValidUrl?: ((input: string, defaultProtocol: string) => boolean) | null;
+
+  /**
    * The default protocol to use when it can't be inferred.
    *
    * @defaultValue ''
@@ -238,6 +277,8 @@ export type LinkAttributes = ProsemirrorAttributes<{
     openLinkOnClick: false,
     autoLinkRegex: DEFAULT_AUTO_LINK_REGEX,
     autoLinkAllowedTLDs: TOP_50_TLDS,
+    findAutoLinks: null,
+    isValidUrl: null,
     defaultTarget: null,
     supportedTargets: [],
     extractHref,
@@ -447,9 +488,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
             return false;
           }
 
-          const href = this.buildHref(url);
-
-          if (!this.isValidTLD(href)) {
+          if (!this.isValidUrl(url)) {
             return false;
           }
 
@@ -575,59 +614,113 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
 
         const { updateLink, removeLink } = this.store.chain(tr);
 
-        changes.forEach(({ from, to, prevFrom, prevTo }) => {
-          // Remove auto links that are no longer valid
-          this.getLinkMarksInRange(prevState.doc, prevFrom, prevTo, true).forEach((prevMark) => {
-            const newFrom = mapping.map(prevMark.from);
-            const newTo = mapping.map(prevMark.to);
-            const newMarks = this.getLinkMarksInRange(doc, newFrom, newTo, true);
-
-            newMarks.forEach((newMark) => {
-              const wasLink = this._autoLinkRegexNonGlobal?.test(prevMark.text);
-              const isLink = this._autoLinkRegexNonGlobal?.test(newMark.text);
-
-              if (wasLink && !isLink) {
-                removeLink({ from: newMark.from, to: newMark.to }).tr();
-              }
-            });
-          });
-
+        changes.forEach(({ prevFrom, prevTo, from, to }) => {
           // Store all the callbacks we need to make
           const onUpdateCallbacks: Array<Pick<EventMeta, 'range' | 'attrs'> & { text: string }> =
             [];
 
-          // Find text that can be auto linked
-          tr.doc.nodesBetween(from, to, (node, pos) => {
-            if (!node.isTextblock || !node.type.allowsMarkType(this.type)) {
-              return;
-            }
+          // Check if node was split into two by `Enter` key press
+          const isNodeSeparated = to - from === 2;
 
-            const nodeText = tr.doc.textBetween(pos, pos + node.nodeSize, undefined, ' ');
-            this.findAutoLinks(nodeText)
-              // calculate link position
-              .map((link) => ({
-                ...link,
-                from: pos + link.start + 1,
-                to: pos + link.end + 1,
-              }))
-              .filter((link) => {
-                // Determine if found link is within the changed range
-                return (
-                  within(link.from, from, to) ||
-                  within(link.to, from, to) ||
-                  within(from, link.from, link.to) ||
-                  within(to, link.from, link.to)
-                );
+          // Get previous links
+          const prevMarks = this.getLinkMarksInRange(prevState.doc, prevFrom, prevTo, true)
+            .filter((item) => item.mark.type === this.type)
+            .map(({ from, to, text }) => ({
+              mappedFrom: mapping.map(from),
+              mappedTo: mapping.map(to),
+              text,
+              from,
+              to,
+            }));
+
+          // Check if links need to be removed or updated.
+          prevMarks.forEach(
+            ({ mappedFrom: newFrom, mappedTo: newTo, from: prevMarkFrom, to: prevMarkTo }, i) =>
+              this.getLinkMarksInRange(doc, newFrom, newTo, true)
+                .filter((item) => item.mark.type === this.type)
+                .forEach((newMark) => {
+                  const prevLinkText = prevState.doc.textBetween(
+                    prevMarkFrom,
+                    prevMarkTo,
+                    undefined,
+                    ' ',
+                  );
+
+                  const newLinkText = doc
+                    .textBetween(newMark.from, newMark.to + 1, undefined, ' ')
+                    .trim();
+
+                  const wasLink = this.isValidUrl(prevLinkText);
+                  const isLink = this.isValidUrl(newLinkText);
+
+                  if (isLink) {
+                    return;
+                  }
+
+                  if (wasLink) {
+                    removeLink({ from: newMark.from, to: newMark.to }).tr();
+
+                    prevMarks.splice(i, 1);
+                  }
+
+                  if (isNodeSeparated) {
+                    return;
+                  }
+
+                  // If link characters have been deleted
+                  from === to &&
+                    // Check newLinkText for a remaining valid link
+                    this.findAutoLinks(newLinkText)
+                      .map((link) =>
+                        this.addLinkProperties({
+                          ...link,
+                          from: newFrom + link.start,
+                          to: newFrom + link.end,
+                        }),
+                      )
+                      .forEach(({ attrs, range, text }) => {
+                        updateLink(attrs, range).tr();
+
+                        onUpdateCallbacks.push({ attrs, range, text });
+                      });
+                }),
+          );
+
+          // Find text that can be auto linked
+          this.findTextBlocksInRange(doc, { from, to }).forEach(({ text, positionStart }) => {
+            // Match links in text node
+            this.findAutoLinks(text)
+              .map((link) =>
+                this.addLinkProperties({
+                  ...link,
+                  // Calculate link position.
+                  from: positionStart + link.start + 1,
+                  to: positionStart + link.end + 1,
+                }),
+              )
+              // Check if link is within the changed range.
+              .filter(({ range }) => {
+                const fromIsInRange = from >= range.from && from <= range.to;
+                const toIsInRange = to >= range.from && to <= range.to;
+
+                return fromIsInRange || toIsInRange || isNodeSeparated;
               })
-              .filter((link) => {
-                // Avoid overwriting manually created links
-                const marks = this.getLinkMarksInRange(tr.doc, link.from, link.to, false);
-                return marks.length === 0;
-              })
-              .forEach(({ from, to, href, text }) => {
-                const attrs = { href, auto: true };
-                const range = { from, to };
+              // Avoid overwriting manually created links.
+              .filter(
+                ({ range }) =>
+                  this.getLinkMarksInRange(tr.doc, range.from, range.to, false).length === 0,
+              )
+              // Prevent updating existing auto links
+              .filter(
+                ({ range: { from }, text }) =>
+                  !prevMarks.some(
+                    ({ text: prevMarkText, mappedFrom }) =>
+                      mappedFrom === from && prevMarkText === text,
+                  ),
+              )
+              .forEach(({ attrs, text, range }) => {
                 updateLink(attrs, range).tr();
+
                 onUpdateCallbacks.push({ attrs, range, text });
               });
           });
@@ -665,14 +758,14 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     const linkMarks: GetMarkRange[] = [];
 
     if (from === to) {
-      const $pos = doc.resolve(from);
-      $pos.marks().forEach(() => {
-        const range = getMarkRange($pos, this.type);
+      const resolveFrom = Math.max(from - 1, 0);
 
-        if (range?.mark.attrs.auto === isAutoLink) {
-          linkMarks.push(range);
-        }
-      });
+      const $pos = doc.resolve(resolveFrom);
+      const range = getMarkRange($pos, this.type);
+
+      if (range?.mark.attrs.auto === isAutoLink) {
+        linkMarks.push(range);
+      }
     } else {
       doc.nodesBetween(from, to, (node, pos) => {
         const marks = node.marks ?? [];
@@ -694,7 +787,56 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     return linkMarks;
   }
 
+  private findTextBlocksInRange(
+    node: ProsemirrorNode,
+    range: FromToProps,
+  ): Array<{ text: string; positionStart: number }> {
+    const nodesWithPos: Array<{
+      node: ProsemirrorNode;
+      pos: number;
+    }> = [];
+    const predicate: (node: ProsemirrorNode) => boolean = (node) =>
+      !node.isTextblock || !node.type.allowsMarkType(this.type);
+
+    // define a placeholder for leaf nodes to calculate link position
+    node.nodesBetween(range.from, range.to, (node, pos) => {
+      if (!predicate(node)) {
+        nodesWithPos.push({
+          node,
+          pos,
+        });
+      }
+    });
+
+    return nodesWithPos.map((textBlock) => ({
+      text: node.textBetween(
+        textBlock.pos,
+        textBlock.pos + textBlock.node.nodeSize,
+        undefined,
+        ' ',
+      ),
+      positionStart: textBlock.pos,
+    }));
+  }
+
+  private addLinkProperties({
+    from,
+    to,
+    href,
+    ...link
+  }: FoundAutoLink & FromToProps): LinkWithProperties {
+    return {
+      ...link,
+      range: { from, to },
+      attrs: { href, auto: true },
+    };
+  }
+
   private findAutoLinks(str: string): FoundAutoLink[] {
+    if (this.options.findAutoLinks) {
+      return this.options.findAutoLinks(str, this.options.defaultProtocol);
+    }
+
     const toAutoLink: FoundAutoLink[] = [];
 
     for (const match of findMatches(str, this.options.autoLinkRegex)) {
@@ -719,6 +861,14 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     }
 
     return toAutoLink;
+  }
+
+  private isValidUrl(text: string): boolean {
+    if (this.options.isValidUrl) {
+      return this.options.isValidUrl(text, this.options.defaultProtocol);
+    }
+
+    return this.isValidTLD(this.buildHref(text)) && !!this._autoLinkRegexNonGlobal?.test(text);
   }
 
   private isValidTLD(str: string): boolean {

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -31,6 +31,7 @@ import {
   MarkExtensionSpec,
   MarkSpecOverride,
   NamedShortcut,
+  NodeWithPosition,
   omitExtraAttributes,
   ProsemirrorAttributes,
   ProsemirrorNode,
@@ -207,7 +208,7 @@ export interface LinkOptions {
    * @param {string} defaultProtocol
    * @returns {array} FoundAutoLink[]
    */
-  findAutoLinks?: ((input: string, defaultProtocol: string) => FoundAutoLink[]) | null;
+  findAutoLinks?: Static<(input: string, defaultProtocol: string) => FoundAutoLink[]>;
 
   /**
    * Check if the given string is a link
@@ -222,7 +223,7 @@ export interface LinkOptions {
    * @param {string} defaultProtocol
    * @returns {boolean}
    */
-  isValidUrl?: ((input: string, defaultProtocol: string) => boolean) | null;
+  isValidUrl?: Static<(input: string, defaultProtocol: string) => boolean>;
 
   /**
    * The default protocol to use when it can't be inferred.
@@ -277,8 +278,8 @@ export type LinkAttributes = ProsemirrorAttributes<{
     openLinkOnClick: false,
     autoLinkRegex: DEFAULT_AUTO_LINK_REGEX,
     autoLinkAllowedTLDs: TOP_50_TLDS,
-    findAutoLinks: null,
-    isValidUrl: null,
+    findAutoLinks: undefined,
+    isValidUrl: undefined,
     defaultTarget: null,
     supportedTargets: [],
     extractHref,
@@ -791,10 +792,7 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
     node: ProsemirrorNode,
     range: FromToProps,
   ): Array<{ text: string; positionStart: number }> {
-    const nodesWithPos: Array<{
-      node: ProsemirrorNode;
-      pos: number;
-    }> = [];
+    const nodesWithPos: NodeWithPosition[] = [];
 
     // define a placeholder for leaf nodes to calculate link position
     node.nodesBetween(range.from, range.to, (node, pos) => {

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -795,17 +795,17 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
       node: ProsemirrorNode;
       pos: number;
     }> = [];
-    const predicate: (node: ProsemirrorNode) => boolean = (node) =>
-      !node.isTextblock || !node.type.allowsMarkType(this.type);
 
     // define a placeholder for leaf nodes to calculate link position
     node.nodesBetween(range.from, range.to, (node, pos) => {
-      if (!predicate(node)) {
-        nodesWithPos.push({
-          node,
-          pos,
-        });
+      if (!node.isTextblock || !node.type.allowsMarkType(this.type)) {
+        return;
       }
+
+      nodesWithPos.push({
+        node,
+        pos,
+      });
     });
 
     return nodesWithPos.map((textBlock) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1214,6 +1214,7 @@ importers:
       '@remirror/pm': ^2.0.0-beta.15
       '@types/extract-domain': 2.2.0
       extract-domain: 2.2.1
+      linkifyjs: ^3.0.5
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core': link:../remirror__core
@@ -1223,6 +1224,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@types/extract-domain': 2.2.0
+      linkifyjs: 3.0.5
 
   packages/remirror__extension-list:
     specifiers:
@@ -20188,6 +20190,10 @@ packages:
 
   /lines-and-columns/1.1.6:
     resolution: {integrity: sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ==}
+
+  /linkifyjs/3.0.5:
+    resolution: {integrity: sha512-1Y9XQH65eQKA9p2xtk+zxvnTeQBG7rdAXSkUG97DmuI/Xhji9uaUzaWxRj6rf9YC0v8KKHkxav7tnLX82Sz5Fg==}
+    dev: true
 
   /lint-staged/11.2.6:
     resolution: {integrity: sha512-Vti55pUnpvPE0J9936lKl0ngVeTdSZpEdTNhASbkaWX7J5R9OEifo1INBGQuGW4zmy6OG+TcWPJ3m5yuy5Q8Tg==}


### PR DESCRIPTION
### Description

Remove auto link if the link becomes invalid.

Before:

"window.confirm" results in "[window.co](//window.co)nfirm"

After:

"window.confirm" results in "window.confirm"

Add options `findAutoLinks` and `isValidUrl` that if provided,
are used instead of `autoLinkAllowedTLDs` and `autoLinkRegex`
to find and validate a link.

closes #1730 
closes #1732

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.


