### PR TITLE
chore(cli): pass a package name to only build that package

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -61,11 +61,9 @@ If you only want to build all packages once, run the following command:
 pnpm run build
 ```
 
-If you only want to build a specific package, run the following command:
+If you only want to build some specific packages, run the following command:
 
 ````bash
-pnpm remirror-cli build @remirror/extension-bold
-# Or
 pnpm remirror-cli build @remirror/extension-bold @remirror/extension-italic
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -63,7 +63,7 @@ pnpm run build
 
 If you only want to build some specific packages, run the following command:
 
-````bash
+```bash
 pnpm remirror-cli build @remirror/extension-bold @remirror/extension-italic
 ```
 
@@ -71,7 +71,7 @@ pnpm remirror-cli build @remirror/extension-bold @remirror/extension-italic
 
 ```bash
 pnpm run storybook
-````
+```
 
 When run this builds all packages and then watches for changes to reload as necessary. If you are running storybook, then it will run `pnpm run watch` automatically, so you don't need to do it yourself.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,11 +55,25 @@ Under the hood, for most packages, this command uses `esbuild` to compile TypeSc
 
 Some packages have their own build scripts, e.g. `@remirror/theme` uses `babel` and `linaria` to produce CSS files. `pnpm run watch` will execute the build scripts in these packages too.
 
+If you only want to build all packages once, run the following command:
+
+```bash
+pnpm run build
+```
+
+If you only want to build a specific package, run the following command:
+
+````bash
+pnpm remirror-cli build @remirror/extension-bold
+# Or
+pnpm remirror-cli build @remirror/extension-bold @remirror/extension-italic
+```
+
 ### Storybook
 
 ```bash
 pnpm run storybook
-```
+````
 
 When run this builds all packages and then watches for changes to reload as necessary. If you are running storybook, then it will run `pnpm run watch` automatically, so you don't need to do it yourself.
 

--- a/packages/remirror__cli/src/commands/build.ts
+++ b/packages/remirror__cli/src/commands/build.ts
@@ -1,11 +1,28 @@
+import process from 'process';
+
 import { logger } from '../logger';
 import { buildPackage } from '../utils/build-package';
 import { listPackagesToBuild } from '../utils/list-packages';
 import { runTsc } from '../utils/run-tsc';
 
-export async function build() {
+export async function build(packageNames?: string[]) {
   logger.debug(`current working directory: ${process.cwd()}`);
-  const packages = await listPackagesToBuild();
+  let packages = await listPackagesToBuild();
+
+  if (packageNames && packageNames.length > 0) {
+    const names = new Set(packageNames);
+    packages = packages.filter((pkg) => names.has(pkg.packageJson.name));
+
+    if (packages.length < names.size) {
+      const usedName = new Set(names);
+
+      for (const pkg of packages) {
+        usedName.delete(pkg.packageJson.name);
+      }
+
+      logger.error(`No packages found for names: ${[...usedName].join(', ')}`);
+    }
+  }
 
   for (const pkg of packages) {
     await buildPackage(pkg);

--- a/packages/remirror__cli/src/index.ts
+++ b/packages/remirror__cli/src/index.ts
@@ -16,7 +16,11 @@ export async function main() {
         `${colors.yellow('yes')} to see more information.)`,
     );
 
-  program.command('build').description(`Build all NPM packages in current monorepo.`).action(build);
+  program
+    .command('build')
+    .argument('[name...]', 'The package you want to build.')
+    .description(`Build NPM packages in current monorepo.`)
+    .action(build);
 
   program
     .command('watch')


### PR DESCRIPTION
### Description

This PR provides a way to build a single package (for faster debug iteration). Eventually, we want to add this feature to `pnpm build`. 

```
pnpm remirror-cli build @remirror/extension-bold @remirror/extension-italic
```


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
