### PR TITLE
chore: remirror-cli watch shouldn't override package.json files

### DIFF
--- a/packages/remirror__cli/src/commands/watch.ts
+++ b/packages/remirror__cli/src/commands/watch.ts
@@ -46,7 +46,7 @@ export async function watch(options: { skipBuild?: boolean }) {
     ignorePermissionErrors: true,
   });
   const executor = new DebounceExecutor(async (dir: string) => {
-    await buildPackage(packageDirMap[dir]);
+    await buildPackage(packageDirMap[dir], false);
     await runTsc();
   });
 

--- a/packages/remirror__cli/src/utils/build-package.ts
+++ b/packages/remirror__cli/src/utils/build-package.ts
@@ -18,12 +18,14 @@ import { writePackageJson } from './write-package-json';
 /**
  * Bundle a package using esbuild and update `package.json` if necessary.
  */
-export async function buildPackage(pkg: Package) {
+export async function buildPackage(pkg: Package, writePackageJson = true) {
   logger.info(`${colors.blue(pkg.packageJson.name)} building...`);
 
   const entryPoints = await parseEntryPoints(pkg);
 
-  await writeMainPackageJson(pkg, entryPoints);
+  if (writePackageJson) {
+    await writeMainPackageJson(pkg, entryPoints);
+  }
 
   const promises: Array<Promise<unknown>> = [];
 
@@ -46,8 +48,10 @@ export async function buildPackage(pkg: Package) {
     }
   }
 
-  for (const entryPoint of entryPoints.filter((entryPoint) => !entryPoint.isMain)) {
-    promises.push(writeSubpathPackageJson(pkg, entryPoint));
+  if (writePackageJson) {
+    for (const entryPoint of entryPoints.filter((entryPoint) => !entryPoint.isMain)) {
+      promises.push(writeSubpathPackageJson(pkg, entryPoint));
+    }
   }
 
   await Promise.all(promises);


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
