### PR TITLE
feat(emoji-ext): add supported characters option

### DIFF
--- a/.changeset/curly-stingrays-dress.md
+++ b/.changeset/curly-stingrays-dress.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-emoji': patch
+---
+
+option for supported characters in emoji suggester.

--- a/packages/remirror__extension-emoji/src/emoji-extension.ts
+++ b/packages/remirror__extension-emoji/src/emoji-extension.ts
@@ -28,7 +28,7 @@ import {
   PrimitiveSelection,
   ShouldSkipFunction,
 } from '@remirror/core';
-import type { Suggester } from '@remirror/pm/suggest';
+import { DEFAULT_SUGGESTER, Suggester } from '@remirror/pm/suggest';
 import { ExtensionEmojiTheme } from '@remirror/theme';
 
 import {
@@ -47,6 +47,7 @@ import {
     fallback: ':red_question_mark:',
     moji: 'noto',
     suggestionCharacter: ':',
+    supportedCharacters: DEFAULT_SUGGESTER.supportedCharacters,
   },
   staticKeys: ['plainText'],
   handlerKeys: ['suggestEmoji'],
@@ -305,6 +306,7 @@ export class EmojiExtension extends NodeExtension<EmojiOptions> {
     return {
       disableDecorations: true,
       invalidPrefixCharacters: `${escapeStringRegex(this.options.suggestionCharacter)}|\\w`,
+      supportedCharacters: this.options.supportedCharacters,
       char: this.options.suggestionCharacter,
       name: this.name,
       suggestTag: 'span',

--- a/packages/remirror__extension-emoji/src/emoji-utils.ts
+++ b/packages/remirror__extension-emoji/src/emoji-utils.ts
@@ -8,8 +8,9 @@ import type {
   ProsemirrorAttributes,
   Static,
 } from '@remirror/core';
+import { Suggester } from '@remirror/pm/src/suggest';
 
-export interface EmojiOptions {
+export interface EmojiOptions extends Pick<Suggester, 'supportedCharacters'> {
   /**
    * The list of emoji data to make available to the user. This is used to
    * create the underlying instance of the `Moji` which is used for searching


### PR DESCRIPTION
### Description

when providing custom data words can be separated by "-" instead of "_"

example "flag-" "flag_"

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
