### PR TITLE
docs(markdown-editor): remove-duplicate-ext

### DIFF
--- a/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
+++ b/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
@@ -48,12 +48,11 @@ export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
   const extensions = useCallback(
     () => [
       new PlaceholderExtension({ placeholder }),
-      new LinkExtension({ autoLink: true }),
       new BoldExtension(),
       new StrikeExtension(),
       new ItalicExtension(),
       new HeadingExtension(),
-      new LinkExtension(),
+      new LinkExtension({ autoLink: true }),
       new BlockquoteExtension(),
       new BulletListExtension({ enableSpine: true }),
       new OrderedListExtension(),

--- a/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
+++ b/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
@@ -47,12 +47,12 @@ export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
 }) => {
   const extensions = useCallback(
     () => [
+      new LinkExtension({ autoLink: true }),
       new PlaceholderExtension({ placeholder }),
       new BoldExtension(),
       new StrikeExtension(),
       new ItalicExtension(),
       new HeadingExtension(),
-      new LinkExtension({ autoLink: true }),
       new BlockquoteExtension(),
       new BulletListExtension({ enableSpine: true }),
       new OrderedListExtension(),

--- a/packages/storybook-react/stories/react-editors/markdown-editor.tsx
+++ b/packages/storybook-react/stories/react-editors/markdown-editor.tsx
@@ -189,12 +189,11 @@ export const DualEditor: React.FC = () => {
 };
 
 const extensions = () => [
-  new LinkExtension({ autoLink: true }),
   new BoldExtension(),
   new StrikeExtension(),
   new ItalicExtension(),
   new HeadingExtension(),
-  new LinkExtension(),
+  new LinkExtension({ autoLink: true }),
   new BlockquoteExtension(),
   new BulletListExtension({ enableSpine: true }),
   new OrderedListExtension(),

--- a/packages/storybook-react/stories/react-editors/markdown-editor.tsx
+++ b/packages/storybook-react/stories/react-editors/markdown-editor.tsx
@@ -189,11 +189,11 @@ export const DualEditor: React.FC = () => {
 };
 
 const extensions = () => [
+  new LinkExtension({ autoLink: true }),
   new BoldExtension(),
   new StrikeExtension(),
   new ItalicExtension(),
   new HeadingExtension(),
-  new LinkExtension({ autoLink: true }),
   new BlockquoteExtension(),
   new BulletListExtension({ enableSpine: true }),
   new OrderedListExtension(),


### PR DESCRIPTION
### Description

looks like the link extension was accidentally added twice

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

