### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/.changeset/spicy-chefs-do.md
+++ b/.changeset/spicy-chefs-do.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Update dependencies.

--- a/packages/prosemirror-paste-rules/package.json
+++ b/packages/prosemirror-paste-rules/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.0"
+    "prosemirror-view": "^1.28.1"
   },
   "peerDependencies": {
     "prosemirror-model": "^1",

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -39,7 +39,7 @@
     "@remirror/core-helpers": "^2.0.0",
     "@remirror/core-utils": "^2.0.3",
     "prosemirror-model": "^1.18.1",
-    "prosemirror-view": "^1.28.0"
+    "prosemirror-view": "^1.28.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prosemirror-suggest/package.json
+++ b/packages/prosemirror-suggest/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.0"
+    "prosemirror-view": "^1.28.1"
   },
   "peerDependencies": {
     "prosemirror-model": "^1",

--- a/packages/prosemirror-trailing-node/package.json
+++ b/packages/prosemirror-trailing-node/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "prosemirror-model": "^1.18.1",
     "prosemirror-state": "^1.4.1",
-    "prosemirror-view": "^1.28.0"
+    "prosemirror-view": "^1.28.1"
   },
   "peerDependencies": {
     "prosemirror-model": "^1",

--- a/packages/remirror__core-utils/package.json
+++ b/packages/remirror__core-utils/package.json
@@ -37,7 +37,7 @@
     "@remirror/messages": "^2.0.1",
     "@types/min-document": "^2.19.0",
     "css-in-js-utils": "^3.1.0",
-    "get-dom-document": "^0.1.0",
+    "get-dom-document": "^0.1.1",
     "min-document": "^2.19.0",
     "parenthesis": "^3.1.8"
   },

--- a/packages/remirror__pm/package.json
+++ b/packages/remirror__pm/package.json
@@ -144,7 +144,7 @@
     "prosemirror-tables": "^1.2.5",
     "prosemirror-trailing-node": "^2.0.0",
     "prosemirror-transform": "^1.7.0",
-    "prosemirror-view": "^1.28.0"
+    "prosemirror-view": "^1.28.1"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,7 +359,7 @@ importers:
       escape-string-regexp: ^4.0.0
       prosemirror-model: ^1.18.1
       prosemirror-state: ^1.4.1
-      prosemirror-view: ^1.28.0
+      prosemirror-view: ^1.28.1
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core-constants': link:../remirror__core-constants
@@ -368,7 +368,7 @@ importers:
     devDependencies:
       prosemirror-model: 1.18.1
       prosemirror-state: 1.4.1
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
 
   packages/prosemirror-resizable-view:
     specifiers:
@@ -376,13 +376,13 @@ importers:
       '@remirror/core-helpers': ^2.0.0
       '@remirror/core-utils': ^2.0.3
       prosemirror-model: ^1.18.1
-      prosemirror-view: ^1.28.0
+      prosemirror-view: ^1.28.1
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core-helpers': link:../remirror__core-helpers
       '@remirror/core-utils': link:../remirror__core-utils
       prosemirror-model: 1.18.1
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
 
   packages/prosemirror-suggest:
     specifiers:
@@ -393,7 +393,7 @@ importers:
       escape-string-regexp: ^4.0.0
       prosemirror-model: ^1.18.1
       prosemirror-state: ^1.4.1
-      prosemirror-view: ^1.28.0
+      prosemirror-view: ^1.28.1
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core-constants': link:../remirror__core-constants
@@ -403,7 +403,7 @@ importers:
     devDependencies:
       prosemirror-model: 1.18.1
       prosemirror-state: 1.4.1
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
 
   packages/prosemirror-trailing-node:
     specifiers:
@@ -413,7 +413,7 @@ importers:
       escape-string-regexp: ^4.0.0
       prosemirror-model: ^1.18.1
       prosemirror-state: ^1.4.1
-      prosemirror-view: ^1.28.0
+      prosemirror-view: ^1.28.1
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core-constants': link:../remirror__core-constants
@@ -422,7 +422,7 @@ importers:
     devDependencies:
       prosemirror-model: 1.18.1
       prosemirror-state: 1.4.1
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
 
   packages/remirror:
     specifiers:
@@ -692,7 +692,7 @@ importers:
       '@types/min-document': ^2.19.0
       '@types/node': ^16.3.3
       css-in-js-utils: ^3.1.0
-      get-dom-document: ^0.1.0
+      get-dom-document: ^0.1.1
       jsdom: ^17.0.0
       min-document: ^2.19.0
       parenthesis: ^3.1.8
@@ -704,7 +704,7 @@ importers:
       '@remirror/messages': link:../remirror__messages
       '@types/min-document': 2.19.0
       css-in-js-utils: 3.1.0
-      get-dom-document: 0.1.0_jsdom@17.0.0
+      get-dom-document: 0.1.1_jsdom@17.0.0
       min-document: 2.19.0
       parenthesis: 3.1.8
     devDependencies:
@@ -1722,7 +1722,7 @@ importers:
       prosemirror-tables: ^1.2.5
       prosemirror-trailing-node: ^2.0.0
       prosemirror-transform: ^1.7.0
-      prosemirror-view: ^1.28.0
+      prosemirror-view: ^1.28.1
     dependencies:
       '@babel/runtime': 7.18.9
       '@remirror/core-constants': link:../remirror__core-constants
@@ -1742,7 +1742,7 @@ importers:
       prosemirror-tables: 1.2.5
       prosemirror-trailing-node: link:../prosemirror-trailing-node
       prosemirror-transform: 1.7.0
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
 
   packages/remirror__preset-core:
     specifiers:
@@ -12437,7 +12437,7 @@ packages:
       mississippi: 2.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 5.3.0
       unique-filename: 1.1.1
@@ -12457,7 +12457,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12501,7 +12501,7 @@ packages:
       mississippi: 1.3.1
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 4.1.6
       unique-filename: 1.1.1
@@ -17071,8 +17071,8 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  /get-dom-document/0.1.0_jsdom@17.0.0:
-    resolution: {integrity: sha512-QaZVTlEk9mlEmg9GYxM4P2q/Df8OFYcQl2w7rHgvt2PaDoJYeQPYnA2c7TaIq7APJBukCba3By5NjeY3drTijQ==}
+  /get-dom-document/0.1.1_jsdom@17.0.0:
+    resolution: {integrity: sha512-UW/5ylJ7Tmr+26aYKAkftK4G0wbtY/YyOjrKPzWDkLifVS/Kpsgkmxzf2yRfJDMyUofEmccU8CxmSCsV3AKT4A==}
     peerDependencies:
       jsdom: '*'
     peerDependenciesMeta:
@@ -22255,7 +22255,7 @@ packages:
       npm-package-arg: 5.1.2
       npm-pick-manifest: 1.0.4
       osenv: 0.1.5
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       promise-retry: 1.1.1
       protoduck: 4.0.0
       safe-buffer: 5.2.1
@@ -23468,6 +23468,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}
@@ -23563,7 +23574,7 @@ packages:
     dependencies:
       prosemirror-state: 1.4.1
       prosemirror-transform: 1.7.0
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
     dev: false
 
   /prosemirror-gapcursor/1.3.1:
@@ -23572,7 +23583,7 @@ packages:
       prosemirror-keymap: 1.2.0
       prosemirror-model: 1.18.1
       prosemirror-state: 1.4.1
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
     dev: false
 
   /prosemirror-history/1.3.0:
@@ -23629,7 +23640,7 @@ packages:
       prosemirror-model: 1.18.1
       prosemirror-state: 1.4.1
       prosemirror-transform: 1.7.0
-      prosemirror-view: 1.28.0
+      prosemirror-view: 1.28.1
     dev: false
 
   /prosemirror-test-builder/1.1.0:
@@ -23645,8 +23656,8 @@ packages:
     dependencies:
       prosemirror-model: 1.18.1
 
-  /prosemirror-view/1.28.0:
-    resolution: {integrity: sha512-cmFK9osE7WAQptye6o/I5LjURZkSF4z3H7+LZmQtpJDZ9x4X/Z9v85oOeDvfRiX/J2rsaRYbEkWWbu3l9eBsdQ==}
+  /prosemirror-view/1.28.1:
+    resolution: {integrity: sha512-6maWMxFG1LAJj4xgRnbfucfM87qahehHmTWn+lionRCX2TixVhlJswOFDJoV0ClgaadhhjMJDaH3rErUQWbYfg==}
     dependencies:
       prosemirror-model: 1.18.1
       prosemirror-state: 1.4.1


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR fixes a bug that causes `getDocument` not able to create a DOM document using JSDOM. See this commit https://github.com/ocavue/get-dom-document/commit/811ba92ee25fb4ccd9d862cfddf13607913cdde5, which has been released as get-dom-document@0.1.1

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
