### PR TITLE
fix(extension-emoji): remove the ESM import from CJS build

### DIFF
--- a/.changeset/old-mugs-collect.md
+++ b/.changeset/old-mugs-collect.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-emoji': patch
+---
+
+Fixes the CJS build of `@remirror/extension-emoji`.

--- a/packages/remirror__cli/src/utils/run-esbuild.ts
+++ b/packages/remirror__cli/src/utils/run-esbuild.ts
@@ -13,7 +13,7 @@ import { removeFileExt } from './remove-file-ext';
 // https://github.com/streamich/react-use/issues/2353
 //
 // We currently use https://github.com/ocavue/svgmoji-cjs as a workaround for https://github.com/svgmoji/svgmoji/issues/24
-const dependenciesToBundle = /(emojibase|react-use)/;
+const dependenciesToBundle = /(react-use)/;
 
 export async function runEsbuild(
   pkg: Package,

--- a/packages/remirror__cli/src/utils/run-esbuild.ts
+++ b/packages/remirror__cli/src/utils/run-esbuild.ts
@@ -10,9 +10,10 @@ import { removeFileExt } from './remove-file-ext';
 // with ESM import syntax.
 // As a workaround, we need to bundle the code from them into our own packages,
 // They can be removed from this list once their maintainers fix these issues:
-// https://github.com/svgmoji/svgmoji/issues/24
 // https://github.com/streamich/react-use/issues/2353
-const dependenciesToBundle = /(emojibase|svgmoji|react-use)/;
+//
+// We currently use https://github.com/ocavue/svgmoji-cjs as a workaround for https://github.com/svgmoji/svgmoji/issues/24
+const dependenciesToBundle = /(emojibase|react-use)/;
 
 export async function runEsbuild(
   pkg: Package,

--- a/packages/remirror__extension-emoji/package.json
+++ b/packages/remirror__extension-emoji/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
+    "@ocavue/svgmoji-cjs": "^0.1.0",
     "@remirror/core": "^2.0.4",
     "@remirror/messages": "^2.0.1",
     "@remirror/theme": "^2.0.0",

--- a/packages/remirror__extension-emoji/src/emoji-utils.ts
+++ b/packages/remirror__extension-emoji/src/emoji-utils.ts
@@ -1,5 +1,5 @@
+import svgmoji from '@ocavue/svgmoji-cjs';
 import type { FlatEmoji, Moji } from 'svgmoji';
-import { Blobmoji, Notomoji, Openmoji, Twemoji } from 'svgmoji';
 import type {
   AcceptUndefined,
   FromToProps,
@@ -9,6 +9,8 @@ import type {
   Static,
 } from '@remirror/core';
 import { Suggester } from '@remirror/pm/suggest';
+
+const { Blobmoji, Notomoji, Openmoji, Twemoji } = svgmoji;
 
 export interface EmojiOptions extends Pick<Suggester, 'supportedCharacters'> {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,6 +994,7 @@ importers:
   packages/remirror__extension-emoji:
     specifiers:
       '@babel/runtime': ^7.13.10
+      '@ocavue/svgmoji-cjs': ^0.1.0
       '@remirror/core': ^2.0.4
       '@remirror/messages': ^2.0.1
       '@remirror/pm': ^2.0.0
@@ -1005,6 +1006,7 @@ importers:
       svgmoji: ^3.2.0
     dependencies:
       '@babel/runtime': 7.18.9
+      '@ocavue/svgmoji-cjs': 0.1.0
       '@remirror/core': link:../remirror__core
       '@remirror/messages': link:../remirror__messages
       '@remirror/theme': link:../remirror__theme
@@ -7251,6 +7253,12 @@ packages:
       rimraf: 3.0.2
     dev: true
 
+  /@ocavue/svgmoji-cjs/0.1.0:
+    resolution: {integrity: sha512-FYCRf7/d80Jd7y3KflOM5gxszqvAxm35AAJ9FWF+D1b6th9VvZI4CVpAGqlVjZme2NhzzJbBLgkxcfeBBzKvVA==}
+    dependencies:
+      svgmoji: 3.2.0
+    dev: false
+
   /@octokit/app/4.3.0:
     resolution: {integrity: sha512-TAi6Ju1u1rf7+V1vd2pg70SFwmHmwt5WAaAJ8BPaIHALxKbLpyyKUaVP1DBBmNmgF+fw0dwBR/edrClDMpdDfQ==}
     deprecated: '''@octokit/app'' will be repurposed in future. Use ''@octokit/auth-app'' instead'
@@ -12465,7 +12473,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -23477,17 +23485,6 @@ packages:
       bluebird:
         optional: true
 
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
-    dev: true
-
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}
     engines: {node: '>=0.12'}
@@ -24850,7 +24847,7 @@ packages:
     dev: false
 
   /remove-accents/0.4.2:
-    resolution: {integrity: sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=}
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
 
   /remove-trailing-separator/1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}

--- a/support/root/.size-limit.json
+++ b/support/root/.size-limit.json
@@ -114,7 +114,6 @@
     "ignore": [
       "@remirror/pm",
       "@types/node",
-      "jsdom",
       "@remirror/core-constants",
       "@remirror/core-helpers",
       "@remirror/core-types",


### PR DESCRIPTION
### Description

Add a new package `@ocauve/svgmoji-cjs`, which simply use CJS to require `svgmoji` and then re-export them. This makes sure that we are using the CJS version of svgmoji instead of the invalid ESM version of svgmoji. 

Why don't we just use `require('svgmoji')` in `@remirror/extension-emoji`?

Because in Node.JS ESM environment, `require` is not available by default. By adding another package, we make sure that Node.JS and bundlers can handler this ESM/CJS mix easier. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
