### PR TITLE
chore: update TypeScript to v4.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "testing": "^0.0.4",
     "ts-documenter": "^0.0.4",
     "tsx": "^3.4.2",
-    "typescript": "~4.5.5",
+    "typescript": "~4.7.4",
     "typescript-styled-plugin": "^0.18.1"
   },
   "engines": {

--- a/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
@@ -6,7 +6,7 @@ import {
   LinkExtension,
 } from 'remirror/extensions';
 import { cleanup } from 'testing/react';
-import { PlainExtension, prosemirrorNodeToHtml } from '@remirror/core';
+import { AnyExtension, PlainExtension, prosemirrorNodeToHtml } from '@remirror/core';
 import { NodeSelection } from '@remirror/pm/state';
 
 import { renderEditor } from '../';
@@ -25,7 +25,7 @@ test('add content', () => {
     view,
     nodes: { doc, p },
     add,
-  } = renderEditor([] as never[]);
+  } = renderEditor<AnyExtension>([]);
   add(doc(p(expected)));
 
   expect(view.dom).toHaveTextContent(expected);

--- a/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
@@ -14,7 +14,7 @@ import { renderEditor } from '../';
 beforeEach(cleanup);
 
 test('renders an editor into the dom', () => {
-  const { view } = renderEditor([]);
+  const { view } = renderEditor<never>([]);
 
   expect(view.dom).toBeVisible();
 });

--- a/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
@@ -95,7 +95,7 @@ test('can throw error if received a non top level node', () => {
   const {
     nodes: { doc, p },
     add,
-  } = renderEditor([]);
+  } = renderEditor<AnyExtension>([]);
 
   expect(() => add(doc(p('')))).not.toThrow();
   expect(() => add(p(''))).toThrow();
@@ -122,9 +122,12 @@ class CustomExtension extends PlainExtension {
 }
 
 function create() {
-  return renderEditor([new BoldExtension(), new CustomExtension()], {
-    builtin: { persistentSelectionClass: undefined },
-  });
+  return renderEditor<BoldExtension | CustomExtension>(
+    [new BoldExtension(), new CustomExtension()],
+    {
+      builtin: { persistentSelectionClass: undefined },
+    },
+  );
 }
 
 describe('add', () => {
@@ -217,7 +220,7 @@ describe('tags', () => {
     view,
     nodes: { doc, p },
     add,
-  } = renderEditor([]);
+  } = renderEditor<never>([]);
 
   beforeEach(() => {
     ({

--- a/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
@@ -25,7 +25,7 @@ test('add content', () => {
     view,
     nodes: { doc, p },
     add,
-  } = renderEditor([]);
+  } = renderEditor([] as never[]);
   add(doc(p(expected)));
 
   expect(view.dom).toHaveTextContent(expected);
@@ -224,7 +224,7 @@ describe('tags', () => {
       view,
       nodes: { doc, p },
       add,
-    } = renderEditor([]));
+    } = renderEditor<never>([]));
   });
 
   it('supports <cursor>', () => {

--- a/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-editor.spec.ts
@@ -37,7 +37,7 @@ test('can be configured with plain node extensions', () => {
     view: { dom },
     nodes: { blockquote, doc, p },
     add,
-  } = renderEditor([new BlockquoteExtension()]);
+  } = renderEditor<BlockquoteExtension>([new BlockquoteExtension()]);
   add(doc(blockquote(p(expected)), p('This is a p')));
 
   expect(dom).toHaveTextContent('A simple blockquote');
@@ -50,7 +50,7 @@ test('can be configured with attribute node extensions', () => {
     nodes: { doc },
     attributeNodes: { heading },
     add,
-  } = renderEditor([new HeadingExtension()]);
+  } = renderEditor<HeadingExtension>([new HeadingExtension()]);
 
   const h3 = heading({ level: 3 });
   const h2 = heading({ level: 2 });
@@ -67,7 +67,7 @@ test('can be configured with plain mark extensions', () => {
     nodes: { doc, p },
     add,
     marks: { bold },
-  } = renderEditor([new BoldExtension()]);
+  } = renderEditor<BoldExtension>([new BoldExtension()]);
   add(doc(p('Text is ', bold(expected))));
 
   expect(dom.querySelector('strong')!.textContent).toBe(expected);
@@ -81,7 +81,7 @@ test('can be configured with attribute mark extensions', () => {
     nodes: { doc, p },
     add,
     attributeMarks: { link },
-  } = renderEditor([new LinkExtension()]);
+  } = renderEditor<LinkExtension>([new LinkExtension()]);
   const googleLinkExtension = link({ href });
   add(doc(p('LinkExtension to ', googleLinkExtension(expected))));
 

--- a/packages/jest-remirror/__tests__/jest-remirror-matchers.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-matchers.spec.ts
@@ -8,7 +8,7 @@ describe('toContainRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const expected = p('simple');
     const { state } = add(doc(expected));
 
@@ -19,7 +19,7 @@ describe('toContainRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const expected = p('simple');
     const { state } = add(doc(expected));
 
@@ -31,7 +31,7 @@ describe('toContainRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const { state } = add(doc(p('old')));
     const { state: newState } = add(doc(p('new')));
 
@@ -43,7 +43,7 @@ describe('toContainRemirrorDocument', () => {
     const {
       nodes: { doc: docOld, p: pOld },
       add: addOld,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
 
     const {
       nodes: { doc, p },
@@ -64,7 +64,7 @@ describe('toEqualRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const expected = p('simple');
     const { state } = add(doc(expected));
 
@@ -75,7 +75,7 @@ describe('toEqualRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const expected = p('simple');
     const { state } = add(doc(expected));
 
@@ -87,7 +87,7 @@ describe('toEqualRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const { state } = add(doc(p('old')));
     const { state: newState } = add(doc(p('new')));
 
@@ -99,7 +99,7 @@ describe('toEqualRemirrorDocument', () => {
     const {
       nodes: { doc: docOld, p: pOld },
       add: addOld,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
 
     const {
       nodes: { doc, p },
@@ -120,7 +120,7 @@ describe('toEqualRemirrorState', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([]);
+    } = renderEditor<never>([]);
     const { state } = add(doc(p('Foo <start>bar<end>')));
     expect(state).toEqualRemirrorState(doc(p('Foo <start>bar<end>')));
     expect(state).not.toEqualRemirrorState(doc(p('Foo <cursor>bar')));

--- a/packages/jest-remirror/__tests__/jest-remirror-matchers.spec.ts
+++ b/packages/jest-remirror/__tests__/jest-remirror-matchers.spec.ts
@@ -48,7 +48,7 @@ describe('toContainRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([new BoldExtension()]);
+    } = renderEditor<BoldExtension>([new BoldExtension()]);
     const oldNode = pOld('simple');
     const newNode = p('simple');
     const { state: oldState } = addOld(docOld(oldNode));
@@ -104,7 +104,7 @@ describe('toEqualRemirrorDocument', () => {
     const {
       nodes: { doc, p },
       add,
-    } = renderEditor([new BoldExtension()]);
+    } = renderEditor<BoldExtension>([new BoldExtension()]);
     const oldNode = pOld('simple');
     const newNode = p('simple');
     const { state: oldState } = addOld(docOld(oldNode));

--- a/packages/jest-remirror/src/jest-remirror-editor.ts
+++ b/packages/jest-remirror/src/jest-remirror-editor.ts
@@ -115,7 +115,7 @@ export class RemirrorTestChain<Extension extends AnyExtension> {
    * ```ts
    * import { HeadingExtension } from 'remirror/extensions';
    *
-   * const editor = renderEditor([new HeadingExtension()])
+   * const editor = renderEditor<HeadingExtension>([new HeadingExtension()])
    * const { heading } = editor.attributeNodes;
    *
    * heading({ level: 4, id: '1223' })('My custom heading');

--- a/packages/remirror__core-helpers/src/core-helpers.ts
+++ b/packages/remirror__core-helpers/src/core-helpers.ts
@@ -916,7 +916,7 @@ export function unset(path: Array<string | number>, target: Shape): Shape {
   return clonedObject;
 }
 
-function makeFunctionForUniqueBy<Item = any>(value: string | string[]) {
+function makeFunctionForUniqueBy<Item extends Shape = Shape>(value: string | string[]) {
   return (item: Item) => {
     return get(item, value as string);
   };

--- a/packages/remirror__core-utils/__tests__/core-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/core-utils.spec.ts
@@ -799,26 +799,26 @@ describe('areSchemasCompatible', () => {
   });
 
   it('is false for schemas with different mark lengths', () => {
-    const { schema: a } = renderEditor([new BoldExtension()]);
+    const { schema: a } = renderEditor<BoldExtension>([new BoldExtension()]);
     const { schema: b } = renderEditor([]);
     expect(areSchemasCompatible(a, b)).toBe(false);
   });
 
   it('is false schemas with different marks', () => {
-    const { schema: a } = renderEditor([new BoldExtension()]);
-    const { schema: b } = renderEditor([new ItalicExtension()]);
+    const { schema: a } = renderEditor<BoldExtension>([new BoldExtension()]);
+    const { schema: b } = renderEditor<ItalicExtension>([new ItalicExtension()]);
     expect(areSchemasCompatible(a, b)).toBe(false);
   });
 
   it('is false schemas with different node lengths', () => {
-    const { schema: a } = renderEditor([new BlockquoteExtension()]);
+    const { schema: a } = renderEditor<BlockquoteExtension>([new BlockquoteExtension()]);
     const { schema: b } = renderEditor([]);
     expect(areSchemasCompatible(a, b)).toBe(false);
   });
 
   it('is false schemas with different nodes', () => {
-    const { schema: a } = renderEditor([new BlockquoteExtension()]);
-    const { schema: b } = renderEditor([new HeadingExtension()]);
+    const { schema: a } = renderEditor<BlockquoteExtension>([new BlockquoteExtension()]);
+    const { schema: b } = renderEditor<HeadingExtension>([new HeadingExtension()]);
     expect(areSchemasCompatible(a, b)).toBe(false);
   });
 });

--- a/packages/remirror__core-utils/__tests__/core-utils.spec.ts
+++ b/packages/remirror__core-utils/__tests__/core-utils.spec.ts
@@ -778,8 +778,8 @@ describe('isStateEqual', () => {
   });
 
   it('returns false with non identical schema', () => {
-    const a = renderEditor([]);
-    const b = renderEditor([]);
+    const a = renderEditor<never>([]);
+    const b = renderEditor<never>([]);
     a.add(a.nodes.doc(a.nodes.p('Hello')));
     b.add(b.nodes.doc(b.nodes.p('Hello')));
     expect(areStatesEqual(a.state, b.state)).toBeFalse();
@@ -788,19 +788,19 @@ describe('isStateEqual', () => {
 
 describe('areSchemasCompatible', () => {
   it('is true for identical schema', () => {
-    const { schema } = renderEditor([]);
+    const { schema } = renderEditor<never>([]);
     expect(areSchemasCompatible(schema, schema)).toBe(true);
   });
 
   it('is true for similar schema', () => {
-    const { schema: a } = renderEditor([]);
-    const { schema: b } = renderEditor([]);
+    const { schema: a } = renderEditor<never>([]);
+    const { schema: b } = renderEditor<never>([]);
     expect(areSchemasCompatible(a, b)).toBe(true);
   });
 
   it('is false for schemas with different mark lengths', () => {
     const { schema: a } = renderEditor<BoldExtension>([new BoldExtension()]);
-    const { schema: b } = renderEditor([]);
+    const { schema: b } = renderEditor<never>([]);
     expect(areSchemasCompatible(a, b)).toBe(false);
   });
 
@@ -812,7 +812,7 @@ describe('areSchemasCompatible', () => {
 
   it('is false schemas with different node lengths', () => {
     const { schema: a } = renderEditor<BlockquoteExtension>([new BlockquoteExtension()]);
-    const { schema: b } = renderEditor([]);
+    const { schema: b } = renderEditor<never>([]);
     expect(areSchemasCompatible(a, b)).toBe(false);
   });
 

--- a/packages/remirror__core/__tests__/commands-extension.spec.ts
+++ b/packages/remirror__core/__tests__/commands-extension.spec.ts
@@ -189,7 +189,7 @@ describe('commands.insertText', () => {
 
 describe('setContent', () => {
   it('can set the content while preserving history', () => {
-    const editor = renderEditor([], { stringHandler: 'html' });
+    const editor = renderEditor<never>([], { stringHandler: 'html' });
     const { doc, p } = editor.nodes;
     editor.add(doc(p('my content')));
 
@@ -201,7 +201,7 @@ describe('setContent', () => {
   });
 
   it('can reset the content while preserving history', () => {
-    const editor = renderEditor([], { stringHandler: 'html' });
+    const editor = renderEditor<never>([], { stringHandler: 'html' });
     const { doc, p } = editor.nodes;
     editor.add(doc(p('my content')));
 

--- a/packages/remirror__core/__tests__/commands-extension.spec.ts
+++ b/packages/remirror__core/__tests__/commands-extension.spec.ts
@@ -120,7 +120,7 @@ describe('commands.insertText', () => {
   });
 
   it('can insert text with marks', () => {
-    const editor = renderEditor([new BoldExtension()]);
+    const editor = renderEditor<BoldExtension>([new BoldExtension()]);
     const { doc, p } = editor.nodes;
     const { bold } = editor.marks;
 

--- a/packages/remirror__core/__tests__/commands-extension.spec.ts
+++ b/packages/remirror__core/__tests__/commands-extension.spec.ts
@@ -35,7 +35,7 @@ test('can chain commands', () => {
 test('clears range selection', () => {
   const text = 'my content';
 
-  const editor = renderEditor([]);
+  const editor = renderEditor<never>([]);
   const { doc, p } = editor.nodes;
   const { commands } = editor;
 
@@ -51,7 +51,7 @@ test('clears range selection', () => {
 });
 
 test('rejects clearing range selection if there is none', () => {
-  const editor = renderEditor([]);
+  const editor = renderEditor<never>([]);
   const { doc, p } = editor.nodes;
   const { commands } = editor;
 
@@ -61,7 +61,7 @@ test('rejects clearing range selection if there is none', () => {
 });
 
 test('it can select text', () => {
-  const editor = renderEditor([]);
+  const editor = renderEditor<never>([]);
   const { doc, p } = editor.nodes;
 
   editor.add(doc(p('my <cursor>content')));
@@ -92,7 +92,7 @@ function sleep(msDelay: number) {
 
 describe('commands.clearRangeSelection', () => {
   it('clears the selection', () => {
-    const editor = renderEditor([]);
+    const editor = renderEditor<never>([]);
     const { doc, p } = editor.nodes;
 
     editor.add(doc(p('my <head>content<anchor> is chill')));
@@ -104,7 +104,7 @@ describe('commands.clearRangeSelection', () => {
   });
 
   it('does nothing when the selection is empty', () => {
-    const editor = renderEditor([]);
+    const editor = renderEditor<never>([]);
     const { doc, p } = editor.nodes;
     editor.add(doc(p('my content<head><anchor> is chill')));
 
@@ -135,7 +135,7 @@ describe('commands.insertText', () => {
   });
 
   it('can insert a range of text', () => {
-    const editor = renderEditor([]);
+    const editor = renderEditor<never>([]);
     const { doc, p } = editor.nodes;
 
     editor.add(doc(p('my <cursor>content')));
@@ -149,7 +149,7 @@ describe('commands.insertText', () => {
   });
 
   it('can insert text asynchronously', async () => {
-    const editor = renderEditor([]);
+    const editor = renderEditor<never>([]);
     const { doc, p } = editor.nodes;
     editor.add(doc(p('my <cursor>CODE!')));
     const promise = sleep(100).then(() => {
@@ -168,7 +168,7 @@ describe('commands.insertText', () => {
   });
 
   it('can recover after a rejected promise', async () => {
-    const editor = renderEditor([]);
+    const editor = renderEditor<never>([]);
     const { doc, p } = editor.nodes;
     editor.add(doc(p('my <cursor>CODE!')));
     const promise = Promise.reject();

--- a/packages/remirror__core/__tests__/decorations-extension.spec.ts
+++ b/packages/remirror__core/__tests__/decorations-extension.spec.ts
@@ -27,7 +27,7 @@ describe('options', () => {
 
     it('retains selection and decoration', () => {
       const builtin = { persistentSelectionClass: 'selection' };
-      const editor = renderEditor([], { builtin });
+      const editor = renderEditor<never>([], { builtin });
       const {
         add,
         dom,

--- a/packages/remirror__core/__tests__/decorations-extension.spec.ts
+++ b/packages/remirror__core/__tests__/decorations-extension.spec.ts
@@ -1,6 +1,6 @@
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
-import { DecorationsExtension } from '../';
+import { AnyExtension, DecorationsExtension } from '../';
 
 extensionValidityTest(DecorationsExtension);
 
@@ -17,7 +17,7 @@ describe('options', () => {
         dom,
         selectText,
         nodes: { p, doc },
-      } = renderEditor([], { builtin: configuration });
+      } = renderEditor<AnyExtension>([], { builtin: configuration });
 
       add(doc(p('Some text')));
       selectText({ from: 4, to: 9 });

--- a/packages/remirror__core/__tests__/doc-changed-extension.spec.ts
+++ b/packages/remirror__core/__tests__/doc-changed-extension.spec.ts
@@ -11,7 +11,7 @@ test('calls the docChanged handler when the document is changed', () => {
     manager,
     add,
     nodes: { p, doc },
-  } = renderEditor([]);
+  } = renderEditor<never>([]);
 
   manager.getExtension(DocChangedExtension).addHandler('docChanged', mock);
 
@@ -34,7 +34,7 @@ test('does not call the docChanged handler when the selection is changed', () =>
     manager,
     add,
     nodes: { p, doc },
-  } = renderEditor([]);
+  } = renderEditor<never>([]);
 
   manager.getExtension(DocChangedExtension).addHandler('docChanged', mock);
 

--- a/packages/remirror__core/__tests__/framework.spec.ts
+++ b/packages/remirror__core/__tests__/framework.spec.ts
@@ -1,15 +1,15 @@
 import { renderEditor } from 'jest-remirror';
 
 test('autoFocus', () => {
-  const defaultEditor = renderEditor([], { props: {} });
+  const defaultEditor = renderEditor<never>([], { props: {} });
   expect(defaultEditor.dom.getAttribute('autofocus')).toBeNull();
 
-  const unfocusedEditor = renderEditor([], { props: { autoFocus: false } });
+  const unfocusedEditor = renderEditor<never>([], { props: { autoFocus: false } });
   expect(unfocusedEditor.dom.getAttribute('autofocus')).toBeNull();
 
-  const focusedEditor = renderEditor([], { props: { autoFocus: true } });
+  const focusedEditor = renderEditor<never>([], { props: { autoFocus: true } });
   expect(focusedEditor.dom.getAttribute('autofocus')).toBe('true');
 
-  const focusedPosition = renderEditor([], { props: { autoFocus: 0 } });
+  const focusedPosition = renderEditor<never>([], { props: { autoFocus: 0 } });
   expect(focusedPosition.dom.getAttribute('autofocus')).toBe('true');
 });

--- a/packages/remirror__core/__tests__/helpers-extension.spec.ts
+++ b/packages/remirror__core/__tests__/helpers-extension.spec.ts
@@ -47,7 +47,7 @@ describe('helpers', () => {
     });
 
     it('returns false if the view is not editable', () => {
-      const { helpers } = renderEditor([], { props: { editable: false } });
+      const { helpers } = renderEditor<never>([], { props: { editable: false } });
       expect(helpers.isViewEditable()).toBeFalse();
     });
   });

--- a/packages/remirror__core/__tests__/helpers-extension.spec.ts
+++ b/packages/remirror__core/__tests__/helpers-extension.spec.ts
@@ -12,7 +12,7 @@ describe('active', () => {
       nodes: { p, doc },
       attributeNodes: { heading: h },
       active,
-    } = renderEditor([new HeadingExtension()]);
+    } = renderEditor<HeadingExtension>([new HeadingExtension()]);
 
     add(doc((p('one'), h({ level: 2 })('tw<cursor>o'))));
 
@@ -81,7 +81,7 @@ describe('commands.insertHtml', () => {
   });
 
   it('can insert marks', () => {
-    const editor = renderEditor([new BoldExtension()]);
+    const editor = renderEditor<BoldExtension>([new BoldExtension()]);
     const { doc, p } = editor.nodes;
     const { bold } = editor.marks;
 

--- a/packages/remirror__core/__tests__/helpers-extension.spec.ts
+++ b/packages/remirror__core/__tests__/helpers-extension.spec.ts
@@ -24,7 +24,7 @@ describe('active', () => {
 describe('helpers', () => {
   describe('`isSelectionEmpty`', () => {
     it('returns true if the selection is empty', () => {
-      const { add, nodes, helpers } = renderEditor([]);
+      const { add, nodes, helpers } = renderEditor<never>([]);
       const { p, doc } = nodes;
 
       add(doc(p('on<cursor>e')));
@@ -32,7 +32,7 @@ describe('helpers', () => {
     });
 
     it('returns false if the selection is not empty', () => {
-      const { add, nodes, helpers } = renderEditor([]);
+      const { add, nodes, helpers } = renderEditor<never>([]);
       const { p, doc } = nodes;
 
       add(doc(p('on<start>e<end>')));
@@ -42,7 +42,7 @@ describe('helpers', () => {
 
   describe('`isViewEditable`', () => {
     it('returns true if the view is editable', () => {
-      const { helpers } = renderEditor([]);
+      const { helpers } = renderEditor<never>([]);
       expect(helpers.isViewEditable()).toBeTrue();
     });
 

--- a/packages/remirror__core/__tests__/keymap-extension.spec.ts
+++ b/packages/remirror__core/__tests__/keymap-extension.spec.ts
@@ -14,7 +14,7 @@ test('supports custom keymaps', () => {
     manager,
     add,
     nodes: { p, doc },
-  } = renderEditor([]);
+  } = renderEditor<never>([]);
 
   manager.getExtension(KeymapExtension).addCustomHandler('keymap', { a: mock });
 
@@ -29,7 +29,7 @@ test('supports the default keymap', () => {
   const {
     add,
     nodes: { p, doc },
-  } = renderEditor([]);
+  } = renderEditor<never>([]);
 
   add(doc(p('Start<cursor>')))
     .press('Enter')

--- a/packages/remirror__core/__tests__/keymap-extension.spec.ts
+++ b/packages/remirror__core/__tests__/keymap-extension.spec.ts
@@ -43,7 +43,7 @@ test('supports turning the keymap off', () => {
   const {
     add,
     nodes: { p, doc },
-  } = renderEditor([], { builtin });
+  } = renderEditor<never>([], { builtin });
 
   add(doc(p('Start<cursor>')))
     .press('Enter')
@@ -57,7 +57,7 @@ test('it supports updating options at runtime', () => {
     manager,
     add,
     nodes: { p, doc },
-  } = renderEditor([], { builtin: { excludeBaseKeymap: true } });
+  } = renderEditor<never>([], { builtin: { excludeBaseKeymap: true } });
 
   add(doc(p('Start<cursor>')))
     .press('Enter')

--- a/packages/remirror__core/__tests__/schema-extension.spec.ts
+++ b/packages/remirror__core/__tests__/schema-extension.spec.ts
@@ -65,7 +65,7 @@ describe('dynamic schema attributes', () => {
 });
 
 test('custom schema', () => {
-  const editor = renderEditor([], { schema });
+  const editor = renderEditor<never>([], { schema });
 
   expect(editor.schema).toBe(schema);
   expect(Object.keys(editor.manager.nodes)).toMatchSnapshot();

--- a/packages/remirror__core/__tests__/tags-extension.spec.ts
+++ b/packages/remirror__core/__tests__/tags-extension.spec.ts
@@ -41,13 +41,15 @@ describe('tags', () => {
       }
     }
 
-    const editor = renderEditor([new CustomExtension()]);
+    const editor = renderEditor<CustomExtension>([new CustomExtension()]);
     expect(editor.manager.nodes.custom.group).toBe(ExtensionTag.Alignment);
   });
 
   it('throws when an invalid tag is added', () => {
     // @ts-expect-error
-    expect(() => renderEditor([new InvalidExtension()])).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      renderEditor<InvalidExtension>([new InvalidExtension()]),
+    ).toThrowErrorMatchingSnapshot();
   });
 
   it('can mutate the tags', () => {
@@ -59,7 +61,7 @@ describe('tags', () => {
     // @ts-expect-error
     expect(ExtensionTag.Awesome).toBe('awesome');
     // @ts-expect-error
-    const editor = renderEditor([new InvalidExtension()]);
+    const editor = renderEditor<InvalidExtension>([new InvalidExtension()]);
     expect(editor.manager.nodes['invalid'].group).toBe('awesome');
 
     // @ts-expect-error

--- a/packages/remirror__core/__tests__/tags-extension.spec.ts
+++ b/packages/remirror__core/__tests__/tags-extension.spec.ts
@@ -46,8 +46,8 @@ describe('tags', () => {
   });
 
   it('throws when an invalid tag is added', () => {
-    // @ts-expect-error
     expect(() =>
+      // @ts-expect-error
       renderEditor<InvalidExtension>([new InvalidExtension()]),
     ).toThrowErrorMatchingSnapshot();
   });
@@ -62,6 +62,7 @@ describe('tags', () => {
     expect(ExtensionTag.Awesome).toBe('awesome');
     // @ts-expect-error
     const editor = renderEditor<InvalidExtension>([new InvalidExtension()]);
+    // @ts-expect-error
     expect(editor.manager.nodes['invalid'].group).toBe('awesome');
 
     // @ts-expect-error

--- a/packages/remirror__core/src/extension/base-class.ts
+++ b/packages/remirror__core/src/extension/base-class.ts
@@ -89,7 +89,7 @@ export abstract class BaseClass<
    *
    * @internal
    */
-  ['~O']: Options & DefaultStaticOptions;
+  ['~O']: Options & DefaultStaticOptions = {} as Options & DefaultStaticOptions;
 
   /**
    * This identifies this as a `Remirror` object. .

--- a/packages/remirror__core/src/extension/extension-types.ts
+++ b/packages/remirror__core/src/extension/extension-types.ts
@@ -256,6 +256,49 @@ export type GetExtensions<Extension> =
     : AnyExtension;
 
 /**
+ * Extract the function return type if the generic type is a function, otherwise
+ *
+ * @internal
+ *
+ * @example
+ *
+ * ```ts
+ * type A = () => string
+ * type B = UnpackedReturnType<A>
+ * // B = string
+ *
+ * type C = string
+ * type D = UnpackedReturnType<A>
+ * // D = string
+ * ```
+ */
+type UnpackedReturnType<MaybeFunction> = MaybeFunction extends (...args: any[]) => infer Returned
+  ? Returned
+  : MaybeFunction;
+
+/**
+ * Get the union extension type from an array of extensions or from a function that returns an array of extension.
+ *
+ * @example
+ *
+ * ```ts
+ * const extensions = [new BoldExtension(), new ItalicExtension()];
+ * type Extension = UnpackedExtension<typeof extensions>
+ * // Extension = BoldExtension | ItalicExtension
+ * ```
+ *
+ * @example
+ *
+ * ```ts
+ * const extensions = () => [new BoldExtension(), new ItalicExtension()];
+ * type Extension = UnpackedExtension<typeof extensions>
+ * // Extension = BoldExtension | ItalicExtension
+ * ```
+ */
+export type UnpackedExtension<Extension extends AnyExtension[] | (() => AnyExtension[])> =
+  UnpackedReturnType<Extension>[number];
+
+/**
  * The type which gets the active methods from the provided extensions.
  */
 export type ActiveFromExtensions<Extension extends AnyExtension> = Record<

--- a/packages/remirror__core/src/extension/extension.ts
+++ b/packages/remirror__core/src/extension/extension.ts
@@ -223,7 +223,9 @@ abstract class Extension<Options extends ValidOptions = EmptyShape> extends Base
    *
    * @internal
    */
-  ['~E']: ReturnType<this['createExtensions']>[number];
+  ['~E']: ReturnType<this['createExtensions']>[number] = {} as ReturnType<
+    this['createExtensions']
+  >[number];
 
   /**
    * Create the extensions which will be consumed by the preset. Override this
@@ -370,55 +372,7 @@ abstract class Extension<Options extends ValidOptions = EmptyShape> extends Base
   setPriority(priority: undefined | ExtensionPriority): void {
     this.priorityOverride = priority;
   }
-}
 
-/**
- * Declaration merging since the constructor property can't be defined on the
- * actual class.
- */
-interface Extension<Options extends ValidOptions = EmptyShape>
-  extends ExtensionLifecycleMethods,
-    Remirror.BaseExtension {
-  /**
-   * The type of the constructor for the extension.
-   */
-  constructor: ExtensionConstructor<Options>;
-
-  /**
-   * An extension can declare the extensions it requires.
-   *
-   * @remarks
-   *
-   * When creating the extension manager the extension will be checked for
-   * required extension as well as a quick check to see if the required
-   * extension is already included. If not present a descriptive error will be
-   * thrown.
-   */
-  requiredExtensions?: AnyExtensionConstructor[];
-}
-
-/**
- * Get the expected type signature for the `defaultOptions`. Requires that every
- * optional setting key (except for keys which are defined on the
- * `BaseExtensionOptions`) has a value assigned.
- */
-export type DefaultExtensionOptions<Options extends ValidOptions> = DefaultOptions<
-  Options,
-  BaseExtensionOptions
->;
-
-/**
- * Here is the extension lifecycle order.
- *
- * ### Ordering
- *
- * - `onCreate`
- * - `onView`
- * - **runtime**
- * - `onStateUpdate` (repeats for every update to the prosemirror editor state)
- * - `onDestroy` (end of life)
- */
-interface ExtensionLifecycleMethods {
   /**
    * This handler is called when the `RemirrorManager` is first created.
    *
@@ -431,6 +385,8 @@ interface ExtensionLifecycleMethods {
    * You can return a `Dispose` function which will automatically be called when
    * the extension is destroyed.
    *
+   * This handler is called before the `onView` handler.
+   *
    * @category Lifecycle Methods
    */
   onCreate?(): Dispose | void;
@@ -441,6 +397,8 @@ interface ExtensionLifecycleMethods {
    *
    * Return a dispose function which will be called when the extension is
    * destroyed.
+   *
+   * This handler is called after the `onCreate` handler.
    *
    * @category Lifecycle Methods
    */
@@ -494,6 +452,39 @@ interface ExtensionLifecycleMethods {
    */
   onDestroy?(): void;
 }
+
+/**
+ * Declaration merging since the constructor property can't be defined on the
+ * actual class.
+ */
+interface Extension<Options extends ValidOptions = EmptyShape> extends Remirror.BaseExtension {
+  /**
+   * The type of the constructor for the extension.
+   */
+  constructor: ExtensionConstructor<Options>;
+
+  /**
+   * An extension can declare the extensions it requires.
+   *
+   * @remarks
+   *
+   * When creating the extension manager the extension will be checked for
+   * required extension as well as a quick check to see if the required
+   * extension is already included. If not present a descriptive error will be
+   * thrown.
+   */
+  requiredExtensions?: AnyExtensionConstructor[];
+}
+
+/**
+ * Get the expected type signature for the `defaultOptions`. Requires that every
+ * optional setting key (except for keys which are defined on the
+ * `BaseExtensionOptions`) has a value assigned.
+ */
+export type DefaultExtensionOptions<Options extends ValidOptions> = DefaultOptions<
+  Options,
+  BaseExtensionOptions
+>;
 
 /**
  * Create a plain extension which doesn't directly map to Prosemirror nodes or

--- a/packages/remirror__core/src/types.ts
+++ b/packages/remirror__core/src/types.ts
@@ -301,7 +301,9 @@ export interface GetChangeOptionsReturn<Options extends ValidOptions> {
   pickChanged: PickChanged<Options>;
 }
 
-export type PickChanged<Options> = <Key extends keyof GetFixedDynamic<Options>>(
+export type PickChanged<Options extends ValidOptions> = <
+  Key extends keyof GetFixedDynamic<Options>,
+>(
   keys: Key[],
 ) => Partial<Pick<GetFixedDynamic<Options>, Key>>;
 

--- a/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
+++ b/packages/remirror__extension-annotation/__tests__/annotation-extension.spec.ts
@@ -561,12 +561,14 @@ describe('custom annotations', () => {
   }
 
   it('should support custom annotations', () => {
+    const extension = new AnnotationExtension<MyAnnotation>();
+    type Extension = typeof extension;
     const {
       add,
       helpers,
       nodes: { p, doc },
       commands,
-    } = renderEditor([new AnnotationExtension<MyAnnotation>()]);
+    } = renderEditor<Extension>([extension]);
 
     add(doc(p('<start>Hello<end>')));
     commands.addAnnotation({ id: '1', tag: 'tag' });
@@ -583,13 +585,15 @@ describe('custom annotations', () => {
   });
 
   it('should support overlapping custom annotations', () => {
+    const extension = new AnnotationExtension<MyAnnotation>();
+    type Extension = typeof extension;
     const {
       dom,
       selectText,
       add,
       nodes: { p, doc },
       commands,
-    } = renderEditor([new AnnotationExtension<MyAnnotation>()]);
+    } = renderEditor<Extension>([extension]);
 
     add(doc(p('<start>Hello<end> my friend')));
 
@@ -630,12 +634,14 @@ describe('custom styling', () => {
       return `background: ${annotations[0]?.color}`;
     };
 
+    const extension = new AnnotationExtension<ColoredAnnotation>({ getStyle });
+    type Extension = typeof extension;
     const {
       dom,
       add,
       nodes: { p, doc },
       commands,
-    } = renderEditor([new AnnotationExtension<ColoredAnnotation>({ getStyle })]);
+    } = renderEditor<Extension>([extension]);
 
     add(doc(p('<start>Hello<end> my friend')));
 

--- a/packages/remirror__extension-bidi/__tests__/bidi-extension.spec.ts
+++ b/packages/remirror__extension-bidi/__tests__/bidi-extension.spec.ts
@@ -10,7 +10,7 @@ test('captures the direction of each node', () => {
     add,
     nodes: { p, doc },
     view,
-  } = renderEditor([new BidiExtension()]);
+  } = renderEditor<BidiExtension>([new BidiExtension()]);
 
   add(doc(p('first paragraph'), p('بسيطة'), p('@')));
   expect(view.dom).toMatchSnapshot();

--- a/packages/remirror__extension-bidi/__tests__/bidi-extension.spec.ts
+++ b/packages/remirror__extension-bidi/__tests__/bidi-extension.spec.ts
@@ -22,7 +22,7 @@ test('updates to the default direction affect the attributes', () => {
     add,
     nodes: { p, doc },
     view,
-  } = renderEditor([extension]);
+  } = renderEditor<BidiExtension>([extension]);
 
   add(doc(p('first paragraph')));
   extension.setOptions({ defaultDirection: 'rtl', autoUpdate: true });
@@ -45,7 +45,9 @@ describe('options', () => {
       add,
       nodes: { p, doc },
       view,
-    } = renderEditor([new BidiExtension({ defaultDirection: 'rtl', autoUpdate: true })]);
+    } = renderEditor<BidiExtension>([
+      new BidiExtension({ defaultDirection: 'rtl', autoUpdate: true }),
+    ]);
 
     add(doc(p('first paragraph'), p('بسيطة'), p('@')));
     expect(view.dom).toMatchSnapshot();
@@ -69,7 +71,7 @@ describe('options', () => {
       add,
       nodes: { p, doc, heading },
       view,
-    } = renderEditor([extension, new HeadingExtension()]);
+    } = renderEditor<BidiExtension | HeadingExtension>([extension, new HeadingExtension()]);
 
     add(doc(p('<cursor>'), heading('')))
       .insertText('بسيطة')

--- a/packages/remirror__extension-blockquote/__tests__/blockquote-extension.spec.ts
+++ b/packages/remirror__extension-blockquote/__tests__/blockquote-extension.spec.ts
@@ -9,7 +9,7 @@ describe('schema', () => {
   const {
     nodes: { blockquote, doc, p },
     schema,
-  } = renderEditor([new BlockquoteExtension()]);
+  } = renderEditor<BlockquoteExtension>([new BlockquoteExtension()]);
 
   it('creates the correct dom node', () => {
     expect(prosemirrorNodeToHtml(blockquote(p('Hello friend!')))).toMatchInlineSnapshot(`

--- a/packages/remirror__extension-blockquote/__tests__/blockquote-extension.spec.ts
+++ b/packages/remirror__extension-blockquote/__tests__/blockquote-extension.spec.ts
@@ -35,7 +35,7 @@ describe('schema', () => {
 test('supports extra attributes', () => {
   const {
     nodes: { blockquote, p },
-  } = renderEditor([
+  } = renderEditor<BlockquoteExtension>([
     new BlockquoteExtension({ extraAttributes: { 'data-custom': 'hello-world' } }),
   ]);
 
@@ -50,7 +50,7 @@ test('supports extra attributes', () => {
 
 function create() {
   const blockquoteExtension = new BlockquoteExtension();
-  return renderEditor([blockquoteExtension]);
+  return renderEditor<BlockquoteExtension>([blockquoteExtension]);
 }
 
 test('inputRules', () => {

--- a/packages/remirror__extension-callout/__tests__/callout-extension.spec.ts
+++ b/packages/remirror__extension-callout/__tests__/callout-extension.spec.ts
@@ -35,7 +35,9 @@ describe('schema', () => {
 test('supports extra attributes', () => {
   const {
     nodes: { callout, p },
-  } = renderEditor([new CalloutExtension({ extraAttributes: { 'data-custom': 'hello-world' } })]);
+  } = renderEditor<CalloutExtension>([
+    new CalloutExtension({ extraAttributes: { 'data-custom': 'hello-world' } }),
+  ]);
 
   expect(prosemirrorNodeToHtml(callout(p('friend!')))).toMatchInlineSnapshot(`
     <div
@@ -51,7 +53,7 @@ test('supports extra attributes', () => {
 
 function create() {
   const calloutExtension = new CalloutExtension();
-  return renderEditor([calloutExtension]);
+  return renderEditor<CalloutExtension>([calloutExtension]);
 }
 
 describe('commands', () => {
@@ -126,7 +128,7 @@ describe('commands', () => {
         attributeNodes: { callout },
 
         commands,
-      } = renderEditor([calloutExtension]);
+      } = renderEditor<CalloutExtension>([calloutExtension]);
 
       add(doc(p(`Make this a callout<cursor>`)));
 

--- a/packages/remirror__extension-callout/__tests__/callout-extension.spec.ts
+++ b/packages/remirror__extension-callout/__tests__/callout-extension.spec.ts
@@ -9,7 +9,7 @@ describe('schema', () => {
   const {
     nodes: { callout, doc, p },
     schema,
-  } = renderEditor([new CalloutExtension()]);
+  } = renderEditor<CalloutExtension>([new CalloutExtension()]);
 
   it('creates the correct dom node', () => {
     expect(prosemirrorNodeToHtml(callout(p('Hello friend!')))).toMatchInlineSnapshot(`

--- a/packages/remirror__extension-code/__tests__/code-extension.spec.ts
+++ b/packages/remirror__extension-code/__tests__/code-extension.spec.ts
@@ -44,7 +44,7 @@ describe('inputRules', () => {
     add,
     nodes: { p, doc },
     marks: { code },
-  } = renderEditor([new CodeExtension()]);
+  } = renderEditor<CodeExtension>([new CodeExtension()]);
 
   beforeEach(() => {
     ({

--- a/packages/remirror__extension-code/__tests__/code-extension.spec.ts
+++ b/packages/remirror__extension-code/__tests__/code-extension.spec.ts
@@ -51,7 +51,7 @@ describe('inputRules', () => {
       add,
       nodes: { p, doc },
       marks: { code },
-    } = renderEditor([new CodeExtension()]));
+    } = renderEditor<CodeExtension>([new CodeExtension()]));
   });
 
   it('should match input rule', () => {
@@ -80,7 +80,7 @@ describe('commands', () => {
     nodes: { p, doc },
     marks: { code },
     commands,
-  } = renderEditor([new CodeExtension()]);
+  } = renderEditor<CodeExtension>([new CodeExtension()]);
 
   beforeEach(() => {
     ({
@@ -89,7 +89,7 @@ describe('commands', () => {
       nodes: { p, doc },
       marks: { code },
       commands,
-    } = renderEditor([new CodeExtension()]));
+    } = renderEditor<CodeExtension>([new CodeExtension()]));
   });
 
   it('#toggleBold', () => {

--- a/packages/remirror__extension-codemirror6/__tests__/codemirror-extension.spec.ts
+++ b/packages/remirror__extension-codemirror6/__tests__/codemirror-extension.spec.ts
@@ -3,7 +3,7 @@ import { renderEditor } from 'jest-remirror';
 import { CodeMirrorExtension } from '../';
 
 function create() {
-  const renderEditorReturn = renderEditor([new CodeMirrorExtension()]);
+  const renderEditorReturn = renderEditor<CodeMirrorExtension>([new CodeMirrorExtension()]);
 
   const {
     add,

--- a/packages/remirror__extension-diff/__tests__/diff-extension.spec.ts
+++ b/packages/remirror__extension-diff/__tests__/diff-extension.spec.ts
@@ -14,7 +14,7 @@ function create(options?: DiffOptions, handlers: GetHandler<DiffOptions> = {}) {
     view,
     commands,
     helpers,
-  } = renderEditor([extension]);
+  } = renderEditor<DiffExtension>([extension]);
   const node = doc(p('This is not yet committed'));
 
   for (const [name, handler] of entries(handlers)) {

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -25,7 +25,11 @@ import { Node } from '@remirror/pm/model';
 import { EditorStateConfig, TextSelection } from '@remirror/pm/state';
 import { DecorationSet } from '@remirror/pm/view';
 
-import { EntityReferenceMetaData, EntityReferenceOptions } from './types';
+import {
+  EntityReferenceMetaData,
+  EntityReferenceOptions,
+  EntityReferencePluginState,
+} from './types';
 import { decorateEntityReferences } from './utils/decorate-entity-references';
 import { getDisjoinedEntityReferencesFromNode } from './utils/disjoined-entity-references';
 import { joinDisjoinedEntityReferences } from './utils/joined-entity-references';
@@ -44,7 +48,7 @@ interface EntityReferenceState {
 
 const getEntityReferencesFromPluginState = (props: StateProps): EntityReferenceMetaData[][] => {
   const { extension, state } = props;
-  const { entityReferences } = extension.getPluginState(state);
+  const { entityReferences } = extension.getPluginState<EntityReferencePluginState>(state);
   return entityReferences;
 };
 

--- a/packages/remirror__extension-hard-break/__tests__/hard-break-extension.spec.ts
+++ b/packages/remirror__extension-hard-break/__tests__/hard-break-extension.spec.ts
@@ -7,7 +7,7 @@ extensionValidityTest(HardBreakExtension);
 
 describe('schema', () => {
   it('should return the correct textContent', () => {
-    const { add, nodes, view } = renderEditor([new HardBreakExtension()]);
+    const { add, nodes, view } = renderEditor<HardBreakExtension>([new HardBreakExtension()]);
     const { doc, hardBreak: br, p } = nodes;
 
     const firstParagraph = p('First line', br(), 'Second line');
@@ -24,7 +24,9 @@ describe('schema', () => {
 
 describe('commands', () => {
   it('insertHardBreak', () => {
-    const { add, nodes, commands, view } = renderEditor([new HardBreakExtension()]);
+    const { add, nodes, commands, view } = renderEditor<HardBreakExtension>([
+      new HardBreakExtension(),
+    ]);
     const { doc, hardBreak: br, p } = nodes;
 
     add(doc(p('This is content<cursor>')));

--- a/packages/remirror__extension-history/__tests__/history-extension.spec.ts
+++ b/packages/remirror__extension-history/__tests__/history-extension.spec.ts
@@ -7,7 +7,7 @@ import { HistoryExtension } from '../';
 extensionValidityTest(HistoryExtension);
 
 describe('commands', () => {
-  const create = () => renderEditor([new HistoryExtension()]);
+  const create = () => renderEditor<HistoryExtension>([new HistoryExtension()]);
 
   it('can undo', () => {
     const {

--- a/packages/remirror__extension-horizontal-rule/__tests__/horizontal-rule-extension.spec.ts
+++ b/packages/remirror__extension-horizontal-rule/__tests__/horizontal-rule-extension.spec.ts
@@ -7,7 +7,9 @@ extensionValidityTest(HorizontalRuleExtension);
 
 describe('insertHorizontalRule', () => {
   it('can insert into the middle of content', () => {
-    const { add, nodes, commands, view } = renderEditor([new HorizontalRuleExtension()]);
+    const { add, nodes, commands, view } = renderEditor<HorizontalRuleExtension>([
+      new HorizontalRuleExtension(),
+    ]);
     const { doc, horizontalRule: hr, p } = nodes;
 
     add(doc(p('This <cursor>is content')));
@@ -18,7 +20,9 @@ describe('insertHorizontalRule', () => {
   });
 
   it('adds a trailing node when at the end of a block node', () => {
-    const { add, nodes, commands, view } = renderEditor([new HorizontalRuleExtension()]);
+    const { add, nodes, commands, view } = renderEditor<HorizontalRuleExtension>([
+      new HorizontalRuleExtension(),
+    ]);
     const { doc, horizontalRule: hr, p } = nodes;
 
     add(doc(p('This is content<cursor>')));
@@ -65,7 +69,7 @@ describe('insertHorizontalRule', () => {
   });
 
   it('does not split content when adding the hr', () => {
-    const editor = renderEditor([new HorizontalRuleExtension()]);
+    const editor = renderEditor<HorizontalRuleExtension>([new HorizontalRuleExtension()]);
     const { add, nodes, view } = editor;
     const { doc, horizontalRule: hr, p } = nodes;
 
@@ -84,7 +88,9 @@ describe('insertHorizontalRule', () => {
 
 describe('inputRules', () => {
   it('adds a trailing node by default', () => {
-    const { add, nodes, view, insertText } = renderEditor([new HorizontalRuleExtension()]);
+    const { add, nodes, view, insertText } = renderEditor<HorizontalRuleExtension>([
+      new HorizontalRuleExtension(),
+    ]);
     const { doc, horizontalRule: hr, p } = nodes;
 
     add(doc(p('This is content'), p('<cursor>'))).insertText('---');
@@ -128,7 +134,7 @@ describe('inputRules', () => {
   });
 
   it('can split content at the start of line', () => {
-    const editor = renderEditor([new HorizontalRuleExtension()]);
+    const editor = renderEditor<HorizontalRuleExtension>([new HorizontalRuleExtension()]);
     const { add, nodes, view } = editor;
     const { doc, horizontalRule: hr, p } = nodes;
 

--- a/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
+++ b/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
@@ -98,7 +98,7 @@ describe('inputRules', () => {
       add,
       nodes: { doc, p },
       marks: { bold, italic },
-    } = renderEditor([new BoldExtension(), new ItalicExtension()]);
+    } = renderEditor<BoldExtension | ItalicExtension>([new BoldExtension(), new ItalicExtension()]);
 
     add(doc(p('_**bold italic<cursor>')))
       .insertText('**')
@@ -122,7 +122,7 @@ describe('inputRules', () => {
       add,
       nodes: { doc, p },
       marks: { bold, italic },
-    } = renderEditor([new BoldExtension(), new ItalicExtension()]);
+    } = renderEditor<BoldExtension | ItalicExtension>([new BoldExtension(), new ItalicExtension()]);
 
     add(doc(p('**_italic bold<cursor>')))
       .insertText('_')

--- a/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
+++ b/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
@@ -11,7 +11,7 @@ describe('inputRules', () => {
       add,
       nodes: { doc, p },
       marks: { italic },
-    } = renderEditor([new ItalicExtension()]);
+    } = renderEditor<ItalicExtension>([new ItalicExtension()]);
 
     add(doc(p('<cursor>')))
       .insertText('Text _italic_')
@@ -29,7 +29,7 @@ describe('inputRules', () => {
       add,
       nodes: { doc, p },
       marks: { italic },
-    } = renderEditor([new ItalicExtension()]);
+    } = renderEditor<ItalicExtension>([new ItalicExtension()]);
 
     add(doc(p('<cursor>')))
       .insertText('Text *italic*')
@@ -46,7 +46,7 @@ describe('inputRules', () => {
     const {
       add,
       nodes: { doc, p },
-    } = renderEditor([new ItalicExtension()]);
+    } = renderEditor<ItalicExtension>([new ItalicExtension()]);
 
     add(doc(p('<cursor>')))
       .insertText('_    _')

--- a/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
+++ b/packages/remirror__extension-italic/__tests__/italic-extension.spec.ts
@@ -63,7 +63,7 @@ describe('inputRules', () => {
     const {
       add,
       nodes: { doc, p },
-    } = renderEditor([new ItalicExtension()]);
+    } = renderEditor<ItalicExtension>([new ItalicExtension()]);
 
     add(doc(p('<cursor>')))
       .insertText('Text *oops_')
@@ -80,7 +80,7 @@ describe('inputRules', () => {
     const {
       add,
       nodes: { doc, p },
-    } = renderEditor([new ItalicExtension()]);
+    } = renderEditor<ItalicExtension>([new ItalicExtension()]);
 
     add(doc(p('<cursor>')))
       .insertText('BBC_News')

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -1415,7 +1415,7 @@ describe('spanning', () => {
       attributeMarks: { link },
       nodes: { doc, p },
       view,
-    } = renderEditor([
+    } = renderEditor<LinkExtension | DecorationsExtension>([
       new LinkExtension(),
       new DecorationsExtension({ persistentSelectionClass: 'selection' }),
     ]);

--- a/packages/remirror__extension-search/__tests__/search-extension.spec.ts
+++ b/packages/remirror__extension-search/__tests__/search-extension.spec.ts
@@ -10,7 +10,7 @@ function create(options?: SearchOptions) {
     nodes: { p, doc },
     view,
     commands,
-  } = renderEditor([new SearchExtension(options)]);
+  } = renderEditor<SearchExtension>([new SearchExtension(options)]);
   const node = doc(p('welcome'), p('friend'), p('hello'), p('welcome friend'));
 
   return { add, p, doc, view, commands, node };

--- a/packages/remirror__extension-strike/__tests__/strike-extension.spec.ts
+++ b/packages/remirror__extension-strike/__tests__/strike-extension.spec.ts
@@ -9,7 +9,7 @@ describe('inputRules', () => {
     add,
     nodes: { p, doc },
     marks: { strike },
-  } = renderEditor([new StrikeExtension()]);
+  } = renderEditor<StrikeExtension>([new StrikeExtension()]);
 
   it('should match input rule', () => {
     add(doc(p('Start<cursor>')))
@@ -37,7 +37,7 @@ describe('commands', () => {
     nodes: { p, doc },
     marks: { strike },
     commands,
-  } = renderEditor([new StrikeExtension()]);
+  } = renderEditor<StrikeExtension>([new StrikeExtension()]);
 
   it('#toggleStrike', () => {
     add(doc(p('Hello <start>strike<end>, lets dance.')));

--- a/packages/remirror__extension-sub/__tests__/sub-extension.spec.ts
+++ b/packages/remirror__extension-sub/__tests__/sub-extension.spec.ts
@@ -11,7 +11,7 @@ describe('commands', () => {
     nodes: { p, doc },
     marks: { sub },
     commands,
-  } = renderEditor([new SubExtension()]);
+  } = renderEditor<SubExtension>([new SubExtension()]);
 
   it('#toggleSub', () => {
     add(doc(p('Hello <start>sub<end>, lets dance.')));

--- a/packages/remirror__extension-sup/__tests__/sup-extension.spec.ts
+++ b/packages/remirror__extension-sup/__tests__/sup-extension.spec.ts
@@ -11,7 +11,7 @@ describe('commands', () => {
     nodes: { p, doc },
     marks: { sup },
     commands,
-  } = renderEditor([new SupExtension()]);
+  } = renderEditor<SupExtension>([new SupExtension()]);
 
   it('#toggleSup', () => {
     add(doc(p('Hello <start>sup<end>, lets dance.')));

--- a/packages/remirror__extension-tables/__tests__/table-extensions.spec.ts
+++ b/packages/remirror__extension-tables/__tests__/table-extensions.spec.ts
@@ -45,7 +45,7 @@ describe('schema', () => {
 });
 
 function create() {
-  return renderEditor([new TableExtension()]);
+  return renderEditor<TableExtension>([new TableExtension()]);
 }
 
 describe('commands', () => {

--- a/packages/remirror__extension-trailing-node/__tests__/trailing-node-extension.spec.ts
+++ b/packages/remirror__extension-trailing-node/__tests__/trailing-node-extension.spec.ts
@@ -5,18 +5,21 @@ import {
   TrailingNodeExtension,
   TrailingNodeOptions,
 } from 'remirror/extensions';
+import { UnpackedExtension } from '@remirror/core';
 
 extensionValidityTest(TrailingNodeExtension);
 
 function create(params?: Partial<TrailingNodeOptions>) {
-  const {
-    add,
-    nodes: { doc, p, heading, blockquote },
-  } = renderEditor(() => [
+  const extensions = () => [
     new TrailingNodeExtension(params),
     new HeadingExtension(),
     new BlockquoteExtension(),
-  ]);
+  ];
+  type Extension = UnpackedExtension<typeof extensions>;
+  const {
+    add,
+    nodes: { doc, p, heading, blockquote },
+  } = renderEditor<Extension>(extensions);
 
   return { add, doc, p, h: heading, b: blockquote };
 }

--- a/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
+++ b/packages/remirror__extension-yjs/__tests__/yjs-extension.spec.ts
@@ -22,7 +22,7 @@ describe('configuration', () => {
   hideConsoleError(true);
 
   it('throws without a provider', () => {
-    expect(() => renderEditor([new YjsExtension()])).toThrowErrorMatchingSnapshot();
+    expect(() => renderEditor<YjsExtension>([new YjsExtension()])).toThrowErrorMatchingSnapshot();
   });
 
   it('calls the destroy provider', () => {

--- a/packages/remirror__react-core/__tests__/use-manager.spec.tsx
+++ b/packages/remirror__react-core/__tests__/use-manager.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act as renderAct, render } from 'testing/react';
-import type { AnyRemirrorManager } from '@remirror/core';
+import type { AnyExtension, AnyRemirrorManager } from '@remirror/core';
 import { ReactExtension } from '@remirror/preset-react';
 import { useManager } from '@remirror/react';
 
@@ -33,7 +33,7 @@ describe.skip('useManager', () => {
   it('rerenders when the manager is destroyed', () => {
     let manager: AnyRemirrorManager;
     const Component = (_: { options?: object }) => {
-      manager = useManager(() => [], {});
+      manager = useManager<AnyExtension>(() => [], {});
 
       return null;
     };

--- a/packages/remirror__react-core/src/hooks/use-manager.ts
+++ b/packages/remirror__react-core/src/hooks/use-manager.ts
@@ -42,7 +42,7 @@ export function useManager<Extension extends AnyExtension = Remirror.Extensions>
   const extensionsRef = useRef(extensions);
   const optionsRef = useRef(options);
 
-  const [manager, setManager] = useState(() => createReactManager(extensions, options));
+  const [manager, setManager] = useState(() => createReactManager<Extension>(extensions, options));
 
   // Keep the parameter refs up to date with the latest value.
   extensionsRef.current = extensions;
@@ -54,7 +54,7 @@ export function useManager<Extension extends AnyExtension = Remirror.Extensions>
     return manager.addHandler('destroy', () => {
       // `clone` is used to ensure that that any stale extensions are
       // reinitialized.
-      setManager(() => createReactManager(extensionsRef.current, optionsRef.current));
+      setManager(() => createReactManager<Extension>(extensionsRef.current, optionsRef.current));
     });
   }, [manager]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
       testing: ^0.0.4
       ts-documenter: ^0.0.4
       tsx: ^3.4.2
-      typescript: ~4.5.5
+      typescript: ~4.7.4
       typescript-styled-plugin: ^0.18.1
     dependencies:
       '@babel/core': 7.18.10
@@ -145,8 +145,8 @@ importers:
       '@linaria/cli': 3.0.0-beta.13_@babel+core@7.18.10
       '@linaria/shaker': 3.0.0-beta.13_@babel+core@7.18.10
       '@linaria/webpack-loader': 3.0.0-beta.13_@babel+core@7.18.10
-      '@lingui/cli': 3.14.0_7477c2f5e9bdd833fa6bda654762ba98
-      '@lingui/macro': 3.14.0_5312bcb717c91da3574854e49b1f7bd3
+      '@lingui/cli': 3.14.0_7b68932357e1e4c51e9c1c9c2fe423ef
+      '@lingui/macro': 3.14.0_17bfe753582e58aba52c6e030e85d25b
       '@lingui/react': 3.14.0
       '@manypkg/cli': 0.19.0
       '@microsoft/api-extractor': 7.29.2
@@ -165,8 +165,8 @@ importers:
       '@types/node': 16.11.36
       '@types/requestidlecallback': 0.3.4
       '@types/testing-library__jest-dom': 5.14.4
-      '@typescript-eslint/eslint-plugin': 5.2.0_61a6ad3162d57b7848b8706dfb95352d
-      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.5.5
+      '@typescript-eslint/eslint-plugin': 5.2.0_f3d21d2071abfa4c350b5f616d0e0529
+      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.7.4
       babel-jest: 28.1.1_@babel+core@7.18.10
       babel-plugin-dev-expression: 0.2.3_@babel+core@7.18.10
       babel-plugin-dynamic-import-node: 2.3.3
@@ -186,9 +186,9 @@ importers:
       eslint-config-prettier: 8.3.0_eslint@8.1.0
       eslint-formatter-github: 1.0.11_eslint@8.1.0
       eslint-plugin-eslint-comments: 3.2.0_eslint@8.1.0
-      eslint-plugin-graphql: 4.0.0_4e9b1df3bf7ed4eb3e79f082030c8779
+      eslint-plugin-graphql: 4.0.0_7d7f17cdfbd2d1d84774656bb08a5ab8
       eslint-plugin-import: 2.25.2_e2137ade58b543557c1b4cbce3ad1f4c
-      eslint-plugin-jest: 26.5.3_e94fc532e2f762ba0849ef19dd45feab
+      eslint-plugin-jest: 26.5.3_69de878211fc28b6270f11994d449e4d
       eslint-plugin-jest-formatting: 3.1.0_eslint@8.1.0
       eslint-plugin-jsx-a11y: 6.4.1_eslint@8.1.0
       eslint-plugin-lit: 1.6.1_eslint@8.1.0
@@ -228,7 +228,7 @@ importers:
       testing: link:packages/testing
       ts-documenter: 0.0.4
       tsx: 3.4.2
-      typescript: 4.5.5
+      typescript: 4.7.4
       typescript-styled-plugin: 0.18.1
 
   packages/a11y-status:
@@ -251,7 +251,7 @@ importers:
       '@babel/runtime': 7.18.9
     devDependencies:
       '@testing-library/react': 13.1.1_react@18.0.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   packages/jest-prosemirror:
@@ -348,7 +348,7 @@ importers:
       w3c-keyname: 2.2.4
     devDependencies:
       '@testing-library/react': 13.1.1_react@18.0.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   packages/prosemirror-paste-rules:
@@ -729,7 +729,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@testing-library/react': 13.1.1_react-dom@18.0.0+react@18.0.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1077,7 +1077,7 @@ importers:
       nanoevents: 5.1.13
     devDependencies:
       '@remirror/pm': link:../remirror__pm
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1382,7 +1382,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1407,7 +1407,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   packages/remirror__extension-react-tables:
@@ -1452,7 +1452,7 @@ importers:
       jsx-dom-cjs: 8.0.2
     devDependencies:
       '@remirror/pm': link:../remirror__pm
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1826,7 +1826,7 @@ importers:
       '@remirror/react-utils': link:../remirror__react-utils
     devDependencies:
       '@remirror/pm': link:../remirror__pm
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1914,7 +1914,7 @@ importers:
       '@remirror/react-renderer': link:../remirror__react-renderer
       '@remirror/react-utils': link:../remirror__react-utils
     devDependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -1977,7 +1977,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2027,7 +2027,7 @@ importers:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
       '@types/jsdom': 16.2.13
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       jsdom: 17.0.0
       react: 18.0.0
@@ -2067,7 +2067,7 @@ importers:
       svgmoji: 3.2.0
     devDependencies:
       '@emotion/css': 11.5.0_@babel+core@7.18.10
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2108,12 +2108,12 @@ importers:
       '@remirror/react-core': link:../remirror__react-core
       '@remirror/react-utils': link:../remirror__react-utils
       multishift: link:../multishift
-      use-isomorphic-layout-effect: 1.1.1_6117da77cd3b6b401e4daff8ae989aad
-      use-previous: 1.1.0_6117da77cd3b6b401e4daff8ae989aad
+      use-isomorphic-layout-effect: 1.1.1_e56feb5dc8ae3f4e939f6fbce05958a1
+      use-previous: 1.1.0_e56feb5dc8ae3f4e939f6fbce05958a1
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2129,7 +2129,7 @@ importers:
       '@babel/runtime': 7.18.9
       '@remirror/core': link:../remirror__core
     devDependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   packages/remirror__react-ssr:
@@ -2150,7 +2150,7 @@ importers:
     devDependencies:
       '@remirror/pm': link:../remirror__pm
       '@remirror/react': link:../remirror__react
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -2169,7 +2169,7 @@ importers:
       '@remirror/core-helpers': link:../remirror__core-helpers
       '@remirror/core-types': link:../remirror__core-types
     devDependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   packages/remirror__styles:
@@ -2188,9 +2188,9 @@ importers:
       '@remirror/core-helpers': link:../remirror__core-helpers
     devDependencies:
       '@emotion/css': 11.5.0_@babel+core@7.18.10
-      '@emotion/react': 11.9.0_be4640d19c7069687d6d07ca829736d3
-      '@emotion/styled': 11.3.0_8657d9292e83c4f9880e96f15f6a4a24
-      '@types/react': 18.0.15
+      '@emotion/react': 11.9.0_fbd95287980d1fb2c030c9181affdcd2
+      '@emotion/styled': 11.3.0_77b76b99df8cc336a41976ea85f4b992
+      '@types/react': 18.0.18
       '@types/styled-components': 5.1.15
       react: 18.0.0
       styled-components: 5.3.3_react@18.0.0
@@ -2315,7 +2315,7 @@ importers:
       '@svgmoji/blob': 3.2.0
       '@types/codemirror': 5.60.5
       '@types/html-escaper': 3.0.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       '@types/refractor': 3.0.2
       '@types/webpack': 5.28.0_@swc+core@1.2.204
@@ -2340,17 +2340,17 @@ importers:
       yjs: 13.5.23
     devDependencies:
       '@storybook/addon-actions': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/addon-controls': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
-      '@storybook/addon-essentials': 6.5.8_d660975ba8f27aecaa9cb5e82c389169
+      '@storybook/addon-controls': 6.5.8_c7751eb1207dba6b2a1702a059e68010
+      '@storybook/addon-essentials': 6.5.8_ed5a5e7d4242d91015bf483ced870cbe
       '@storybook/addon-links': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/builder-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
-      '@storybook/cli': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/builder-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
+      '@storybook/cli': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/components': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core': 6.5.8_a6587dc93bb595735579dd2974bacc73
-      '@storybook/manager-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
+      '@storybook/core': 6.5.8_a5cb76487ff4abb83b46b79c69116307
+      '@storybook/manager-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
       '@storybook/node-logger': 6.5.8
-      '@storybook/react': 6.5.8_79e948ef66167ad9a1038475fd459697
+      '@storybook/react': 6.5.8_d77bea406bd5388fb04fa3d6f7650ff9
       '@storybook/theming': 6.5.8_react-dom@18.0.0+react@18.0.0
       linkifyjs: 3.0.5
       postcss: 8.4.14
@@ -2411,7 +2411,7 @@ importers:
       '@remirror/preset-core': link:../remirror__preset-core
       '@remirror/react': link:../remirror__react
       '@testing-library/react': 13.1.1_react@18.0.0
-      '@testing-library/react-hooks': 8.0.0_c1fa3cb753776c72390d349e4b1cd54e
+      '@testing-library/react-hooks': 8.0.0_fdf971faa9dd6e236bebd0001004263e
       '@types/fluent-ffmpeg': 2.1.18
       '@types/min-document': 2.19.0
       '@types/react-test-renderer': 18.0.0
@@ -2435,7 +2435,7 @@ importers:
       signal-exit: 3.0.7
       test-keyboard: link:../test-keyboard
     devDependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   support:
@@ -2714,8 +2714,8 @@ importers:
     dependencies:
       '@babel/runtime': 7.18.9
       '@emotion/css': 11.5.0_@babel+core@7.18.10
-      '@emotion/react': 11.9.0_be4640d19c7069687d6d07ca829736d3
-      '@emotion/styled': 11.3.0_8657d9292e83c4f9880e96f15f6a4a24
+      '@emotion/react': 11.9.0_fbd95287980d1fb2c030c9181affdcd2
+      '@emotion/styled': 11.3.0_77b76b99df8cc336a41976ea85f4b992
       '@fontsource/fira-code': 4.5.1
       '@fontsource/rubik': 4.5.0
       '@mdx-js/react': 1.6.22_react@18.0.0
@@ -2739,19 +2739,19 @@ importers:
       remark-sectionize: 1.1.1
       remirror: link:../packages/remirror
     devDependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/module-type-aliases': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
-      '@docusaurus/plugin-client-redirects': 2.0.1_3c14b94a72fdb8007342869112f2f09d
-      '@docusaurus/plugin-content-docs': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-ideal-image': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-sitemap': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/preset-classic': 2.0.1_843e9cbf1340bc558bee0fe0c0c52e38
-      '@docusaurus/theme-classic': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/theme-common': 2.0.1_3c14b94a72fdb8007342869112f2f09d
-      '@docusaurus/theme-live-codeblock': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/plugin-client-redirects': 2.0.1_486b7aefecf912e64a008bb444a33a19
+      '@docusaurus/plugin-content-docs': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-ideal-image': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-sitemap': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/preset-classic': 2.0.1_81e1e26ae0413ad2a3ad6a73a87697d4
+      '@docusaurus/theme-classic': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/theme-common': 2.0.1_486b7aefecf912e64a008bb444a33a19
+      '@docusaurus/theme-live-codeblock': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@tsconfig/docusaurus': 1.0.6
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-dom': 18.0.2
       '@types/react-helmet': 6.1.5
       '@types/react-router-dom': 5.3.3
@@ -4838,7 +4838,7 @@ packages:
     resolution: {integrity: sha512-jnNrO2JVYYhj2pP2FomlHIy6220n6mrLn2t9v2/qc+rM7M/fbIcKMgk9ky4RN+L/maUEmteckzg6/PIYoAAXJg==}
     dev: true
 
-  /@docsearch/react/3.2.0_5c0ae146579744f001b6734b6de3341a:
+  /@docsearch/react/3.2.0_2d4440f14e2b52b91587807539e3c660:
     resolution: {integrity: sha512-ATS3w5JBgQGQF0kHn5iOAPfnCCaoLouZQMmI7oENV//QMFrYbjhUZxBU9lIwAT7Rzybud+Jtb4nG5IEjBk3Ixw==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -4848,7 +4848,7 @@ packages:
       '@algolia/autocomplete-core': 1.7.1
       '@algolia/autocomplete-preset-algolia': 1.7.1_algoliasearch@4.13.1
       '@docsearch/css': 3.2.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       algoliasearch: 4.13.1
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -4856,7 +4856,7 @@ packages:
       - '@algolia/client-search'
     dev: true
 
-  /@docusaurus/core/2.0.1_3c14b94a72fdb8007342869112f2f09d:
+  /@docusaurus/core/2.0.1_486b7aefecf912e64a008bb444a33a19:
     resolution: {integrity: sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -4915,7 +4915,7 @@ packages:
       postcss-loader: 7.0.0_postcss@8.4.14+webpack@5.73.0
       prompts: 2.4.2
       react: 18.0.0
-      react-dev-utils: 12.0.1_b6bd403259010b30b04432efc8443f76
+      react-dev-utils: 12.0.1_a614ce8116f7bc552e6fd02b3cef57c3
       react-dom: 18.0.0_react@18.0.0
       react-helmet-async: 1.3.0_react-dom@18.0.0+react@18.0.0
       react-loadable: /@docusaurus/react-loadable/5.5.2_react@18.0.0
@@ -5029,7 +5029,7 @@ packages:
       '@docusaurus/react-loadable': 5.5.2_react@18.0.0
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 18.0.0
@@ -5043,14 +5043,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-client-redirects/2.0.1_3c14b94a72fdb8007342869112f2f09d:
+  /@docusaurus/plugin-client-redirects/2.0.1_486b7aefecf912e64a008bb444a33a19:
     resolution: {integrity: sha512-A/giM3MIRRyUmxNzLb/jWvmRf0NtPYX4bV04njAnziAdPo4dqT4dZF2Hvy0uUSaF/SXPGLUjrZWWpzTl5mTJtQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/logger': 2.0.1
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
       '@docusaurus/utils-common': 2.0.1_@docusaurus+types@2.0.1
@@ -5078,14 +5078,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-blog/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-content-blog/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/logger': 2.0.1
       '@docusaurus/mdx-loader': 2.0.1_4c9aa46b2109b9a43950c3d3e6047bd7
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
@@ -5119,14 +5119,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-docs/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-content-docs/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/logger': 2.0.1
       '@docusaurus/mdx-loader': 2.0.1_4c9aa46b2109b9a43950c3d3e6047bd7
       '@docusaurus/module-type-aliases': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
@@ -5160,14 +5160,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-content-pages/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-content-pages/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/mdx-loader': 2.0.1_4c9aa46b2109b9a43950c3d3e6047bd7
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
@@ -5193,20 +5193,20 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-debug/2.0.1_843e9cbf1340bc558bee0fe0c0c52e38:
+  /@docusaurus/plugin-debug/2.0.1_81e1e26ae0413ad2a3ad6a73a87697d4:
     resolution: {integrity: sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
       fs-extra: 10.1.0
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
-      react-json-view: 1.21.3_5c0ae146579744f001b6734b6de3341a
+      react-json-view: 1.21.3_2d4440f14e2b52b91587807539e3c660
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -5226,14 +5226,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-analytics/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-google-analytics/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@docusaurus/utils-validation': 2.0.1_83bec54fbaead915ed05888f575e716e
       react: 18.0.0
@@ -5255,14 +5255,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-google-gtag/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-google-gtag/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@docusaurus/utils-validation': 2.0.1_83bec54fbaead915ed05888f575e716e
       react: 18.0.0
@@ -5284,7 +5284,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-ideal-image/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-ideal-image/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-SD8kf9VCa3qIYTU3Cdv4Yeqootb73Klzzejr6nWd5t01bNRKSw9b7jOOSh54eDxH47uYqD1Ycok8WkookmMexg==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -5295,7 +5295,7 @@ packages:
       jimp:
         optional: true
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/lqip-loader': 2.0.1_webpack@5.73.0
       '@docusaurus/responsive-loader': 1.7.0_sharp@0.30.7
       '@docusaurus/theme-translations': 2.0.1
@@ -5325,14 +5325,14 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/plugin-sitemap/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/plugin-sitemap/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/logger': 2.0.1
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
@@ -5359,24 +5359,24 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/preset-classic/2.0.1_843e9cbf1340bc558bee0fe0c0c52e38:
+  /@docusaurus/preset-classic/2.0.1_81e1e26ae0413ad2a3ad6a73a87697d4:
     resolution: {integrity: sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
-      '@docusaurus/plugin-content-blog': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-content-docs': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-content-pages': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-debug': 2.0.1_843e9cbf1340bc558bee0fe0c0c52e38
-      '@docusaurus/plugin-google-analytics': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-google-gtag': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-sitemap': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/theme-classic': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/theme-common': 2.0.1_3c14b94a72fdb8007342869112f2f09d
-      '@docusaurus/theme-search-algolia': 2.0.1_932a1f9ea421e97f4fae24b92767a497
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
+      '@docusaurus/plugin-content-blog': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-content-docs': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-content-pages': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-debug': 2.0.1_81e1e26ae0413ad2a3ad6a73a87697d4
+      '@docusaurus/plugin-google-analytics': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-google-gtag': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-sitemap': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/theme-classic': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/theme-common': 2.0.1_486b7aefecf912e64a008bb444a33a19
+      '@docusaurus/theme-search-algolia': 2.0.1_e675b94aec202286d9ccd9da44517966
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
@@ -5425,20 +5425,20 @@ packages:
       sharp: 0.30.7
     dev: true
 
-  /@docusaurus/theme-classic/2.0.1_2445bc361f6266ac155e99ff74e6126a:
+  /@docusaurus/theme-classic/2.0.1_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/mdx-loader': 2.0.1_4c9aa46b2109b9a43950c3d3e6047bd7
       '@docusaurus/module-type-aliases': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
-      '@docusaurus/plugin-content-blog': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-content-docs': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-content-pages': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/theme-common': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/plugin-content-blog': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-content-docs': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-content-pages': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/theme-common': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/theme-translations': 2.0.1
       '@docusaurus/types': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
@@ -5475,7 +5475,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-common/2.0.1_3c14b94a72fdb8007342869112f2f09d:
+  /@docusaurus/theme-common/2.0.1_486b7aefecf912e64a008bb444a33a19:
     resolution: {integrity: sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==}
     engines: {node: '>=16.14'}
     peerDependencies:
@@ -5484,12 +5484,12 @@ packages:
     dependencies:
       '@docusaurus/mdx-loader': 2.0.1_4c9aa46b2109b9a43950c3d3e6047bd7
       '@docusaurus/module-type-aliases': 2.0.1_caaf169d5cb91f3004a3f33c2dcdb4de
-      '@docusaurus/plugin-content-blog': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-content-docs': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/plugin-content-pages': 2.0.1_2445bc361f6266ac155e99ff74e6126a
+      '@docusaurus/plugin-content-blog': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-content-docs': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/plugin-content-pages': 2.0.1_41368181287923085aae1420dd4bdd93
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-router-config': 5.0.6
       clsx: 1.2.1
       parse-numeric-range: 1.3.0
@@ -5515,15 +5515,15 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-live-codeblock/2.0.1_3c14b94a72fdb8007342869112f2f09d:
+  /@docusaurus/theme-live-codeblock/2.0.1_486b7aefecf912e64a008bb444a33a19:
     resolution: {integrity: sha512-H+4Vn1KT6sTXi1mnB5yjBzV5+ubFE2E5P2S4nqg2xBGtkCubSGJ7BCQYY5+gPbvE8HsphjhWAS+H+rtDDgEikQ==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
-      '@docusaurus/theme-common': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
+      '@docusaurus/theme-common': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/theme-translations': 2.0.1
       '@docusaurus/utils-validation': 2.0.1_83bec54fbaead915ed05888f575e716e
       '@philpl/buble': 0.19.7
@@ -5550,18 +5550,18 @@ packages:
       - webpack-cli
     dev: true
 
-  /@docusaurus/theme-search-algolia/2.0.1_932a1f9ea421e97f4fae24b92767a497:
+  /@docusaurus/theme-search-algolia/2.0.1_e675b94aec202286d9ccd9da44517966:
     resolution: {integrity: sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==}
     engines: {node: '>=16.14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.2.0_5c0ae146579744f001b6734b6de3341a
-      '@docusaurus/core': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docsearch/react': 3.2.0_2d4440f14e2b52b91587807539e3c660
+      '@docusaurus/core': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/logger': 2.0.1
-      '@docusaurus/plugin-content-docs': 2.0.1_2445bc361f6266ac155e99ff74e6126a
-      '@docusaurus/theme-common': 2.0.1_3c14b94a72fdb8007342869112f2f09d
+      '@docusaurus/plugin-content-docs': 2.0.1_41368181287923085aae1420dd4bdd93
+      '@docusaurus/theme-common': 2.0.1_486b7aefecf912e64a008bb444a33a19
       '@docusaurus/theme-translations': 2.0.1
       '@docusaurus/utils': 2.0.1_83bec54fbaead915ed05888f575e716e
       '@docusaurus/utils-validation': 2.0.1_83bec54fbaead915ed05888f575e716e
@@ -5609,7 +5609,7 @@ packages:
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       commander: 5.1.0
       joi: 17.6.0
       react: 18.0.0
@@ -5768,7 +5768,7 @@ packages:
   /@emotion/memoize/0.7.5:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
 
-  /@emotion/react/11.9.0_be4640d19c7069687d6d07ca829736d3:
+  /@emotion/react/11.9.0_fbd95287980d1fb2c030c9181affdcd2:
     resolution: {integrity: sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5787,7 +5787,7 @@ packages:
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
       '@emotion/weak-memoize': 0.2.5
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       hoist-non-react-statics: 3.3.2
       react: 18.0.0
 
@@ -5803,7 +5803,7 @@ packages:
   /@emotion/sheet/1.1.0:
     resolution: {integrity: sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==}
 
-  /@emotion/styled/11.3.0_8657d9292e83c4f9880e96f15f6a4a24:
+  /@emotion/styled/11.3.0_77b76b99df8cc336a41976ea85f4b992:
     resolution: {integrity: sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5820,10 +5820,10 @@ packages:
       '@babel/runtime': 7.18.9
       '@emotion/babel-plugin': 11.9.2_@babel+core@7.18.10
       '@emotion/is-prop-valid': 1.1.0
-      '@emotion/react': 11.9.0_be4640d19c7069687d6d07ca829736d3
+      '@emotion/react': 11.9.0_fbd95287980d1fb2c030c9181affdcd2
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
   /@emotion/stylis/0.8.5:
@@ -5839,7 +5839,7 @@ packages:
   /@emotion/weak-memoize/0.2.5:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_ab32f33b18941edd23f94d710936753e:
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_6bedfee32e8641671595f2fc6b072c8f:
     resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -5848,13 +5848,13 @@ packages:
       cosmiconfig: 7.0.0
       lodash.get: 4.4.2
       make-error: 1.3.6
-      ts-node: 9.1.1_typescript@4.5.5
+      ts-node: 9.1.1_typescript@4.7.4
       tslib: 2.4.0
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_e1c3b685f8b7686dcc885a02fd14c5f0:
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_cb132979841079273b6378d6412c7bb8:
     resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -5863,7 +5863,7 @@ packages:
       cosmiconfig: 7.0.1
       lodash.get: 4.4.2
       make-error: 1.3.6
-      ts-node: 9.1.1_typescript@4.5.5
+      ts-node: 9.1.1_typescript@4.7.4
       tslib: 2.4.0
     transitivePeerDependencies:
       - typescript
@@ -6802,19 +6802,19 @@ packages:
       - supports-color
     dev: false
 
-  /@lingui/babel-plugin-extract-messages/3.14.0_typescript@4.5.5:
+  /@lingui/babel-plugin-extract-messages/3.14.0_typescript@4.7.4:
     resolution: {integrity: sha512-4lcDgVdjYiObuFdDwnAG3jJxS+d3YLq4i7qywlHgjIqteKUH01S3paJRXhZaPvLGl56HarSq0kt8Pymxw8lOrA==}
     engines: {node: '>=10.0.0'}
     dependencies:
       '@babel/generator': 7.18.12
       '@babel/runtime': 7.18.9
-      '@lingui/conf': 3.14.0_typescript@4.5.5
+      '@lingui/conf': 3.14.0_typescript@4.7.4
       mkdirp: 1.0.4
     transitivePeerDependencies:
       - typescript
     dev: false
 
-  /@lingui/cli/3.14.0_7477c2f5e9bdd833fa6bda654762ba98:
+  /@lingui/cli/3.14.0_7b68932357e1e4c51e9c1c9c2fe423ef:
     resolution: {integrity: sha512-QZURsIf7A97tf28b/ffpeL0DekA6tBmcwnj4FBui1SbQqJw1d4IPg2bUM5VRn3/25vhqpi9Uhx5m9x7Vv8QfCQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
@@ -6828,8 +6828,8 @@ packages:
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
       '@babel/runtime': 7.18.9
       '@babel/types': 7.18.10
-      '@lingui/babel-plugin-extract-messages': 3.14.0_typescript@4.5.5
-      '@lingui/conf': 3.14.0_typescript@4.5.5
+      '@lingui/babel-plugin-extract-messages': 3.14.0_typescript@4.7.4
+      '@lingui/conf': 3.14.0_typescript@4.7.4
       babel-plugin-macros: 3.1.0
       bcp-47: 1.0.8
       chalk: 4.1.2
@@ -6854,15 +6854,15 @@ packages:
       pofile: 1.1.1
       pseudolocale: 1.2.0
       ramda: 0.27.1
-      typescript: 4.5.5
+      typescript: 4.7.4
     dev: false
 
-  /@lingui/conf/3.14.0_typescript@4.5.5:
+  /@lingui/conf/3.14.0_typescript@4.7.4:
     resolution: {integrity: sha512-5GMAbIRad9FavqYsfZCRAwjcOLzE7tONDJe9lSYE5SSJbbG01RI5kR5P0B84DUhTI6cGXau+1dAcP9K+JbEx+g==}
     engines: {node: '>=10.0.0'}
     dependencies:
       '@babel/runtime': 7.18.9
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_e1c3b685f8b7686dcc885a02fd14c5f0
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_cb132979841079273b6378d6412c7bb8
       chalk: 4.1.2
       cosmiconfig: 7.0.1
       jest-validate: 26.6.2
@@ -6885,7 +6885,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /@lingui/macro/3.14.0_5312bcb717c91da3574854e49b1f7bd3:
+  /@lingui/macro/3.14.0_17bfe753582e58aba52c6e030e85d25b:
     resolution: {integrity: sha512-NxTRrhrZ/cUO9PX/4vWys90Ku58+ExxHuE30IuDnnDldWhWlOdycmjDt9tB+yIiUdFym/veSxBs+h114FzG5mA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -6894,7 +6894,7 @@ packages:
       babel-plugin-macros: "2 ||\_3"
     dependencies:
       '@babel/runtime': 7.18.9
-      '@lingui/conf': 3.14.0_typescript@4.5.5
+      '@lingui/conf': 3.14.0_typescript@4.7.4
       '@lingui/react': 3.14.0
       babel-plugin-macros: 3.1.0
       ramda: 0.27.1
@@ -7687,7 +7687,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.8_d0ef1faf74c0bfca284634bf69606dc0:
+  /@storybook/addon-controls/6.5.8_c7751eb1207dba6b2a1702a059e68010:
     resolution: {integrity: sha512-fB6p5DgVHUnJKUzOlT2mtvaSCincnO+vuYLyf++f+l4BlYK1Es9HNl/puaRoMgdW+LoGJjXPTIMcMByeHVIt6Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7702,7 +7702,7 @@ packages:
       '@storybook/api': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/client-logger': 6.5.8
       '@storybook/components': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/node-logger': 6.5.8
       '@storybook/store': 6.5.8_react-dom@18.0.0+react@18.0.0
@@ -7721,7 +7721,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs/6.5.8_aeb5663c8c25fc82425181fa70f49e55:
+  /@storybook/addon-docs/6.5.8_f5b371c3458855dbf6fc10cbd7717be6:
     resolution: {integrity: sha512-pAvWwh5YCrsW9nHCrd5BpFigvqn92JisX0aEnwAqKC9B1AW1LxhdPn1o9CQCeszQGaq163RA6AzkCejvAqhtUQ==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -7742,7 +7742,7 @@ packages:
       '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/api': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/components': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/core-events': 6.5.8
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.8_react-dom@18.0.0+react@18.0.0
@@ -7776,7 +7776,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.8_d660975ba8f27aecaa9cb5e82c389169:
+  /@storybook/addon-essentials/6.5.8_ed5a5e7d4242d91015bf483ced870cbe:
     resolution: {integrity: sha512-K/Aw/GLugCz5/S3c2tz5lnfC8aN6dSoQQDr8xaMDcBlT9h/xZ1l4jQQnx/mvY/qEvXtexBF41DE6ROWGKSZeSg==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -7836,16 +7836,16 @@ packages:
       '@babel/core': 7.18.10
       '@storybook/addon-actions': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/addon-backgrounds': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/addon-controls': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
-      '@storybook/addon-docs': 6.5.8_aeb5663c8c25fc82425181fa70f49e55
+      '@storybook/addon-controls': 6.5.8_c7751eb1207dba6b2a1702a059e68010
+      '@storybook/addon-docs': 6.5.8_f5b371c3458855dbf6fc10cbd7717be6
       '@storybook/addon-measure': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/addon-outline': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/addon-toolbars': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/addon-viewport': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/api': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/builder-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/builder-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/node-logger': 6.5.8
       core-js: 3.24.1
       react: 18.0.0
@@ -8033,7 +8033,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.8_d0ef1faf74c0bfca284634bf69606dc0:
+  /@storybook/builder-webpack4/6.5.8_c7751eb1207dba6b2a1702a059e68010:
     resolution: {integrity: sha512-4/CVp/AlOxCeWZ/DF1TVS/TuzHao4l9KCq7DhL+utFEVl9c/dpgoZXc0Gy2FfHa2RXHKckrH/VUfV2KQk4TNSw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8051,7 +8051,7 @@ packages:
       '@storybook/client-api': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/client-logger': 6.5.8
       '@storybook/components': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/core-events': 6.5.8
       '@storybook/node-logger': 6.5.8
       '@storybook/preview-web': 6.5.8_react-dom@18.0.0+react@18.0.0
@@ -8069,12 +8069,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_179b813bcdfbf064b625c3011939f25a
+      fork-ts-checker-webpack-plugin: 4.1.6_b8c957c7b71b0201a324d95456678680
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
+      pnp-webpack-plugin: 1.6.4_typescript@4.7.4
       postcss: 8.4.14
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_postcss@8.4.14+webpack@4.46.0
@@ -8085,7 +8085,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -8102,7 +8102,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/builder-webpack5/6.5.8_2445bc361f6266ac155e99ff74e6126a:
+  /@storybook/builder-webpack5/6.5.8_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-bc7LSGzOqTUImejsfjWAHEHwBreoPQKS6pfnWYkjKMvfvWOwlHSAxwOSM5DyS4cvpcpMDG8yBJNz2QcvXFVLxA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8120,7 +8120,7 @@ packages:
       '@storybook/client-api': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/client-logger': 6.5.8
       '@storybook/components': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/core-events': 6.5.8
       '@storybook/node-logger': 6.5.8
       '@storybook/preview-web': 6.5.8_react-dom@18.0.0+react@18.0.0
@@ -8135,7 +8135,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.24.1
       css-loader: 5.2.7_webpack@5.73.0
-      fork-ts-checker-webpack-plugin: 6.5.1_b6bd403259010b30b04432efc8443f76
+      fork-ts-checker-webpack-plugin: 6.5.1_a614ce8116f7bc552e6fd02b3cef57c3
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       html-webpack-plugin: 5.5.0_webpack@5.73.0
@@ -8147,7 +8147,7 @@ packages:
       style-loader: 2.0.0_webpack@5.73.0
       terser-webpack-plugin: 5.3.3_@swc+core@1.2.204+webpack@5.73.0
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.2.204
       webpack-dev-middleware: 4.3.0_webpack@5.73.0
@@ -8194,18 +8194,18 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/cli/6.5.8_d0ef1faf74c0bfca284634bf69606dc0:
+  /@storybook/cli/6.5.8_c7751eb1207dba6b2a1702a059e68010:
     resolution: {integrity: sha512-ZdqBIaAdYtQxeK52rx87NDYbWSDaMs8cGoxAeo0P+56cl8g3FLOAl+Q5DKziopKkUardtbTUQH9N/7y4g7onXg==}
     hasBin: true
     dependencies:
       '@babel/core': 7.18.10
       '@babel/preset-env': 7.18.10_@babel+core@7.18.10
       '@storybook/codemod': 6.5.8_@babel+preset-env@7.18.10
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/csf-tools': 6.5.8
       '@storybook/node-logger': 6.5.8
       '@storybook/semver': 7.3.2
-      '@storybook/telemetry': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/telemetry': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       boxen: 5.1.2
       chalk: 4.1.2
       commander: 6.2.1
@@ -8320,7 +8320,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/core-client/6.5.8_343854e08d3f42c1e66e41a07076658d:
+  /@storybook/core-client/6.5.8_2ee7c8cdec965727d50b416ab3f29949:
     resolution: {integrity: sha512-8x8qKQ2clvpfDcoWrNBmQ8Xt9z/i32TFIBp4PEZMcbB7eqo517nzfllLiXDipiJgO7BGxKtY5CRHQ9pAU9G27A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8351,13 +8351,49 @@ packages:
       react-dom: 18.0.0_react@18.0.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/core-client/6.5.8_97eea3f9076d23cfde5ac823ae9b1ae5:
+    resolution: {integrity: sha512-8x8qKQ2clvpfDcoWrNBmQ8Xt9z/i32TFIBp4PEZMcbB7eqo517nzfllLiXDipiJgO7BGxKtY5CRHQ9pAU9G27A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
+      '@storybook/channel-postmessage': 6.5.8
+      '@storybook/channel-websocket': 6.5.8
+      '@storybook/client-api': 6.5.8_react-dom@18.0.0+react@18.0.0
+      '@storybook/client-logger': 6.5.8
+      '@storybook/core-events': 6.5.8
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/preview-web': 6.5.8_react-dom@18.0.0+react@18.0.0
+      '@storybook/store': 6.5.8_react-dom@18.0.0+react@18.0.0
+      '@storybook/ui': 6.5.8_react-dom@18.0.0+react@18.0.0
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.24.1
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.10.1
+      react: 18.0.0
+      react-dom: 18.0.0_react@18.0.0
+      regenerator-runtime: 0.13.9
+      ts-dedent: 2.2.0
+      typescript: 4.7.4
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
     dev: true
 
-  /@storybook/core-client/6.5.8_541d850209db593b4f44af61fc97be7e:
+  /@storybook/core-client/6.5.8_f53aece59a18888a23ace8ab2107f404:
     resolution: {integrity: sha512-8x8qKQ2clvpfDcoWrNBmQ8Xt9z/i32TFIBp4PEZMcbB7eqo517nzfllLiXDipiJgO7BGxKtY5CRHQ9pAU9G27A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8388,49 +8424,13 @@ packages:
       react-dom: 18.0.0_react@18.0.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      typescript: 4.5.5
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-    dev: true
-
-  /@storybook/core-client/6.5.8_cf867233168297d4c6ba495c871bcfc5:
-    resolution: {integrity: sha512-8x8qKQ2clvpfDcoWrNBmQ8Xt9z/i32TFIBp4PEZMcbB7eqo517nzfllLiXDipiJgO7BGxKtY5CRHQ9pAU9G27A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/channel-postmessage': 6.5.8
-      '@storybook/channel-websocket': 6.5.8
-      '@storybook/client-api': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/client-logger': 6.5.8
-      '@storybook/core-events': 6.5.8
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/store': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/ui': 6.5.8_react-dom@18.0.0+react@18.0.0
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.24.1
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.10.1
-      react: 18.0.0
-      react-dom: 18.0.0_react@18.0.0
-      regenerator-runtime: 0.13.9
-      ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.2.204
     dev: true
 
-  /@storybook/core-common/6.5.8_d0ef1faf74c0bfca284634bf69606dc0:
+  /@storybook/core-common/6.5.8_c7751eb1207dba6b2a1702a059e68010:
     resolution: {integrity: sha512-ELGKLMx1d0oEA2LT+fsmo85X2RNE1EO+It7B1bw//g7jyf1hmZ7t3lXMZUCqt7eml1qy1N72LDkfmmU+H9H6ww==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8474,7 +8474,7 @@ packages:
       express: 4.17.3
       file-system-cache: 1.0.5
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.1_179b813bcdfbf064b625c3011939f25a
+      fork-ts-checker-webpack-plugin: 6.5.1_b8c957c7b71b0201a324d95456678680
       fs-extra: 9.1.0
       glob: 7.2.0
       handlebars: 4.7.7
@@ -8490,7 +8490,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -8507,7 +8507,7 @@ packages:
       core-js: 3.24.1
     dev: true
 
-  /@storybook/core-server/6.5.8_a6587dc93bb595735579dd2974bacc73:
+  /@storybook/core-server/6.5.8_a5cb76487ff4abb83b46b79c69116307:
     resolution: {integrity: sha512-ti7+MW1xzD9O0JLwgZTwulxhJx5YGPNu+hRpGhJSjKrqGX1h6K6ilmkBSHvyLqpiE+F4mxvqb5Rx3KBIEdEgbw==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -8524,19 +8524,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.5
-      '@storybook/builder-webpack4': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
-      '@storybook/builder-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
-      '@storybook/core-client': 6.5.8_343854e08d3f42c1e66e41a07076658d
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/builder-webpack4': 6.5.8_c7751eb1207dba6b2a1702a059e68010
+      '@storybook/builder-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
+      '@storybook/core-client': 6.5.8_97eea3f9076d23cfde5ac823ae9b1ae5
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/core-events': 6.5.8
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.8
-      '@storybook/manager-webpack4': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
-      '@storybook/manager-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
+      '@storybook/manager-webpack4': 6.5.8_c7751eb1207dba6b2a1702a059e68010
+      '@storybook/manager-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
       '@storybook/node-logger': 6.5.8
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/telemetry': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/telemetry': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@types/node': 16.11.36
       '@types/node-fetch': 2.5.12
       '@types/pretty-hrtime': 1.0.1
@@ -8567,7 +8567,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       util-deprecate: 1.0.2
       watchpack: 2.3.1
       webpack: 4.46.0
@@ -8586,7 +8586,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.8_a6587dc93bb595735579dd2974bacc73:
+  /@storybook/core/6.5.8_3e8bb2db1e187c5adbadc4a6ada90bbc:
     resolution: {integrity: sha512-+Fv4n1E5N4Avty9GcRbz4vB2IWH//se2OUU+RTT3vneCOGjyus5bj0Or6GU5wef5UGuvHF78mHg/frhWpguzsw==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -8603,13 +8603,14 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
-      '@storybook/core-client': 6.5.8_541d850209db593b4f44af61fc97be7e
-      '@storybook/core-server': 6.5.8_a6587dc93bb595735579dd2974bacc73
-      '@storybook/manager-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
+      '@storybook/builder-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
+      '@storybook/core-client': 6.5.8_f53aece59a18888a23ace8ab2107f404
+      '@storybook/core-server': 6.5.8_a5cb76487ff4abb83b46b79c69116307
+      '@storybook/manager-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
-      typescript: 4.5.5
+      typescript: 4.7.4
+      webpack: 5.73.0_@swc+core@1.2.204
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - bluebird
@@ -8623,7 +8624,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.8_ae5dfe475b3427afc63fe7d094a883e5:
+  /@storybook/core/6.5.8_a5cb76487ff4abb83b46b79c69116307:
     resolution: {integrity: sha512-+Fv4n1E5N4Avty9GcRbz4vB2IWH//se2OUU+RTT3vneCOGjyus5bj0Or6GU5wef5UGuvHF78mHg/frhWpguzsw==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -8640,14 +8641,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
-      '@storybook/core-client': 6.5.8_cf867233168297d4c6ba495c871bcfc5
-      '@storybook/core-server': 6.5.8_a6587dc93bb595735579dd2974bacc73
-      '@storybook/manager-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
+      '@storybook/builder-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
+      '@storybook/core-client': 6.5.8_2ee7c8cdec965727d50b416ab3f29949
+      '@storybook/core-server': 6.5.8_a5cb76487ff4abb83b46b79c69116307
+      '@storybook/manager-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
-      typescript: 4.5.5
-      webpack: 5.73.0_@swc+core@1.2.204
+      typescript: 4.7.4
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
       - bluebird
@@ -8709,7 +8709,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/manager-webpack4/6.5.8_d0ef1faf74c0bfca284634bf69606dc0:
+  /@storybook/manager-webpack4/6.5.8_c7751eb1207dba6b2a1702a059e68010:
     resolution: {integrity: sha512-qW5/L3cJHvtNi5ylDxObALZWaAHMsWQlPP8GRxm95NHpff4CfRo/qs7puY9ZeLmJSic0KchoHEH/8AScflLOgA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8723,8 +8723,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.10
       '@babel/preset-react': 7.18.6_@babel+core@7.18.10
       '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-client': 6.5.8_343854e08d3f42c1e66e41a07076658d
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-client': 6.5.8_97eea3f9076d23cfde5ac823ae9b1ae5
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/node-logger': 6.5.8
       '@storybook/theming': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/ui': 6.5.8_react-dom@18.0.0+react@18.0.0
@@ -8741,7 +8741,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.5.5
+      pnp-webpack-plugin: 1.6.4_typescript@4.7.4
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       read-pkg-up: 7.0.1
@@ -8751,7 +8751,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.46.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -8767,7 +8767,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack5/6.5.8_2445bc361f6266ac155e99ff74e6126a:
+  /@storybook/manager-webpack5/6.5.8_41368181287923085aae1420dd4bdd93:
     resolution: {integrity: sha512-foW/ZvTqGZAl4TfcfGKdS3RlaBDDAgEjUCbCaVShlZRshZ8tzWBVu3JQFqbPVGslH89T5qp9DUYoN/SJqTUpcg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8781,8 +8781,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.10
       '@babel/preset-react': 7.18.6_@babel+core@7.18.10
       '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/core-client': 6.5.8_cf867233168297d4c6ba495c871bcfc5
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-client': 6.5.8_f53aece59a18888a23ace8ab2107f404
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/node-logger': 6.5.8
       '@storybook/theming': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@storybook/ui': 6.5.8_react-dom@18.0.0+react@18.0.0
@@ -8807,7 +8807,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 5.3.3_@swc+core@1.2.204+webpack@5.73.0
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.2.204
       webpack-dev-middleware: 4.3.0_webpack@5.73.0
@@ -8885,7 +8885,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.5.5+webpack@5.73.0:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.7.4+webpack@5.73.0:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -8896,15 +8896,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.1.1_typescript@4.5.5
+      react-docgen-typescript: 2.1.1_typescript@4.7.4
       tslib: 2.4.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       webpack: 5.73.0_@swc+core@1.2.204
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react/6.5.8_79e948ef66167ad9a1038475fd459697:
+  /@storybook/react/6.5.8_d77bea406bd5388fb04fa3d6f7650ff9:
     resolution: {integrity: sha512-LdObfhhPb9gAFBtRNb3awYJe1qMiYeda1ppkj0ZvccbV04YrmbW5bzYvfOCvU6D34ugbQJhJyWuvraO/0EJK6w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -8937,15 +8937,15 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.18.10
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.5_507edfb7803659f143bd9745dd2fead5
       '@storybook/addons': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/builder-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
+      '@storybook/builder-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
       '@storybook/client-logger': 6.5.8
-      '@storybook/core': 6.5.8_ae5dfe475b3427afc63fe7d094a883e5
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core': 6.5.8_3e8bb2db1e187c5adbadc4a6ada90bbc
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.8_react-dom@18.0.0+react@18.0.0
-      '@storybook/manager-webpack5': 6.5.8_2445bc361f6266ac155e99ff74e6126a
+      '@storybook/manager-webpack5': 6.5.8_41368181287923085aae1420dd4bdd93
       '@storybook/node-logger': 6.5.8
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.5.5+webpack@5.73.0
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.7.4+webpack@5.73.0
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.8_react-dom@18.0.0+react@18.0.0
       '@types/estree': 0.0.51
@@ -8970,7 +8970,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      typescript: 4.5.5
+      typescript: 4.7.4
       util-deprecate: 1.0.2
       webpack: 5.73.0_@swc+core@1.2.204
     transitivePeerDependencies:
@@ -9062,11 +9062,11 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.8_d0ef1faf74c0bfca284634bf69606dc0:
+  /@storybook/telemetry/6.5.8_c7751eb1207dba6b2a1702a059e68010:
     resolution: {integrity: sha512-QnAhYF8CwcjC1bT2PK7Zqvo6E42TPl0MY6JS+H6qSZU/BmYeS0It8ZURNfPsA/OzVVLHUkQs96CisKh3N0WWaw==}
     dependencies:
       '@storybook/client-logger': 6.5.8
-      '@storybook/core-common': 6.5.8_d0ef1faf74c0bfca284634bf69606dc0
+      '@storybook/core-common': 6.5.8_c7751eb1207dba6b2a1702a059e68010
       chalk: 4.1.2
       core-js: 3.24.1
       detect-package-manager: 2.0.1
@@ -9517,7 +9517,7 @@ packages:
       react-error-boundary: 3.1.4
     dev: false
 
-  /@testing-library/react-hooks/8.0.0_c1fa3cb753776c72390d349e4b1cd54e:
+  /@testing-library/react-hooks/8.0.0_fdf971faa9dd6e236bebd0001004263e:
     resolution: {integrity: sha512-uZqcgtcUUtw7Z9N32W13qQhVAD+Xki2hxbTR461MKax8T6Jr8nsUvZB+vcBTkzY2nFvsUet434CsgF0ncW2yFw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -9534,7 +9534,7 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.18.9
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
       react-error-boundary: 3.1.4_react@18.0.0
       react-test-renderer: 18.0.0_react@18.0.0
@@ -9790,7 +9790,7 @@ packages:
   /@types/hoist-non-react-statics/3.3.1:
     resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       hoist-non-react-statics: 3.3.2
     dev: true
 
@@ -10015,26 +10015,26 @@ packages:
   /@types/react-color/3.0.6:
     resolution: {integrity: sha512-OzPIO5AyRmLA7PlOyISlgabpYUa3En74LP8mTMa0veCA719SvYQov4WLMsHvCgXP+L+KI9yGhYnqZafVGG0P4w==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/reactcss': 1.2.6
     dev: false
 
   /@types/react-dom/18.0.2:
     resolution: {integrity: sha512-UxeS+Wtj5bvLRREz9tIgsK4ntCuLDo0EcAcACgw3E+9wE8ePDr9uQpq53MfcyxyIS55xJ+0B6mDS8c4qkkHLBg==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
 
   /@types/react-helmet/6.1.5:
     resolution: {integrity: sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
     dev: true
 
   /@types/react-router-config/5.0.6:
     resolution: {integrity: sha512-db1mx37a1EJDf1XeX8jJN7R3PZABmJQXR8r28yUjVMFSjkmnQo6X6pOEEmNl+Tp2gYQOGPdYbFIipBtdElZ3Yg==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-router': 5.1.17
     dev: true
 
@@ -10042,7 +10042,7 @@ packages:
     resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       '@types/react-router': 5.1.17
     dev: true
 
@@ -10056,27 +10056,20 @@ packages:
   /@types/react-syntax-highlighter/11.0.5:
     resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
     dev: true
 
   /@types/react-syntax-highlighter/13.5.2:
     resolution: {integrity: sha512-sRZoKZBGKaE7CzMvTTgz+0x/aVR58ZYUTfB7HN76vC+yQnvo1FWtzNARBt0fGqcLGEVakEzMu/CtPzssmanu8Q==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
     dev: false
 
   /@types/react-test-renderer/18.0.0:
     resolution: {integrity: sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
     dev: false
-
-  /@types/react/18.0.15:
-    resolution: {integrity: sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==}
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.0
 
   /@types/react/18.0.18:
     resolution: {integrity: sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==}
@@ -10084,12 +10077,11 @@ packages:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.1.0
-    dev: true
 
   /@types/reactcss/1.2.6:
     resolution: {integrity: sha512-qaIzpCuXNWomGR1Xq8SCFTtF4v8V27Y6f+b9+bzHiv087MylI/nTCqqdChNeWS7tslgROmYB7yeiruWX7WnqNg==}
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
     dev: false
 
   /@types/refractor/3.0.2:
@@ -10191,7 +10183,7 @@ packages:
     resolution: {integrity: sha512-4evch8BRI3AKgb0GAZ/sn+mSeB+Dq7meYtMi7J/0Mg98Dt1+r8fySOek7Sjw1W+Wskyjc93565o5xWAT/FdY0Q==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       csstype: 3.1.0
     dev: true
 
@@ -10325,7 +10317,7 @@ packages:
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.2.0_61a6ad3162d57b7848b8706dfb95352d:
+  /@typescript-eslint/eslint-plugin/5.2.0_f3d21d2071abfa4c350b5f616d0e0529:
     resolution: {integrity: sha512-qQwg7sqYkBF4CIQSyRQyqsYvP+g/J0To9ZPVNJpfxfekl5RmdvQnFFTVVwpRtaUDFNvjfe/34TgY/dpc3MgNTw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10336,8 +10328,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.2.0_eslint@8.1.0+typescript@4.5.5
-      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.5.5
+      '@typescript-eslint/experimental-utils': 5.2.0_eslint@8.1.0+typescript@4.7.4
+      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.7.4
       '@typescript-eslint/scope-manager': 5.2.0
       debug: 4.3.4
       eslint: 8.1.0
@@ -10345,13 +10337,13 @@ packages:
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils/5.2.0_eslint@8.1.0+typescript@4.5.5:
+  /@typescript-eslint/experimental-utils/5.2.0_eslint@8.1.0+typescript@4.7.4:
     resolution: {integrity: sha512-fWyT3Agf7n7HuZZRpvUYdFYbPk3iDCq6fgu3ulia4c7yxmPnwVBovdSOX7RL+k8u6hLbrXcdAehlWUVpGh6IEw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10360,7 +10352,7 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.2.0
       '@typescript-eslint/types': 5.2.0
-      '@typescript-eslint/typescript-estree': 5.2.0_typescript@4.5.5
+      '@typescript-eslint/typescript-estree': 5.2.0_typescript@4.7.4
       eslint: 8.1.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.1.0
@@ -10369,7 +10361,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.2.0_eslint@8.1.0+typescript@4.5.5:
+  /@typescript-eslint/parser/5.2.0_eslint@8.1.0+typescript@4.7.4:
     resolution: {integrity: sha512-Uyy4TjJBlh3NuA8/4yIQptyJb95Qz5PX//6p8n7zG0QnN4o3NF9Je3JHbVU7fxf5ncSXTmnvMtd/LDQWDk0YqA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10381,10 +10373,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.2.0
       '@typescript-eslint/types': 5.2.0
-      '@typescript-eslint/typescript-estree': 5.2.0_typescript@4.5.5
+      '@typescript-eslint/typescript-estree': 5.2.0_typescript@4.7.4
       debug: 4.3.4
       eslint: 8.1.0
-      typescript: 4.5.5
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10415,7 +10407,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.2.0_typescript@4.5.5:
+  /@typescript-eslint/typescript-estree/5.2.0_typescript@4.7.4:
     resolution: {integrity: sha512-RsdXq2XmVgKbm9nLsE3mjNUM7BTr/K4DYR9WfFVMUuozHWtH5gMpiNZmtrMG8GR385EOSQ3kC9HiEMJWimxd/g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10430,13 +10422,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.28.0_typescript@4.5.5:
+  /@typescript-eslint/typescript-estree/5.28.0_typescript@4.7.4:
     resolution: {integrity: sha512-9GX+GfpV+F4hdTtYc6OV9ZkyYilGXPmQpm6AThInpBmKJEyRSIjORJd1G9+bknb7OTFYL+Vd4FBJAO6T78OVqA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10451,13 +10443,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.5.5
-      typescript: 4.5.5
+      tsutils: 3.21.0_typescript@4.7.4
+      typescript: 4.7.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.28.0_eslint@8.1.0+typescript@4.5.5:
+  /@typescript-eslint/utils/5.28.0_eslint@8.1.0+typescript@4.7.4:
     resolution: {integrity: sha512-E60N5L0fjv7iPJV3UGc4EC+A3Lcj4jle9zzR0gW7vXhflO7/J29kwiTGITA2RlrmPokKiZbBy2DgaclCaEUs6g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10466,7 +10458,7 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.28.0
       '@typescript-eslint/types': 5.28.0
-      '@typescript-eslint/typescript-estree': 5.28.0_typescript@4.5.5
+      '@typescript-eslint/typescript-estree': 5.28.0_typescript@4.7.4
       eslint: 8.1.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.1.0
@@ -12289,7 +12281,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -15339,7 +15331,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.5.5
+      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.7.4
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -15359,14 +15351,14 @@ packages:
       ignore: 5.2.0
     dev: false
 
-  /eslint-plugin-graphql/4.0.0_4e9b1df3bf7ed4eb3e79f082030c8779:
+  /eslint-plugin-graphql/4.0.0_7d7f17cdfbd2d1d84774656bb08a5ab8:
     resolution: {integrity: sha512-d5tQm24YkVvCEk29ZR5ScsgXqAGCjKlMS8lx3mS7FS/EKsWbkvXQImpvic03EpMIvNTBW5e+2xnHzXB/VHNZJw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       '@babel/runtime': 7.18.9
-      graphql-config: 3.4.1_4e9b1df3bf7ed4eb3e79f082030c8779
+      graphql-config: 3.4.1_7d7f17cdfbd2d1d84774656bb08a5ab8
       lodash.flatten: 4.4.0
       lodash.without: 4.4.0
     transitivePeerDependencies:
@@ -15387,7 +15379,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.5.5
+      '@typescript-eslint/parser': 5.2.0_eslint@8.1.0+typescript@4.7.4
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
@@ -15417,7 +15409,7 @@ packages:
       eslint: 8.1.0
     dev: false
 
-  /eslint-plugin-jest/26.5.3_e94fc532e2f762ba0849ef19dd45feab:
+  /eslint-plugin-jest/26.5.3_69de878211fc28b6270f11994d449e4d:
     resolution: {integrity: sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -15430,8 +15422,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.2.0_61a6ad3162d57b7848b8706dfb95352d
-      '@typescript-eslint/utils': 5.28.0_eslint@8.1.0+typescript@4.5.5
+      '@typescript-eslint/eslint-plugin': 5.2.0_f3d21d2071abfa4c350b5f616d0e0529
+      '@typescript-eslint/utils': 5.28.0_eslint@8.1.0+typescript@4.7.4
       eslint: 8.1.0
       jest: 28.1.1_@types+node@16.11.36
     transitivePeerDependencies:
@@ -16556,7 +16548,7 @@ packages:
     resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
     dev: false
 
-  /fork-ts-checker-webpack-plugin/4.1.6_179b813bcdfbf064b625c3011939f25a:
+  /fork-ts-checker-webpack-plugin/4.1.6_b8c957c7b71b0201a324d95456678680:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -16577,14 +16569,14 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.5.5
+      typescript: 4.7.4
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.1_179b813bcdfbf064b625c3011939f25a:
+  /fork-ts-checker-webpack-plugin/6.5.1_a614ce8116f7bc552e6fd02b3cef57c3:
     resolution: {integrity: sha512-x1wumpHOEf4gDROmKTaB6i4/Q6H3LwmjVO7fIX47vBwlZbtPjU33hgoMuD/Q/y6SU8bnuYSoN6ZQOLshGp0T/g==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -16612,11 +16604,11 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.5.5
-      webpack: 4.46.0
+      typescript: 4.7.4
+      webpack: 5.73.0_@swc+core@1.2.204
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.1_b6bd403259010b30b04432efc8443f76:
+  /fork-ts-checker-webpack-plugin/6.5.1_b8c957c7b71b0201a324d95456678680:
     resolution: {integrity: sha512-x1wumpHOEf4gDROmKTaB6i4/Q6H3LwmjVO7fIX47vBwlZbtPjU33hgoMuD/Q/y6SU8bnuYSoN6ZQOLshGp0T/g==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -16644,8 +16636,8 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.5.5
-      webpack: 5.73.0_@swc+core@1.2.204
+      typescript: 4.7.4
+      webpack: 4.46.0
     dev: true
 
   /form-data/2.3.3:
@@ -17297,13 +17289,13 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: false
 
-  /graphql-config/3.4.1_4e9b1df3bf7ed4eb3e79f082030c8779:
+  /graphql-config/3.4.1_7d7f17cdfbd2d1d84774656bb08a5ab8:
     resolution: {integrity: sha512-g9WyK4JZl1Ko++FSyE5Ir2g66njfxGzrDDhBOwnkoWf/t3TnnZG6BBkWP+pkqVJ5pqMJGPKHNrbew8jRxStjhw==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_ab32f33b18941edd23f94d710936753e
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_6bedfee32e8641671595f2fc6b072c8f
       '@graphql-tools/graphql-file-loader': 6.2.7
       '@graphql-tools/json-file-loader': 6.2.6
       '@graphql-tools/load': 6.2.8
@@ -22578,11 +22570,11 @@ packages:
     engines: {node: '>=12.13.0'}
     dev: false
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.5.5:
+  /pnp-webpack-plugin/1.6.4_typescript@4.7.4:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.5.5
+      ts-pnp: 1.2.0_typescript@4.7.4
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -23293,6 +23285,17 @@ packages:
       bluebird:
         optional: true
 
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
+    dev: true
+
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}
     engines: {node: '>=0.12'}
@@ -23806,7 +23809,7 @@ packages:
       tinycolor2: 1.4.2
     dev: false
 
-  /react-dev-utils/12.0.1_b6bd403259010b30b04432efc8443f76:
+  /react-dev-utils/12.0.1_a614ce8116f7bc552e6fd02b3cef57c3:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     dependencies:
@@ -23819,7 +23822,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.1_b6bd403259010b30b04432efc8443f76
+      fork-ts-checker-webpack-plugin: 6.5.1_a614ce8116f7bc552e6fd02b3cef57c3
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -23842,12 +23845,12 @@ packages:
       - webpack
     dev: true
 
-  /react-docgen-typescript/2.1.1_typescript@4.5.5:
+  /react-docgen-typescript/2.1.1_typescript@4.7.4:
     resolution: {integrity: sha512-XWe8bsYqVjxciKdpNoufaHiB7FgUHIOnVQgxUolRL3Zlof2zkdTzuQH6SU2n3Ek9kfy3O1c63ojMtNfpiuNeZQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.5.5
+      typescript: 4.7.4
     dev: true
 
   /react-docgen/5.4.0:
@@ -23960,7 +23963,7 @@ packages:
   /react-is/18.0.0:
     resolution: {integrity: sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==}
 
-  /react-json-view/1.21.3_5c0ae146579744f001b6734b6de3341a:
+  /react-json-view/1.21.3_2d4440f14e2b52b91587807539e3c660:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
     peerDependencies:
       react: ^17.0.0 || ^16.3.0 || ^15.5.4
@@ -23971,7 +23974,7 @@ packages:
       react-base16-styling: 0.6.0
       react-dom: 18.0.0_react@18.0.0
       react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 8.3.3_6117da77cd3b6b401e4daff8ae989aad
+      react-textarea-autosize: 8.3.3_e56feb5dc8ae3f4e939f6fbce05958a1
     transitivePeerDependencies:
       - '@types/react'
       - encoding
@@ -24115,7 +24118,7 @@ packages:
       scheduler: 0.21.0
     dev: false
 
-  /react-textarea-autosize/8.3.3_6117da77cd3b6b401e4daff8ae989aad:
+  /react-textarea-autosize/8.3.3_e56feb5dc8ae3f4e939f6fbce05958a1:
     resolution: {integrity: sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -24124,7 +24127,7 @@ packages:
       '@babel/runtime': 7.18.9
       react: 18.0.0
       use-composed-ref: 1.1.0_react@18.0.0
-      use-latest: 1.2.0_6117da77cd3b6b401e4daff8ae989aad
+      use-latest: 1.2.0_e56feb5dc8ae3f4e939f6fbce05958a1
     transitivePeerDependencies:
       - '@types/react'
     dev: true
@@ -26883,7 +26886,7 @@ packages:
       code-block-writer: 10.1.1
     dev: false
 
-  /ts-node/9.1.1_typescript@4.5.5:
+  /ts-node/9.1.1_typescript@4.7.4:
     resolution: {integrity: sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
@@ -26895,11 +26898,11 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.21
-      typescript: 4.5.5
+      typescript: 4.7.4
       yn: 3.1.1
     dev: false
 
-  /ts-pnp/1.2.0_typescript@4.5.5:
+  /ts-pnp/1.2.0_typescript@4.7.4:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -26908,7 +26911,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.5.5
+      typescript: 4.7.4
     dev: true
 
   /tsconfig-paths/3.11.0:
@@ -26955,14 +26958,14 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: false
 
-  /tsutils/3.21.0_typescript@4.5.5:
+  /tsutils/3.21.0_typescript@4.7.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.5.5
+      typescript: 4.7.4
     dev: false
 
   /tsx/3.4.2:
@@ -27115,16 +27118,10 @@ packages:
     resolution: {integrity: sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==}
     dev: false
 
-  /typescript/4.5.5:
-    resolution: {integrity: sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   /typescript/4.7.4:
     resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
-    dev: false
 
   /ua-parser-js/0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
@@ -27479,7 +27476,7 @@ packages:
       ts-essentials: 2.0.12
     dev: true
 
-  /use-isomorphic-layout-effect/1.1.1_6117da77cd3b6b401e4daff8ae989aad:
+  /use-isomorphic-layout-effect/1.1.1_e56feb5dc8ae3f4e939f6fbce05958a1:
     resolution: {integrity: sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==}
     peerDependencies:
       '@types/react': '*'
@@ -27488,10 +27485,10 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
 
-  /use-latest/1.2.0_6117da77cd3b6b401e4daff8ae989aad:
+  /use-latest/1.2.0_e56feb5dc8ae3f4e939f6fbce05958a1:
     resolution: {integrity: sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==}
     peerDependencies:
       '@types/react': '*'
@@ -27500,18 +27497,18 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.0.15
+      '@types/react': 18.0.18
       react: 18.0.0
-      use-isomorphic-layout-effect: 1.1.1_6117da77cd3b6b401e4daff8ae989aad
+      use-isomorphic-layout-effect: 1.1.1_e56feb5dc8ae3f4e939f6fbce05958a1
     dev: true
 
-  /use-previous/1.1.0_6117da77cd3b6b401e4daff8ae989aad:
+  /use-previous/1.1.0_e56feb5dc8ae3f4e939f6fbce05958a1:
     resolution: {integrity: sha512-t6ltKuYIpvcqD+VBnlUOaT+N94bN7HwUdB1u7rSpCIh9XvMJQIjsw/G8DoJlSDh029khFQ2L8q88oUWfKoWy5w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       react: 18.0.0
-      use-isomorphic-layout-effect: 1.1.1_6117da77cd3b6b401e4daff8ae989aad
+      use-isomorphic-layout-effect: 1.1.1_e56feb5dc8ae3f4e939f6fbce05958a1
     transitivePeerDependencies:
       - '@types/react'
     dev: false


### PR DESCRIPTION
 

### Description

1. Update TS from v4.5.5 to v4.7.4. This allows us to update [api-extractor](https://www.npmjs.com/package/@microsoft/api-extractor) which needs this version of TS. 
2. After updating TS to v4.7.4, `pnpm typecheck` keeps throwing `Type instantiation is excessively deep and possibly infinite.`. This may relate to <https://github.com/microsoft/TypeScript/issues/48552>. To fix this, I need to explicitly set some generic types, for example:
   ```diff
   - useManager(() => [], {});
   + useManager<AnyExtension>(() => [], {});

   - renderEditor([new BoldExtension()]);
   + renderEditor<BoldExtension>([new BoldExtension()]);
   ```
3. Some small changes for types. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
