### PR TITLE
fix: patch default import for turndown

### DIFF
--- a/.changeset/popular-squids-draw.md
+++ b/.changeset/popular-squids-draw.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-markdown': patch
+---
+
+Fix the default import for `turndown`.

--- a/packages/remirror__extension-markdown/src/html-to-markdown.ts
+++ b/packages/remirror__extension-markdown/src/html-to-markdown.ts
@@ -4,8 +4,10 @@
  * Use `turndown` to provide a github flavoured markdown converter and the
  * default common mark converter.
  */
-import TurndownService from 'turndown';
-import { ErrorConstant, invariant, isElementDomNode } from '@remirror/core';
+import _TurndownService from 'turndown';
+import { defaultImport, ErrorConstant, invariant, isElementDomNode } from '@remirror/core';
+
+const TurndownService = defaultImport(_TurndownService);
 
 /**
  * Converts the provide HTML to markdown.


### PR DESCRIPTION
### Description

This fixes the `import_turndown.default is not a constructor` error in some set-ups.

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
