### PR TITLE
fix(extension-emoji): don't use .cjs in the svgmoji wrapper

### DIFF
--- a/.changeset/wicked-schools-smile.md
+++ b/.changeset/wicked-schools-smile.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-emoji': patch
+---
+
+Workarounds the import error for `@remirror/extension-emoji` when using `react-scripts start` by not using `.cjs` file extension.

--- a/packages/remirror__core-helpers/src/default-import.ts
+++ b/packages/remirror__core-helpers/src/default-import.ts
@@ -38,8 +38,9 @@ export function defaultImport<T>(mod: T): T {
       : mod;
 
   if (
+    defaultVal &&
+    typeof mod === 'object' &&
     '__esModule' in defaultVal &&
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     (defaultVal as any).__esModule &&
     (defaultVal as any).default !== undefined
   ) {

--- a/packages/remirror__extension-emoji/package.json
+++ b/packages/remirror__extension-emoji/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "@ocavue/svgmoji-cjs": "^0.1.0",
+    "@ocavue/svgmoji-cjs": "^0.1.1",
     "@remirror/core": "^2.0.4",
     "@remirror/messages": "^2.0.1",
     "@remirror/theme": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,7 +994,7 @@ importers:
   packages/remirror__extension-emoji:
     specifiers:
       '@babel/runtime': ^7.13.10
-      '@ocavue/svgmoji-cjs': ^0.1.0
+      '@ocavue/svgmoji-cjs': ^0.1.1
       '@remirror/core': ^2.0.4
       '@remirror/messages': ^2.0.1
       '@remirror/pm': ^2.0.0
@@ -1006,7 +1006,7 @@ importers:
       svgmoji: ^3.2.0
     dependencies:
       '@babel/runtime': 7.18.9
-      '@ocavue/svgmoji-cjs': 0.1.0
+      '@ocavue/svgmoji-cjs': 0.1.1
       '@remirror/core': link:../remirror__core
       '@remirror/messages': link:../remirror__messages
       '@remirror/theme': link:../remirror__theme
@@ -7253,8 +7253,8 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /@ocavue/svgmoji-cjs/0.1.0:
-    resolution: {integrity: sha512-FYCRf7/d80Jd7y3KflOM5gxszqvAxm35AAJ9FWF+D1b6th9VvZI4CVpAGqlVjZme2NhzzJbBLgkxcfeBBzKvVA==}
+  /@ocavue/svgmoji-cjs/0.1.1:
+    resolution: {integrity: sha512-tCP6ggbtgIL4hPM5goVFSjL51jH/BLl/yBLy98wAV9a2L/Sn9iS3abfprPeQw6/nan5lLaz4Vz8ZP37LKh+xfQ==}
     dependencies:
       svgmoji: 3.2.0
     dev: false
@@ -12473,7 +12473,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -23484,6 +23484,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
+    dev: true
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}


### PR DESCRIPTION
### Description

Fixes https://github.com/remirror/remirror-examples/issues/21

Create React App has poor support for `.cjs` file extension (see https://github.com/facebook/create-react-app/issues/11889#issuecomment-1114878121). 

As a workaround, I change the file extension from `index.cjs` => `index.js` in `@ocavue/svgmoji-cjs@0.1.1`. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
