### PR TITLE
fix(extension-file): reduce dependency footprint

### DIFF
--- a/.changeset/sharp-flowers-reflect.md
+++ b/.changeset/sharp-flowers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-file': patch
+---
+
+Reduces the dependency footprint from `@remirror/extension-file`.

--- a/packages/remirror__extension-file/__tests__/tsconfig.json
+++ b/packages/remirror__extension-file/__tests__/tsconfig.json
@@ -38,10 +38,10 @@
       "path": "../../remirror__core/src"
     },
     {
-      "path": "../../remirror__react/src"
+      "path": "../../remirror__extension-react-component/src"
     },
     {
-      "path": "../../remirror__react-components/src"
+      "path": "../../remirror__react-core/src"
     },
     {
       "path": "../../remirror__theme/src"

--- a/packages/remirror__extension-file/package.json
+++ b/packages/remirror__extension-file/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@remirror/core": "^2.0.0",
-    "@remirror/react": "^2.0.0",
-    "@remirror/react-components": "^2.0.0",
+    "@remirror/extension-react-component": "^2.0.0",
+    "@remirror/react-core": "^2.0.0",
     "@remirror/theme": "^2.0.0",
     "nanoevents": "^5.1.13"
   },

--- a/packages/remirror__extension-file/src/file-component.tsx
+++ b/packages/remirror__extension-file/src/file-component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { UploadContext } from '@remirror/core';
-import { NodeViewComponentProps, useCommands } from '@remirror/react';
+import { NodeViewComponentProps } from '@remirror/extension-react-component';
+import { useCommands } from '@remirror/react-core';
 import { ExtensionFileTheme } from '@remirror/theme';
 
 import type { FileAttributes } from './file-extension';

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -24,8 +24,8 @@ import {
   UploadFileHandler,
   UploadPlaceholderPayload,
 } from '@remirror/core';
+import { NodeViewComponentProps } from '@remirror/extension-react-component';
 import { PasteRule } from '@remirror/pm/paste-rules';
-import { NodeViewComponentProps } from '@remirror/react';
 
 import { FileComponent, FileComponentProps } from './file-component';
 import { createDataUrlFileUploader } from './file-uploaders';

--- a/packages/remirror__extension-file/src/tsconfig.json
+++ b/packages/remirror__extension-file/src/tsconfig.json
@@ -20,10 +20,10 @@
       "path": "../../remirror__core/src"
     },
     {
-      "path": "../../remirror__react/src"
+      "path": "../../remirror__extension-react-component/src"
     },
     {
-      "path": "../../remirror__react-components/src"
+      "path": "../../remirror__react-core/src"
     },
     {
       "path": "../../remirror__theme/src"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1059,9 +1059,9 @@ importers:
     specifiers:
       '@babel/runtime': ^7.13.10
       '@remirror/core': ^2.0.0
+      '@remirror/extension-react-component': ^2.0.0
       '@remirror/pm': ^2.0.0
-      '@remirror/react': ^2.0.0
-      '@remirror/react-components': ^2.0.0
+      '@remirror/react-core': ^2.0.0
       '@remirror/theme': ^2.0.0
       '@types/react': ^18.0.6
       '@types/react-dom': ^18.0.2
@@ -1071,8 +1071,8 @@ importers:
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core': link:../remirror__core
-      '@remirror/react': link:../remirror__react
-      '@remirror/react-components': link:../remirror__react-components
+      '@remirror/extension-react-component': link:../remirror__extension-react-component
+      '@remirror/react-core': link:../remirror__react-core
       '@remirror/theme': link:../remirror__theme
       nanoevents: 5.1.13
     devDependencies:
@@ -12437,7 +12437,7 @@ packages:
       mississippi: 2.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 5.3.0
       unique-filename: 1.1.1
@@ -12457,7 +12457,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12501,7 +12501,7 @@ packages:
       mississippi: 1.3.1
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 4.1.6
       unique-filename: 1.1.1
@@ -22248,7 +22248,7 @@ packages:
       npm-package-arg: 5.1.2
       npm-pick-manifest: 1.0.4
       osenv: 0.1.5
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       promise-retry: 1.1.1
       protoduck: 4.0.0
       safe-buffer: 5.2.1
@@ -23461,6 +23461,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -325,8 +325,8 @@
       "react",
       "react-dom",
       "@remirror/core",
-      "@remirror/react",
-      "@remirror/react-components",
+      "@remirror/extension-react-component",
+      "@remirror/react-core",
       "@remirror/theme"
     ],
     "running": false,

--- a/website/extension-examples/extension-link/linkify-js.tsx
+++ b/website/extension-examples/extension-link/linkify-js.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-link/linkify.tsx';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-link/linkify-js.tsx';
 
 import { StoryExample } from '../../src/components/story-example-component';
 
@@ -17,7 +17,7 @@ const ExampleComponent = (): JSX.Element => {
   const story = (
     <BrowserOnly>
       {() => {
-        const ComponentStory = require('../../../packages/storybook-react/stories/extension-link/linkify').default
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-link/linkify-js').default
         return <ComponentStory/>
       }}
     </BrowserOnly>


### PR DESCRIPTION
### Description

Reduce dependency footprint by importing more underlaying packages. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Before this PR, `@remirror/extension-file@1.0.0` has 210 dependencies (including MUI)
![_remirror_extension_file_dependencies](https://user-images.githubusercontent.com/24715727/190632263-b793cafc-397c-4185-99c7-c5bcb1bbb77d.svg)


After this PR `@remirror/extension-file@0.0.0-pr1862.1` only has 60 dependencies

![_remirror_extension_file_0_0_0_pr1862_1_dependencies](https://user-images.githubusercontent.com/24715727/190632276-0638108f-7fc1-48be-805e-d44080f28d98.svg)


(image generated by https://npmgraph.js.org/?q=%40remirror%2Fextension-file%400.0.0-pr1862.1)

<!-- Delete this section if not applicable -->
