### PR TITLE
feat(extension-event): add events for double and triple clicks

### DIFF
--- a/.changeset/shaggy-mugs-fly.md
+++ b/.changeset/shaggy-mugs-fly.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': minor
+---
+
+Adds four new events `doubleClick`, `doubleClickMark`, `tripleClick` and `tripleClickMark`. They have the same interface as the existing `click` and `clickMark` event, but are triggered when the user double or triple clicks.

--- a/packages/remirror__extension-events/__tests__/events-extension.spec.ts
+++ b/packages/remirror__extension-events/__tests__/events-extension.spec.ts
@@ -59,22 +59,31 @@ describe('events', () => {
     expect(mouseUpHandler).toHaveBeenCalled();
   });
 
-  it('responds to editor `click` events', () => {
-    const eventsExtension = new EventsExtension();
-    const clickHandler: any = jest.fn(() => true);
-    const editor = renderEditor([eventsExtension]);
-    const { view, add } = editor;
-    const { doc, p } = editor.nodes;
-    const node = p('first');
+  it.each([
+    ['click', 'handleClickOn'],
+    ['doubleClick', 'handleDoubleClickOn'],
+    ['tripleClick', 'handleTripleClickOn'],
+  ] as const)(
+    'responds to editor `%s` events',
+    (remirrorEventName, prosemirrorEventHandlerName) => {
+      const eventsExtension = new EventsExtension();
+      const clickHandler: any = jest.fn(() => true);
+      const editor = renderEditor([eventsExtension]);
+      const { view, add } = editor;
+      const { doc, p } = editor.nodes;
+      const node = p('first');
 
-    eventsExtension.addHandler('click', clickHandler);
-    add(doc(p('first')));
+      eventsExtension.addHandler(remirrorEventName, clickHandler);
+      add(doc(p('first')));
 
-    // JSDOM doesn't pass events through so the only way to simulate is to
-    // directly simulate the `handleClick` prop.
-    view.someProp('handleClickOn', (fn) => fn(view, 2, node, 1, {} as MouseEvent, true));
-    expect(clickHandler).toHaveBeenCalled();
-  });
+      // JSDOM doesn't pass events through so the only way to simulate is to
+      // directly simulate the `handleClick` prop.
+      view.someProp(prosemirrorEventHandlerName, (fn) =>
+        fn(view, 2, node, 1, {} as MouseEvent, true),
+      );
+      expect(clickHandler).toHaveBeenCalled();
+    },
+  );
 
   it('should not throw when clicked on before first state called', () => {
     const eventsExtension = new EventsExtension();


### PR DESCRIPTION
### Description

Add new events for double and triple clicks. They uses the [handleDoubleClickOn](https://prosemirror.net/docs/ref/#view.EditorProps.handleDoubleClickOn) and [handleTripleClickOn](https://prosemirror.net/docs/ref/#view.EditorProps.handleTripleClickOn) from ProseMirror under the hood. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
