### PR TITLE
fix(jest-prosemirror): clarify the TS return type for `pmBuild`

### DIFF
--- a/.changeset/hungry-eggs-beam.md
+++ b/.changeset/hungry-eggs-beam.md
@@ -1,0 +1,5 @@
+---
+'jest-prosemirror': patch
+---
+
+Clarify the TS return type for `pmBuild`.


### PR DESCRIPTION
### Description

This PR fixes the [following error](https://github.com/ocavue/rino/runs/8308770778?check_suite_focus=true): 

```

Error: node_modules/.pnpm/jest-prosemirror@2.0.0-beta.18_jsdom@20.0.0/node_modules/jest-prosemirror/dist-types/jest-prosemirror-nodes.d.ts(56,50): error TS2536: Type 'Name' cannot be used to index type '{ doc: { nodeType: string; }; p: { nodeType: string; }; text: { nodeType: string; }; } & Types'.
 ELIFECYCLE  Command failed with exit code 2.
Error: Process completed with exit code 1.

```
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
