### PR TITLE
fix(extension-emoji): correct a bad import

### DIFF
--- a/.changeset/famous-penguins-kiss.md
+++ b/.changeset/famous-penguins-kiss.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-emoji': patch
+---
+
+Correct a bad import.

--- a/packages/remirror__extension-emoji/src/emoji-utils.ts
+++ b/packages/remirror__extension-emoji/src/emoji-utils.ts
@@ -8,7 +8,7 @@ import type {
   ProsemirrorAttributes,
   Static,
 } from '@remirror/core';
-import { Suggester } from '@remirror/pm/src/suggest';
+import { Suggester } from '@remirror/pm/suggest';
 
 export interface EmojiOptions extends Pick<Suggester, 'supportedCharacters'> {
   /**


### PR DESCRIPTION
### Description

The packages uploaded to NPM don't include `src` folder, so TypeScript will complain about it:

```
 error TS2345: Argument of type '{ plainText: true; data: FlatEmoji[]; }' is not assignable to parameter of type 'EmojiOptions'.
  Property 'supportedCharacters' is missing in type '{ plainText: true; data: FlatEmoji[]; }' but required in type 'EmojiOptions'.
error Command failed with exit code 1.
```
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
