### PR TITLE
fix(extension-emoji): use namespace import for svgmoji

### DIFF
--- a/.changeset/orange-buses-lie.md
+++ b/.changeset/orange-buses-lie.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-emoji': patch
+---
+
+Fixes the import error for `@remirror/extension-emoji` when using `vite dev`.

--- a/packages/remirror__extension-emoji/src/emoji-utils.ts
+++ b/packages/remirror__extension-emoji/src/emoji-utils.ts
@@ -1,7 +1,8 @@
-import svgmoji from '@ocavue/svgmoji-cjs';
+import * as _svgmoji from '@ocavue/svgmoji-cjs';
 import type { FlatEmoji, Moji } from 'svgmoji';
-import type {
+import {
   AcceptUndefined,
+  defaultImport,
   FromToProps,
   Handler,
   PrimitiveSelection,
@@ -10,6 +11,7 @@ import type {
 } from '@remirror/core';
 import { Suggester } from '@remirror/pm/suggest';
 
+const svgmoji = defaultImport(_svgmoji);
 const { Blobmoji, Notomoji, Openmoji, Twemoji } = svgmoji;
 
 export interface EmojiOptions extends Pick<Suggester, 'supportedCharacters'> {

--- a/packages/remirror__extension-emoji/src/emoji-utils.ts
+++ b/packages/remirror__extension-emoji/src/emoji-utils.ts
@@ -1,15 +1,15 @@
 import * as _svgmoji from '@ocavue/svgmoji-cjs';
 import type { FlatEmoji, Moji } from 'svgmoji';
-import {
+import type {
   AcceptUndefined,
-  defaultImport,
   FromToProps,
   Handler,
   PrimitiveSelection,
   ProsemirrorAttributes,
   Static,
 } from '@remirror/core';
-import { Suggester } from '@remirror/pm/suggest';
+import { defaultImport } from '@remirror/core';
+import type { Suggester } from '@remirror/pm/suggest';
 
 const svgmoji = defaultImport(_svgmoji);
 const { Blobmoji, Notomoji, Openmoji, Twemoji } = svgmoji;


### PR DESCRIPTION
### Description

Fixes https://github.com/remirror/remirror/issues/1884 
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
