### PR TITLE
chore: add a temporary script to fix the api-extractor error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,9 @@ jobs:
       - name: generate .d.ts files
         run: pnpm typecheck
 
+      - name: patch MUI package.json files
+        run: bash support/scripts/patch-mui-package-json.sh
+
       - name: generate api markdown files
         run: pnpm api
 

--- a/support/scripts/patch-mui-package-json.sh
+++ b/support/scripts/patch-mui-package-json.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Temporary workaround for https://github.com/microsoft/rushstack/issues/2070.
+#
+# The issue above has been fixed in the latest api-extractor v7.30.0. However,
+# another issue (https://github.com/microsoft/rushstack/issues/3620) prevents us
+# from upgrading to that version.
+
+set -e
+
+cd $(dirname $0)/../..
+
+pwd
+
+packageJsonFiles="$(find ./node_modules -type f -name package.json | grep 'mui' | sort | uniq)"
+
+for packageJsonFile in $packageJsonFiles; do
+  name=$(cat "$packageJsonFile" | jq '.name')
+  if [[ "$name" == "null" ]]; then
+    echo "N $packageJsonFile does not include name"
+    # Add the name field to the package.json
+    echo "$(jq '. += {"name": "name"}' $packageJsonFile)" > "$packageJsonFile"
+  else
+    echo "Y $packageJsonFile does include name: $name"
+  fi
+done


### PR DESCRIPTION
This is needed for https://github.com/remirror/remirror/pull/1787
