### PR TITLE
feat(markdown-ext): add optional escape function

### DIFF
--- a/.changeset/rich-mayflies-play.md
+++ b/.changeset/rich-mayflies-play.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-markdown': patch
+---
+
+Overriding TurndownService.prototype.escape to customise the escaping behaviour.
+
+See turndownService [Documentation](https://github.com/mixmark-io/turndown#escaping-markdown-characters)

--- a/packages/remirror__extension-markdown/src/html-to-markdown.ts
+++ b/packages/remirror__extension-markdown/src/html-to-markdown.ts
@@ -10,7 +10,11 @@ import { ErrorConstant, invariant, isElementDomNode } from '@remirror/core';
 /**
  * Converts the provide HTML to markdown.
  */
-export function htmlToMarkdown(html: string): string {
+export function htmlToMarkdown(html: string, escape?: (input: string) => string): string {
+  if (escape) {
+    turndownService.escape = escape;
+  }
+
   return turndownService.turndown(html);
 }
 

--- a/packages/remirror__extension-markdown/src/markdown-extension.ts
+++ b/packages/remirror__extension-markdown/src/markdown-extension.ts
@@ -28,7 +28,7 @@ export interface MarkdownOptions {
    *
    * By default this uses
    */
-  htmlToMarkdown?: Static<(html: string) => string>;
+  htmlToMarkdown?: Static<(html: string, escape?: (input: string) => string) => string>;
 
   /**
    * Takes a markdown string and outputs html. It is up to you to make sure the
@@ -67,6 +67,18 @@ export interface MarkdownOptions {
    * @defaultValue false
    */
   copyAsMarkdown?: boolean;
+
+  /**
+   * Overriding TurndownService.prototype.escape
+   *
+   * If you are confident in doing so, you may want to customise the escaping behaviour
+   * to suit your needs.
+   * This can be done by overriding TurndownService.prototype.escape. escape takes the text of each
+   * HTML element and should return a version with the Markdown characters escaped.
+   *
+   * Note: text in code elements is never passed toescape.
+   */
+  escape?: Static<(input: string) => string>;
 }
 
 /**
@@ -89,6 +101,7 @@ export interface MarkdownOptions {
     htmlToMarkdown,
     markdownToHtml,
     htmlSanitizer,
+    escape: undefined,
     activeNodes: [ExtensionTag.Code],
     copyAsMarkdown: false,
   },
@@ -114,7 +127,7 @@ export class MarkdownExtension extends PlainExtension<MarkdownOptions> {
           wrapper.append(serializer.serializeFragment(slice.content));
 
           // Here we take the sliced text and transform it into markdown.
-          return this.options.htmlToMarkdown(wrapper.innerHTML);
+          return this.options.htmlToMarkdown(wrapper.innerHTML, this.options.escape);
         }
       : undefined;
 
@@ -193,7 +206,7 @@ export class MarkdownExtension extends PlainExtension<MarkdownOptions> {
    */
   @helper()
   getMarkdown(state?: EditorState): Helper<string> {
-    return this.options.htmlToMarkdown(this.store.helpers.getHTML(state));
+    return this.options.htmlToMarkdown(this.store.helpers.getHTML(state), this.options.escape);
   }
 
   /**


### PR DESCRIPTION


### Description

Option to Override TurndownService.prototype.escape related to #1717

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Note I also removed the link ext in this demo

https://user-images.githubusercontent.com/3860298/189478501-f6c8780a-1406-48af-aba4-a628c1c6c508.mov


