### PR TITLE
fix(core-utils): remove domino from the codebase

### DIFF
--- a/.changeset/witty-vans-roll.md
+++ b/.changeset/witty-vans-roll.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Removes `domino` from the codebase.

--- a/packages/remirror__core-utils/__tests__/core-utils.node.spec.ts
+++ b/packages/remirror__core-utils/__tests__/core-utils.node.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+
+import { doc, p, schema as testSchema } from 'jest-prosemirror';
+
+import { htmlToProsemirrorNode, prosemirrorNodeToDom } from '../';
+
+describe('toDOM', () => {
+  const node = doc(p('hello'));
+
+  it('allows for custom document to be passed in', async () => {
+    const { JSDOM } = await import('jsdom');
+    const customDocument = new JSDOM().window.document;
+    expect(prosemirrorNodeToDom(node, customDocument)).toBeObject();
+
+    const wrongDocument = {} as Document;
+    expect(() => prosemirrorNodeToDom(node, customDocument)).not.toThrow();
+    expect(() => prosemirrorNodeToDom(node, wrongDocument)).toThrow();
+  });
+});
+
+describe('htmlToProsemirrorNode', () => {
+  const content = `<p>Hello</p>`;
+
+  it('allows for custom document to be passed in', async () => {
+    const { JSDOM } = await import('jsdom');
+    const customDocument = new JSDOM().window.document;
+    expect(
+      htmlToProsemirrorNode({
+        content: content,
+        schema: testSchema,
+        document: customDocument,
+      }),
+    ).toEqualProsemirrorNode(doc(p('Hello')));
+
+    const wrongDocument = {} as Document;
+    expect(() =>
+      htmlToProsemirrorNode({
+        content: content,
+        schema: testSchema,
+        document: customDocument,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      htmlToProsemirrorNode({
+        content: content,
+        schema: testSchema,
+        document: wrongDocument,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/remirror__core-utils/__tests__/core-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/core-utils.spec.ts
@@ -1,4 +1,7 @@
-import domino from 'domino';
+/**
+ * @jest-environment jsdom
+ */
+
 import {
   a,
   atomInline,
@@ -735,10 +738,6 @@ describe('toDOM', () => {
   it('transforms a doc into a documentFragment', () => {
     expect(prosemirrorNodeToDom(node)).toBeInstanceOf(DocumentFragment);
   });
-
-  it('allows for custom document to be passed in', () => {
-    expect(prosemirrorNodeToDom(node, domino.createDocument())).toBeObject();
-  });
 });
 
 describe('htmlToProsemirrorNode', () => {
@@ -748,16 +747,6 @@ describe('htmlToProsemirrorNode', () => {
     expect(htmlToProsemirrorNode({ content: content, schema: testSchema })).toEqualProsemirrorNode(
       doc(p('Hello')),
     );
-  });
-
-  it('allows for custom document to be passed in', () => {
-    expect(
-      htmlToProsemirrorNode({
-        content: content,
-        schema: testSchema,
-        document: domino.createDocument(),
-      }),
-    ).toEqualProsemirrorNode(doc(p('Hello')));
   });
 });
 

--- a/packages/remirror__core-utils/package.json
+++ b/packages/remirror__core-utils/package.json
@@ -44,20 +44,15 @@
     "@remirror/pm": "^2.0.0-beta.14",
     "@types/jsdom": "^16.2.13",
     "@types/node": "^16.3.3",
-    "domino": "^2.1.6",
     "jsdom": "^17.0.0"
   },
   "peerDependencies": {
     "@remirror/pm": "^2.0.0-beta.14",
     "@types/node": "*",
-    "domino": "*",
     "jsdom": "*"
   },
   "peerDependenciesMeta": {
     "@types/node": {
-      "optional": true
-    },
-    "domino": {
       "optional": true
     },
     "jsdom": {

--- a/packages/remirror__core-utils/readme.md
+++ b/packages/remirror__core-utils/readme.md
@@ -20,4 +20,4 @@ This is included by default when you install the recommended `remirror` package.
 
 If you plan to support SSR and need to parse the html contents of the editor in an SSR environment then `min-document` is automatically added to all node environments.
 
-However, `min-document` can't actually parse the content properly since the implementation is intentionally underpowered. To properly parse content from a html string you will need to install either `jsdom` or `domino`. These dependencies are only included within non-browser builds and won't bloat your bundle size in the browser.
+However, `min-document` can't actually parse the content properly since the implementation is intentionally underpowered. To properly parse content from a html string you will need to install `jsdom`. These dependencies are only included within non-browser builds and won't bloat your bundle size in the browser.

--- a/packages/remirror__core-utils/src/core-utils.ts
+++ b/packages/remirror__core-utils/src/core-utils.ts
@@ -1222,13 +1222,6 @@ export function getDocument(): Document {
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('domino').createDocument();
-  } catch {
-    // ignore
-  }
-
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require('min-document');
   } catch {
     // ignore

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,7 +692,6 @@ importers:
       '@types/min-document': ^2.19.0
       '@types/node': ^16.3.3
       css-in-js-utils: ^3.1.0
-      domino: ^2.1.6
       jsdom: ^17.0.0
       min-document: ^2.19.0
       parenthesis: ^3.1.8
@@ -710,7 +709,6 @@ importers:
       '@remirror/pm': link:../remirror__pm
       '@types/jsdom': 16.2.13
       '@types/node': 16.11.36
-      domino: 2.1.6
       jsdom: 17.0.0
 
   packages/remirror__dev:
@@ -5402,7 +5400,7 @@ packages:
     peerDependencies:
       react: '*'
     dependencies:
-      '@types/react': 18.0.18
+      '@types/react': 18.0.15
       prop-types: 15.8.1
       react: 18.0.0
     dev: true
@@ -10048,7 +10046,7 @@ packages:
     resolution: {integrity: sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.18
+      '@types/react': 18.0.15
     dev: true
 
   /@types/react-syntax-highlighter/11.0.5:
@@ -10075,14 +10073,6 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.0
-
-  /@types/react/18.0.18:
-    resolution: {integrity: sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.0
-    dev: true
 
   /@types/reactcss/1.2.6:
     resolution: {integrity: sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==}
@@ -12267,7 +12257,7 @@ packages:
       mississippi: 2.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 5.3.0
       unique-filename: 1.1.1
@@ -12287,7 +12277,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12331,7 +12321,7 @@ packages:
       mississippi: 1.3.1
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 4.1.6
       unique-filename: 1.1.1
@@ -12521,7 +12511,7 @@ packages:
     dev: true
 
   /caseless/0.12.0:
-    resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
     dev: false
 
   /ccount/1.1.0:
@@ -13692,7 +13682,7 @@ packages:
     engines: {node: '>= 6'}
 
   /css.escape/1.5.1:
-    resolution: {integrity: sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=}
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
     dev: false
 
   /css/3.0.0:
@@ -14397,6 +14387,7 @@ packages:
 
   /domino/2.1.6:
     resolution: {integrity: sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==}
+    dev: false
 
   /dompurify/2.3.3:
     resolution: {integrity: sha512-dqnqRkPMAjOZE0FogZ+ceJNM2dZ3V/yNOuFB7+39qpO93hHhfRpHw3heYQC7DPK9FqbQTfBKUJhiSfz4MvXYwg==}
@@ -17357,7 +17348,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.17.0
+      uglify-js: 3.16.3
 
   /har-schema/2.0.0:
     resolution: {integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=}
@@ -22072,7 +22063,7 @@ packages:
       npm-package-arg: 5.1.2
       npm-pick-manifest: 1.0.4
       osenv: 0.1.5
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       promise-retry: 1.1.1
       protoduck: 4.0.0
       safe-buffer: 5.2.1
@@ -23285,6 +23276,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}
@@ -27123,8 +27125,8 @@ packages:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
     dev: true
 
-  /uglify-js/3.17.0:
-    resolution: {integrity: sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==}
+  /uglify-js/3.16.3:
+    resolution: {integrity: sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -11,10 +11,7 @@
     "name": "create-context-state",
     "limit": "1.5 KB",
     "path": "packages/create-context-state/dist/create-context-state.js",
-    "ignore": [
-      "@types/react",
-      "react"
-    ],
+    "ignore": ["@types/react", "react"],
     "running": false,
     "gzip": true
   },
@@ -22,12 +19,7 @@
     "name": "multishift",
     "limit": "20 KB",
     "path": "packages/multishift/dist/multishift.js",
-    "ignore": [
-      "@types/react",
-      "react",
-      "@remirror/core-helpers",
-      "@remirror/core-types"
-    ],
+    "ignore": ["@types/react", "react", "@remirror/core-helpers", "@remirror/core-types"],
     "running": false,
     "gzip": true
   },
@@ -49,10 +41,7 @@
     "name": "prosemirror-resizable-view",
     "limit": "5 KB",
     "path": "packages/prosemirror-resizable-view/dist/prosemirror-resizable-view.js",
-    "ignore": [
-      "@remirror/core-helpers",
-      "@remirror/core-utils"
-    ],
+    "ignore": ["@remirror/core-helpers", "@remirror/core-utils"],
     "running": false,
     "gzip": true
   },
@@ -114,11 +103,7 @@
     "name": "@remirror/core-types",
     "limit": "110 B",
     "path": "packages/remirror__core-types/dist/remirror-core-types.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core-constants",
-      "@remirror/types"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core-constants", "@remirror/types"],
     "running": false,
     "gzip": true
   },
@@ -142,11 +127,7 @@
     "name": "@remirror/dom",
     "limit": "5 KB",
     "path": "packages/remirror__dom/dist/remirror-dom.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/preset-core"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/preset-core"],
     "running": false,
     "gzip": true
   },
@@ -167,11 +148,7 @@
     "name": "@remirror/extension-bidi",
     "limit": "5 KB",
     "path": "packages/remirror__extension-bidi/dist/remirror-extension-bidi.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -179,12 +156,7 @@
     "name": "@remirror/extension-blockquote",
     "limit": "5 KB",
     "path": "packages/remirror__extension-blockquote/dist/remirror-extension-blockquote.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages",
-      "@remirror/theme"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,
     "gzip": true
   },
@@ -192,11 +164,7 @@
     "name": "@remirror/extension-bold",
     "limit": "5 KB",
     "path": "packages/remirror__extension-bold/dist/remirror-extension-bold.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -204,12 +172,7 @@
     "name": "@remirror/extension-callout",
     "limit": "15 KB",
     "path": "packages/remirror__extension-callout/dist/remirror-extension-callout.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages",
-      "@remirror/theme"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,
     "gzip": true
   },
@@ -217,11 +180,7 @@
     "name": "@remirror/extension-code",
     "limit": "5 KB",
     "path": "packages/remirror__extension-code/dist/remirror-extension-code.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -258,10 +217,7 @@
     "name": "@remirror/extension-codemirror6",
     "limit": "60 KB",
     "path": "packages/remirror__extension-codemirror6/dist/remirror-extension-codemirror6.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core"],
     "running": false,
     "gzip": true
   },
@@ -269,11 +225,7 @@
     "name": "@remirror/extension-collaboration",
     "limit": "5 KB",
     "path": "packages/remirror__extension-collaboration/dist/remirror-extension-collaboration.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -281,11 +233,7 @@
     "name": "@remirror/extension-columns",
     "limit": "5 KB",
     "path": "packages/remirror__extension-columns/dist/remirror-extension-columns.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -293,10 +241,7 @@
     "name": "@remirror/extension-count",
     "limit": "5 KB",
     "path": "packages/remirror__extension-count/dist/remirror-extension-count.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core"],
     "running": false,
     "gzip": true
   },
@@ -304,11 +249,7 @@
     "name": "@remirror/extension-diff",
     "limit": "5 KB",
     "path": "packages/remirror__extension-diff/dist/remirror-extension-diff.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -316,11 +257,7 @@
     "name": "@remirror/extension-doc",
     "limit": "5 KB",
     "path": "packages/remirror__extension-doc/dist/remirror-extension-doc.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -328,11 +265,7 @@
     "name": "@remirror/extension-drop-cursor",
     "limit": "5 KB",
     "path": "packages/remirror__extension-drop-cursor/dist/remirror-extension-drop-cursor.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -340,11 +273,7 @@
     "name": "@remirror/extension-embed",
     "limit": "20 KB",
     "path": "packages/remirror__extension-embed/dist/remirror-extension-embed.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -352,12 +281,7 @@
     "name": "@remirror/extension-emoji",
     "limit": "60 KB",
     "path": "packages/remirror__extension-emoji/dist/remirror-extension-emoji.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages",
-      "@remirror/theme"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,
     "gzip": true
   },
@@ -378,11 +302,7 @@
     "name": "@remirror/extension-epic-mode",
     "limit": "5 KB",
     "path": "packages/remirror__extension-epic-mode/dist/remirror-extension-epic-mode.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -390,11 +310,7 @@
     "name": "@remirror/extension-events",
     "limit": "5 KB",
     "path": "packages/remirror__extension-events/dist/remirror-extension-events.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -420,11 +336,7 @@
     "name": "@remirror/extension-font-family",
     "limit": "5 KB",
     "path": "packages/remirror__extension-font-family/dist/remirror-extension-font-family.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -432,11 +344,7 @@
     "name": "@remirror/extension-font-size",
     "limit": "5 KB",
     "path": "packages/remirror__extension-font-size/dist/remirror-extension-font-size.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -444,11 +352,7 @@
     "name": "@remirror/extension-gap-cursor",
     "limit": "5 KB",
     "path": "packages/remirror__extension-gap-cursor/dist/remirror-extension-gap-cursor.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -456,11 +360,7 @@
     "name": "@remirror/extension-hard-break",
     "limit": "5 KB",
     "path": "packages/remirror__extension-hard-break/dist/remirror-extension-hard-break.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -468,11 +368,7 @@
     "name": "@remirror/extension-heading",
     "limit": "5 KB",
     "path": "packages/remirror__extension-heading/dist/remirror-extension-heading.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -480,11 +376,7 @@
     "name": "@remirror/extension-history",
     "limit": "5 KB",
     "path": "packages/remirror__extension-history/dist/remirror-extension-history.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -492,11 +384,7 @@
     "name": "@remirror/extension-horizontal-rule",
     "limit": "5 KB",
     "path": "packages/remirror__extension-horizontal-rule/dist/remirror-extension-horizontal-rule.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -504,12 +392,7 @@
     "name": "@remirror/extension-image",
     "limit": "20 KB",
     "path": "packages/remirror__extension-image/dist/remirror-extension-image.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages",
-      "@remirror/theme"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,
     "gzip": true
   },
@@ -517,11 +400,7 @@
     "name": "@remirror/extension-italic",
     "limit": "5 KB",
     "path": "packages/remirror__extension-italic/dist/remirror-extension-italic.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -556,11 +435,7 @@
     "name": "@remirror/extension-markdown",
     "limit": "25 KB",
     "path": "packages/remirror__extension-markdown/dist/remirror-extension-markdown.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -595,11 +470,7 @@
     "name": "@remirror/extension-node-formatting",
     "limit": "5 KB",
     "path": "packages/remirror__extension-node-formatting/dist/remirror-extension-node-formatting.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -607,11 +478,7 @@
     "name": "@remirror/extension-paragraph",
     "limit": "5 KB",
     "path": "packages/remirror__extension-paragraph/dist/remirror-extension-paragraph.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -619,12 +486,7 @@
     "name": "@remirror/extension-placeholder",
     "limit": "5 KB",
     "path": "packages/remirror__extension-placeholder/dist/remirror-extension-placeholder.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages",
-      "@remirror/theme"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,
     "gzip": true
   },
@@ -701,11 +563,7 @@
     "name": "@remirror/extension-search",
     "limit": "5 KB",
     "path": "packages/remirror__extension-search/dist/remirror-extension-search.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -713,10 +571,7 @@
     "name": "@remirror/extension-shortcuts",
     "limit": "5 KB",
     "path": "packages/remirror__extension-shortcuts/dist/remirror-extension-shortcuts.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core"],
     "running": false,
     "gzip": true
   },
@@ -724,11 +579,7 @@
     "name": "@remirror/extension-strike",
     "limit": "5 KB",
     "path": "packages/remirror__extension-strike/dist/remirror-extension-strike.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -736,12 +587,7 @@
     "name": "@remirror/extension-tables",
     "limit": "10 KB",
     "path": "packages/remirror__extension-tables/dist/remirror-extension-tables.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages",
-      "@remirror/theme"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
     "running": false,
     "gzip": true
   },
@@ -749,11 +595,7 @@
     "name": "@remirror/extension-text",
     "limit": "5 KB",
     "path": "packages/remirror__extension-text/dist/remirror-extension-text.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -761,11 +603,7 @@
     "name": "@remirror/extension-text-case",
     "limit": "5 KB",
     "path": "packages/remirror__extension-text-case/dist/remirror-extension-text-case.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -800,11 +638,7 @@
     "name": "@remirror/extension-trailing-node",
     "limit": "5 KB",
     "path": "packages/remirror__extension-trailing-node/dist/remirror-extension-trailing-node.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -812,11 +646,7 @@
     "name": "@remirror/extension-underline",
     "limit": "5 KB",
     "path": "packages/remirror__extension-underline/dist/remirror-extension-underline.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -824,11 +654,7 @@
     "name": "@remirror/extension-whitespace",
     "limit": "5 KB",
     "path": "packages/remirror__extension-whitespace/dist/remirror-extension-whitespace.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -836,12 +662,7 @@
     "name": "@remirror/extension-yjs",
     "limit": "115 KB",
     "path": "packages/remirror__extension-yjs/dist/remirror-extension-yjs.js",
-    "ignore": [
-      "@remirror/pm",
-      "yjs",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "yjs", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },
@@ -849,9 +670,7 @@
     "name": "@remirror/i18n",
     "limit": "50 KB",
     "path": "packages/remirror__i18n/dist/remirror-i18n.js",
-    "ignore": [
-      "@remirror/core-helpers"
-    ],
+    "ignore": ["@remirror/core-helpers"],
     "running": false,
     "gzip": true
   },
@@ -859,9 +678,7 @@
     "name": "@remirror/icons",
     "limit": "30 KB",
     "path": "packages/remirror__icons/dist/remirror-icons.js",
-    "ignore": [
-      "@remirror/core-helpers"
-    ],
+    "ignore": ["@remirror/core-helpers"],
     "running": false,
     "gzip": true
   },
@@ -869,9 +686,7 @@
     "name": "@remirror/messages",
     "limit": "50 KB",
     "path": "packages/remirror__messages/dist/remirror-messages.js",
-    "ignore": [
-      "@remirror/core-helpers"
-    ],
+    "ignore": ["@remirror/core-helpers"],
     "running": false,
     "gzip": true
   },
@@ -1020,11 +835,7 @@
     "name": "@remirror/react-renderer",
     "limit": "50 KB",
     "path": "packages/remirror__react-renderer/dist/remirror-react-renderer.js",
-    "ignore": [
-      "@types/react",
-      "react",
-      "@remirror/core"
-    ],
+    "ignore": ["@types/react", "react", "@remirror/core"],
     "running": false,
     "gzip": true
   },
@@ -1062,9 +873,7 @@
     "name": "@remirror/theme",
     "limit": "10 KB",
     "path": "packages/remirror__theme/dist/remirror-theme.js",
-    "ignore": [
-      "@remirror/core-types"
-    ],
+    "ignore": ["@remirror/core-types"],
     "running": false,
     "gzip": true
   },
@@ -1080,10 +889,7 @@
     "name": "test-keyboard",
     "limit": "10 KB",
     "path": "packages/test-keyboard/dist/test-keyboard.js",
-    "ignore": [
-      "@remirror/core-helpers",
-      "@remirror/core-types"
-    ],
+    "ignore": ["@remirror/core-helpers", "@remirror/core-types"],
     "running": false,
     "gzip": true
   },
@@ -1091,10 +897,7 @@
     "name": "@remirror/extension-template",
     "limit": "5 KB",
     "path": "support/templates/extension-template/dist/remirror-extension-template.browser.esm.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core"],
     "running": false,
     "gzip": true
   },
@@ -1102,9 +905,7 @@
     "name": "@remirror/minimal-template",
     "limit": "50 KB",
     "path": "support/templates/minimal-template/dist/remirror-minimal-template.browser.esm.js",
-    "ignore": [
-      "@remirror/core-helpers"
-    ],
+    "ignore": ["@remirror/core-helpers"],
     "running": false,
     "gzip": true
   },
@@ -1112,10 +913,7 @@
     "name": "@remirror/preset-template",
     "limit": "10 KB",
     "path": "support/templates/preset-template/dist/remirror-preset-template.browser.esm.js",
-    "ignore": [
-      "@remirror/pm",
-      "@remirror/core"
-    ],
+    "ignore": ["@remirror/pm", "@remirror/core"],
     "running": false,
     "gzip": true
   }

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -11,7 +11,10 @@
     "name": "create-context-state",
     "limit": "1.5 KB",
     "path": "packages/create-context-state/dist/create-context-state.js",
-    "ignore": ["@types/react", "react"],
+    "ignore": [
+      "@types/react",
+      "react"
+    ],
     "running": false,
     "gzip": true
   },
@@ -19,7 +22,12 @@
     "name": "multishift",
     "limit": "20 KB",
     "path": "packages/multishift/dist/multishift.js",
-    "ignore": ["@types/react", "react", "@remirror/core-helpers", "@remirror/core-types"],
+    "ignore": [
+      "@types/react",
+      "react",
+      "@remirror/core-helpers",
+      "@remirror/core-types"
+    ],
     "running": false,
     "gzip": true
   },
@@ -41,7 +49,10 @@
     "name": "prosemirror-resizable-view",
     "limit": "5 KB",
     "path": "packages/prosemirror-resizable-view/dist/prosemirror-resizable-view.js",
-    "ignore": ["@remirror/core-helpers", "@remirror/core-utils"],
+    "ignore": [
+      "@remirror/core-helpers",
+      "@remirror/core-utils"
+    ],
     "running": false,
     "gzip": true
   },
@@ -103,7 +114,11 @@
     "name": "@remirror/core-types",
     "limit": "110 B",
     "path": "packages/remirror__core-types/dist/remirror-core-types.js",
-    "ignore": ["@remirror/pm", "@remirror/core-constants", "@remirror/types"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core-constants",
+      "@remirror/types"
+    ],
     "running": false,
     "gzip": true
   },
@@ -114,7 +129,6 @@
     "ignore": [
       "@remirror/pm",
       "@types/node",
-      "domino",
       "jsdom",
       "@remirror/core-constants",
       "@remirror/core-helpers",
@@ -128,7 +142,11 @@
     "name": "@remirror/dom",
     "limit": "5 KB",
     "path": "packages/remirror__dom/dist/remirror-dom.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/preset-core"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/preset-core"
+    ],
     "running": false,
     "gzip": true
   },
@@ -149,7 +167,11 @@
     "name": "@remirror/extension-bidi",
     "limit": "5 KB",
     "path": "packages/remirror__extension-bidi/dist/remirror-extension-bidi.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -157,7 +179,12 @@
     "name": "@remirror/extension-blockquote",
     "limit": "5 KB",
     "path": "packages/remirror__extension-blockquote/dist/remirror-extension-blockquote.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages",
+      "@remirror/theme"
+    ],
     "running": false,
     "gzip": true
   },
@@ -165,7 +192,11 @@
     "name": "@remirror/extension-bold",
     "limit": "5 KB",
     "path": "packages/remirror__extension-bold/dist/remirror-extension-bold.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -173,7 +204,12 @@
     "name": "@remirror/extension-callout",
     "limit": "15 KB",
     "path": "packages/remirror__extension-callout/dist/remirror-extension-callout.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages",
+      "@remirror/theme"
+    ],
     "running": false,
     "gzip": true
   },
@@ -181,7 +217,11 @@
     "name": "@remirror/extension-code",
     "limit": "5 KB",
     "path": "packages/remirror__extension-code/dist/remirror-extension-code.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -218,7 +258,10 @@
     "name": "@remirror/extension-codemirror6",
     "limit": "60 KB",
     "path": "packages/remirror__extension-codemirror6/dist/remirror-extension-codemirror6.js",
-    "ignore": ["@remirror/pm", "@remirror/core"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core"
+    ],
     "running": false,
     "gzip": true
   },
@@ -226,7 +269,11 @@
     "name": "@remirror/extension-collaboration",
     "limit": "5 KB",
     "path": "packages/remirror__extension-collaboration/dist/remirror-extension-collaboration.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -234,7 +281,11 @@
     "name": "@remirror/extension-columns",
     "limit": "5 KB",
     "path": "packages/remirror__extension-columns/dist/remirror-extension-columns.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -242,7 +293,10 @@
     "name": "@remirror/extension-count",
     "limit": "5 KB",
     "path": "packages/remirror__extension-count/dist/remirror-extension-count.js",
-    "ignore": ["@remirror/pm", "@remirror/core"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core"
+    ],
     "running": false,
     "gzip": true
   },
@@ -250,7 +304,11 @@
     "name": "@remirror/extension-diff",
     "limit": "5 KB",
     "path": "packages/remirror__extension-diff/dist/remirror-extension-diff.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -258,7 +316,11 @@
     "name": "@remirror/extension-doc",
     "limit": "5 KB",
     "path": "packages/remirror__extension-doc/dist/remirror-extension-doc.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -266,7 +328,11 @@
     "name": "@remirror/extension-drop-cursor",
     "limit": "5 KB",
     "path": "packages/remirror__extension-drop-cursor/dist/remirror-extension-drop-cursor.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -274,7 +340,11 @@
     "name": "@remirror/extension-embed",
     "limit": "20 KB",
     "path": "packages/remirror__extension-embed/dist/remirror-extension-embed.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -282,7 +352,12 @@
     "name": "@remirror/extension-emoji",
     "limit": "60 KB",
     "path": "packages/remirror__extension-emoji/dist/remirror-extension-emoji.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages",
+      "@remirror/theme"
+    ],
     "running": false,
     "gzip": true
   },
@@ -303,7 +378,11 @@
     "name": "@remirror/extension-epic-mode",
     "limit": "5 KB",
     "path": "packages/remirror__extension-epic-mode/dist/remirror-extension-epic-mode.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -311,7 +390,11 @@
     "name": "@remirror/extension-events",
     "limit": "5 KB",
     "path": "packages/remirror__extension-events/dist/remirror-extension-events.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -337,7 +420,11 @@
     "name": "@remirror/extension-font-family",
     "limit": "5 KB",
     "path": "packages/remirror__extension-font-family/dist/remirror-extension-font-family.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -345,7 +432,11 @@
     "name": "@remirror/extension-font-size",
     "limit": "5 KB",
     "path": "packages/remirror__extension-font-size/dist/remirror-extension-font-size.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -353,7 +444,11 @@
     "name": "@remirror/extension-gap-cursor",
     "limit": "5 KB",
     "path": "packages/remirror__extension-gap-cursor/dist/remirror-extension-gap-cursor.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -361,7 +456,11 @@
     "name": "@remirror/extension-hard-break",
     "limit": "5 KB",
     "path": "packages/remirror__extension-hard-break/dist/remirror-extension-hard-break.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -369,7 +468,11 @@
     "name": "@remirror/extension-heading",
     "limit": "5 KB",
     "path": "packages/remirror__extension-heading/dist/remirror-extension-heading.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -377,7 +480,11 @@
     "name": "@remirror/extension-history",
     "limit": "5 KB",
     "path": "packages/remirror__extension-history/dist/remirror-extension-history.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -385,7 +492,11 @@
     "name": "@remirror/extension-horizontal-rule",
     "limit": "5 KB",
     "path": "packages/remirror__extension-horizontal-rule/dist/remirror-extension-horizontal-rule.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -393,7 +504,12 @@
     "name": "@remirror/extension-image",
     "limit": "20 KB",
     "path": "packages/remirror__extension-image/dist/remirror-extension-image.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages",
+      "@remirror/theme"
+    ],
     "running": false,
     "gzip": true
   },
@@ -401,7 +517,11 @@
     "name": "@remirror/extension-italic",
     "limit": "5 KB",
     "path": "packages/remirror__extension-italic/dist/remirror-extension-italic.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -436,7 +556,11 @@
     "name": "@remirror/extension-markdown",
     "limit": "25 KB",
     "path": "packages/remirror__extension-markdown/dist/remirror-extension-markdown.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -471,7 +595,11 @@
     "name": "@remirror/extension-node-formatting",
     "limit": "5 KB",
     "path": "packages/remirror__extension-node-formatting/dist/remirror-extension-node-formatting.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -479,7 +607,11 @@
     "name": "@remirror/extension-paragraph",
     "limit": "5 KB",
     "path": "packages/remirror__extension-paragraph/dist/remirror-extension-paragraph.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -487,7 +619,12 @@
     "name": "@remirror/extension-placeholder",
     "limit": "5 KB",
     "path": "packages/remirror__extension-placeholder/dist/remirror-extension-placeholder.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages",
+      "@remirror/theme"
+    ],
     "running": false,
     "gzip": true
   },
@@ -564,7 +701,11 @@
     "name": "@remirror/extension-search",
     "limit": "5 KB",
     "path": "packages/remirror__extension-search/dist/remirror-extension-search.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -572,7 +713,10 @@
     "name": "@remirror/extension-shortcuts",
     "limit": "5 KB",
     "path": "packages/remirror__extension-shortcuts/dist/remirror-extension-shortcuts.js",
-    "ignore": ["@remirror/pm", "@remirror/core"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core"
+    ],
     "running": false,
     "gzip": true
   },
@@ -580,7 +724,11 @@
     "name": "@remirror/extension-strike",
     "limit": "5 KB",
     "path": "packages/remirror__extension-strike/dist/remirror-extension-strike.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -588,7 +736,12 @@
     "name": "@remirror/extension-tables",
     "limit": "10 KB",
     "path": "packages/remirror__extension-tables/dist/remirror-extension-tables.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages", "@remirror/theme"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages",
+      "@remirror/theme"
+    ],
     "running": false,
     "gzip": true
   },
@@ -596,7 +749,11 @@
     "name": "@remirror/extension-text",
     "limit": "5 KB",
     "path": "packages/remirror__extension-text/dist/remirror-extension-text.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -604,7 +761,11 @@
     "name": "@remirror/extension-text-case",
     "limit": "5 KB",
     "path": "packages/remirror__extension-text-case/dist/remirror-extension-text-case.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -639,7 +800,11 @@
     "name": "@remirror/extension-trailing-node",
     "limit": "5 KB",
     "path": "packages/remirror__extension-trailing-node/dist/remirror-extension-trailing-node.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -647,7 +812,11 @@
     "name": "@remirror/extension-underline",
     "limit": "5 KB",
     "path": "packages/remirror__extension-underline/dist/remirror-extension-underline.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -655,7 +824,11 @@
     "name": "@remirror/extension-whitespace",
     "limit": "5 KB",
     "path": "packages/remirror__extension-whitespace/dist/remirror-extension-whitespace.js",
-    "ignore": ["@remirror/pm", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -663,7 +836,12 @@
     "name": "@remirror/extension-yjs",
     "limit": "115 KB",
     "path": "packages/remirror__extension-yjs/dist/remirror-extension-yjs.js",
-    "ignore": ["@remirror/pm", "yjs", "@remirror/core", "@remirror/messages"],
+    "ignore": [
+      "@remirror/pm",
+      "yjs",
+      "@remirror/core",
+      "@remirror/messages"
+    ],
     "running": false,
     "gzip": true
   },
@@ -671,7 +849,9 @@
     "name": "@remirror/i18n",
     "limit": "50 KB",
     "path": "packages/remirror__i18n/dist/remirror-i18n.js",
-    "ignore": ["@remirror/core-helpers"],
+    "ignore": [
+      "@remirror/core-helpers"
+    ],
     "running": false,
     "gzip": true
   },
@@ -679,7 +859,9 @@
     "name": "@remirror/icons",
     "limit": "30 KB",
     "path": "packages/remirror__icons/dist/remirror-icons.js",
-    "ignore": ["@remirror/core-helpers"],
+    "ignore": [
+      "@remirror/core-helpers"
+    ],
     "running": false,
     "gzip": true
   },
@@ -687,7 +869,9 @@
     "name": "@remirror/messages",
     "limit": "50 KB",
     "path": "packages/remirror__messages/dist/remirror-messages.js",
-    "ignore": ["@remirror/core-helpers"],
+    "ignore": [
+      "@remirror/core-helpers"
+    ],
     "running": false,
     "gzip": true
   },
@@ -836,7 +1020,11 @@
     "name": "@remirror/react-renderer",
     "limit": "50 KB",
     "path": "packages/remirror__react-renderer/dist/remirror-react-renderer.js",
-    "ignore": ["@types/react", "react", "@remirror/core"],
+    "ignore": [
+      "@types/react",
+      "react",
+      "@remirror/core"
+    ],
     "running": false,
     "gzip": true
   },
@@ -874,7 +1062,9 @@
     "name": "@remirror/theme",
     "limit": "10 KB",
     "path": "packages/remirror__theme/dist/remirror-theme.js",
-    "ignore": ["@remirror/core-types"],
+    "ignore": [
+      "@remirror/core-types"
+    ],
     "running": false,
     "gzip": true
   },
@@ -890,7 +1080,10 @@
     "name": "test-keyboard",
     "limit": "10 KB",
     "path": "packages/test-keyboard/dist/test-keyboard.js",
-    "ignore": ["@remirror/core-helpers", "@remirror/core-types"],
+    "ignore": [
+      "@remirror/core-helpers",
+      "@remirror/core-types"
+    ],
     "running": false,
     "gzip": true
   },
@@ -898,7 +1091,10 @@
     "name": "@remirror/extension-template",
     "limit": "5 KB",
     "path": "support/templates/extension-template/dist/remirror-extension-template.browser.esm.js",
-    "ignore": ["@remirror/pm", "@remirror/core"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core"
+    ],
     "running": false,
     "gzip": true
   },
@@ -906,7 +1102,9 @@
     "name": "@remirror/minimal-template",
     "limit": "50 KB",
     "path": "support/templates/minimal-template/dist/remirror-minimal-template.browser.esm.js",
-    "ignore": ["@remirror/core-helpers"],
+    "ignore": [
+      "@remirror/core-helpers"
+    ],
     "running": false,
     "gzip": true
   },
@@ -914,7 +1112,10 @@
     "name": "@remirror/preset-template",
     "limit": "10 KB",
     "path": "support/templates/preset-template/dist/remirror-preset-template.browser.esm.js",
-    "ignore": ["@remirror/pm", "@remirror/core"],
+    "ignore": [
+      "@remirror/pm",
+      "@remirror/core"
+    ],
     "running": false,
     "gzip": true
   }


### PR DESCRIPTION
### Description

Close https://github.com/remirror/remirror/issues/1816 

When I try to use `jsdom` instead of `domino` in `core-utils.spec.ts`, I got the following error:

```
    ReferenceError: TextEncoder is not defined
```

I don't know why, but if I move these tests to a new file `core-utils.node.spec.ts`, in which I use comment `@jest-environment node` to specify the test environment to node (instead of jsdom), I no longer see this error. 


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
