### PR TITLE
docs(markdown-editor): remove link ext

### DIFF
--- a/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
+++ b/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
@@ -13,7 +13,6 @@ import {
   HardBreakExtension,
   HeadingExtension,
   ItalicExtension,
-  LinkExtension,
   ListItemExtension,
   MarkdownExtension,
   OrderedListExtension,
@@ -50,12 +49,10 @@ export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
   const extensions = useCallback(
     () => [
       new PlaceholderExtension({ placeholder }),
-      new LinkExtension({ autoLink: true }),
       new BoldExtension(),
       new StrikeExtension(),
       new ItalicExtension(),
       new HeadingExtension(),
-      new LinkExtension(),
       new BlockquoteExtension(),
       new BulletListExtension({ enableSpine: true }),
       new OrderedListExtension(),

--- a/packages/storybook-react/stories/react-editors/markdown-editor.tsx
+++ b/packages/storybook-react/stories/react-editors/markdown-editor.tsx
@@ -17,7 +17,6 @@ import {
   HardBreakExtension,
   HeadingExtension,
   ItalicExtension,
-  LinkExtension,
   ListItemExtension,
   MarkdownExtension,
   OrderedListExtension,
@@ -191,12 +190,10 @@ export const DualEditor: React.FC = () => {
 };
 
 const extensions = () => [
-  new LinkExtension({ autoLink: true }),
   new BoldExtension(),
   new StrikeExtension(),
   new ItalicExtension(),
   new HeadingExtension(),
-  new LinkExtension(),
   new BlockquoteExtension(),
   new BulletListExtension({ enableSpine: true }),
   new OrderedListExtension(),


### PR DESCRIPTION
### Description

I think a markdown editor does not need the link ext. 

Note I also created #1844 feel free to close either one.

This would solve the following issue, seen in #1717, when pasting this markdown `Check: [CommonMark](https://commonmark.org/)` in the markdown editor

**Expected results**
`Check: [CommonMark](https://commonmark.org/)`

**Actual results**
`Check: [CommonMark]([https://commonmark.org](https://commonmark.org))`


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
