### PR TITLE
fix(core-utils): don't use `instanceof` in `isDomNode`

### DIFF
--- a/.changeset/sharp-rats-compete.md
+++ b/.changeset/sharp-rats-compete.md
@@ -1,0 +1,6 @@
+---
+'multishift': patch
+'@remirror/core-utils': patch
+---
+
+Do not use `instanceof` in `isDomNode` anymore. This increases the compatibility on Node.js environments, where might exist more than one DOM API implementation.

--- a/packages/multishift/src/multishift-utils.ts
+++ b/packages/multishift/src/multishift-utils.ts
@@ -46,6 +46,29 @@ import type {
 } from './multishift-types';
 
 /**
+ * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+ *
+ * We use our own enum instead of the global `Node` object to be more compatible with server
+ * environments.
+ *
+ * @internal
+ */
+const enum DomNodeType {
+  ELEMENT_NODE = 1,
+  ATTRIBUTE_NODE = 2,
+  TEXT_NODE = 3,
+  CDATA_SECTION_NODE = 4,
+  ENTITY_REFERENCE_NODE = 5,
+  ENTITY_NODE = 6,
+  PROCESSING_INSTRUCTION_NODE = 7,
+  COMMENT_NODE = 8,
+  DOCUMENT_NODE = 9,
+  DOCUMENT_TYPE_NODE = 10,
+  DOCUMENT_FRAGMENT_NODE = 11,
+  NOTATION_NODE = 12,
+}
+
+/**
  * The default unique identifier getter function.
  */
 export function defaultGetItemId<Item = any>(item: Item): Item {
@@ -1121,29 +1144,6 @@ export function scrollIntoView(
     el.scrollTop = top;
     el.scrollLeft = left;
   });
-}
-
-/**
- * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
- *
- * We use our own enum instead of the global `Node` object to be more compatible with server
- * environments.
- *
- * @internal
- */
-const enum DomNodeType {
-  ELEMENT_NODE = 1,
-  ATTRIBUTE_NODE = 2,
-  TEXT_NODE = 3,
-  CDATA_SECTION_NODE = 4,
-  ENTITY_REFERENCE_NODE = 5,
-  ENTITY_NODE = 6,
-  PROCESSING_INSTRUCTION_NODE = 7,
-  COMMENT_NODE = 8,
-  DOCUMENT_NODE = 9,
-  DOCUMENT_TYPE_NODE = 10,
-  DOCUMENT_FRAGMENT_NODE = 11,
-  NOTATION_NODE = 12,
 }
 
 /**

--- a/packages/multishift/src/multishift-utils.ts
+++ b/packages/multishift/src/multishift-utils.ts
@@ -1124,16 +1124,35 @@ export function scrollIntoView(
 }
 
 /**
+ * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+ *
+ * We use our own enum instead of the global `Node` object to be more compatible with server
+ * environments.
+ *
+ * @internal
+ */
+const enum DomNodeType {
+  ELEMENT_NODE = 1,
+  ATTRIBUTE_NODE = 2,
+  TEXT_NODE = 3,
+  CDATA_SECTION_NODE = 4,
+  ENTITY_REFERENCE_NODE = 5,
+  ENTITY_NODE = 6,
+  PROCESSING_INSTRUCTION_NODE = 7,
+  COMMENT_NODE = 8,
+  DOCUMENT_NODE = 9,
+  DOCUMENT_TYPE_NODE = 10,
+  DOCUMENT_FRAGMENT_NODE = 11,
+  NOTATION_NODE = 12,
+}
+
+/**
  * Checks whether the passed value is a valid dom node
  *
  * @param domNode - the dom node
  */
 export function isNode(domNode: unknown): domNode is Node {
-  return isObject(Node)
-    ? domNode instanceof Node
-    : isObject(domNode) &&
-        isNumber((domNode as any).nodeType) &&
-        isString((domNode as any).nodeName);
+  return isObject(domNode) && isNumber(domNode.nodeType) && isString(domNode.nodeName);
 }
 
 /**
@@ -1142,7 +1161,7 @@ export function isNode(domNode: unknown): domNode is Node {
  * @param domNode - the dom node
  */
 export const isHTMLElement = (domNode: unknown): domNode is HTMLElement =>
-  isNode(domNode) && domNode.nodeType === Node.ELEMENT_NODE;
+  isNode(domNode) && domNode.nodeType === DomNodeType.ELEMENT_NODE;
 
 /**
  * Checks that this is a browser environment.

--- a/packages/remirror__core-utils/src/dom-utils.ts
+++ b/packages/remirror__core-utils/src/dom-utils.ts
@@ -1,13 +1,5 @@
 import parse from 'parenthesis';
-import {
-  Cast,
-  clamp,
-  findMatches,
-  includes,
-  isNumber,
-  isObject,
-  isString,
-} from '@remirror/core-helpers';
+import { clamp, findMatches, includes, isNumber, isObject, isString } from '@remirror/core-helpers';
 import { KebabCase, StringKey } from '@remirror/core-types';
 
 import { getMatchString } from './core-utils';
@@ -290,12 +282,30 @@ export function convertPixelsToDomUnit(
  * @param domNode - the dom node
  */
 export function isDomNode(domNode: unknown): domNode is Node {
-  return (
-    typeof document !== 'undefined' &&
-    (isObject(Node)
-      ? domNode instanceof Node
-      : isObject(domNode) && isNumber(Cast(domNode).nodeType) && isString(Cast(domNode).nodeName))
-  );
+  return isObject(domNode) && isNumber(domNode.nodeType) && isString(domNode.nodeName);
+}
+
+/**
+ * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+ *
+ * We use our own enum instead of the global `Node` object to be more compatible with server
+ * environments.
+ *
+ * @internal
+ */
+const enum DomNodeType {
+  ELEMENT_NODE = 1,
+  ATTRIBUTE_NODE = 2,
+  TEXT_NODE = 3,
+  CDATA_SECTION_NODE = 4,
+  ENTITY_REFERENCE_NODE = 5,
+  ENTITY_NODE = 6,
+  PROCESSING_INSTRUCTION_NODE = 7,
+  COMMENT_NODE = 8,
+  DOCUMENT_NODE = 9,
+  DOCUMENT_TYPE_NODE = 10,
+  DOCUMENT_FRAGMENT_NODE = 11,
+  NOTATION_NODE = 12,
 }
 
 /**
@@ -304,7 +314,7 @@ export function isDomNode(domNode: unknown): domNode is Node {
  * @param domNode - the dom node
  */
 export function isElementDomNode(domNode: unknown): domNode is HTMLElement {
-  return isDomNode(domNode) && domNode.nodeType === Node.ELEMENT_NODE;
+  return isDomNode(domNode) && domNode.nodeType === DomNodeType.ELEMENT_NODE;
 }
 
 /**
@@ -313,5 +323,5 @@ export function isElementDomNode(domNode: unknown): domNode is HTMLElement {
  * @param domNode - the dom node
  */
 export function isTextDomNode(domNode: unknown): domNode is Text {
-  return isDomNode(domNode) && domNode.nodeType === Node.TEXT_NODE;
+  return isDomNode(domNode) && domNode.nodeType === DomNodeType.TEXT_NODE;
 }

--- a/packages/remirror__core-utils/src/dom-utils.ts
+++ b/packages/remirror__core-utils/src/dom-utils.ts
@@ -5,6 +5,29 @@ import { KebabCase, StringKey } from '@remirror/core-types';
 import { getMatchString } from './core-utils';
 
 /**
+ * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+ *
+ * We use our own enum instead of the global `Node` object to be more compatible with server
+ * environments.
+ *
+ * @internal
+ */
+const enum DomNodeType {
+  ELEMENT_NODE = 1,
+  ATTRIBUTE_NODE = 2,
+  TEXT_NODE = 3,
+  CDATA_SECTION_NODE = 4,
+  ENTITY_REFERENCE_NODE = 5,
+  ENTITY_NODE = 6,
+  PROCESSING_INSTRUCTION_NODE = 7,
+  COMMENT_NODE = 8,
+  DOCUMENT_NODE = 9,
+  DOCUMENT_TYPE_NODE = 10,
+  DOCUMENT_FRAGMENT_NODE = 11,
+  NOTATION_NODE = 12,
+}
+
+/**
  * Get the styles for a given property of an element.
  */
 export function getStyle(
@@ -283,29 +306,6 @@ export function convertPixelsToDomUnit(
  */
 export function isDomNode(domNode: unknown): domNode is Node {
   return isObject(domNode) && isNumber(domNode.nodeType) && isString(domNode.nodeName);
-}
-
-/**
- * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
- *
- * We use our own enum instead of the global `Node` object to be more compatible with server
- * environments.
- *
- * @internal
- */
-const enum DomNodeType {
-  ELEMENT_NODE = 1,
-  ATTRIBUTE_NODE = 2,
-  TEXT_NODE = 3,
-  CDATA_SECTION_NODE = 4,
-  ENTITY_REFERENCE_NODE = 5,
-  ENTITY_NODE = 6,
-  PROCESSING_INSTRUCTION_NODE = 7,
-  COMMENT_NODE = 8,
-  DOCUMENT_NODE = 9,
-  DOCUMENT_TYPE_NODE = 10,
-  DOCUMENT_FRAGMENT_NODE = 11,
-  NOTATION_NODE = 12,
 }
 
 /**


### PR DESCRIPTION
### Description

Makes the `isDomNode` less strict by don't using `instanceof` in this function. 

This PR fixes an issue I saw on the Discord channel. `isDomNode` won't work if there are two DOM `document` objects and one is in the global environment but the passed node is created by another `document` object. 

> I'm trying out the htmlToProsemirrorNode function - all is good but it skips parsing a few elements (e.g. a  tags) on the server side. I see that it's caused by this line https://github.com/remirror/remirror/blob/77293727c85dcb73f9733f05dceb012d119bca0c/packages/remirror__extension-link/src/link-extension.ts#L330 - the 'isElementDomNode' function is using the global document instead so it keeps failing on the server. The codeblock and react-table extensions are also affected. Should this be fixed or is there a way to bypass this check on the server?

By the way, ESBuild is good enough that it inlines the `enum` when bundling the code. So the bundled code has a good runtime performance. 

```js
// packages/remirror__core-utils/dist/remirror-core-utils.cjs
function isElementDomNode(domNode) {
  return isDomNode(domNode) && domNode.nodeType === 1 /* ELEMENT_NODE */;
}
function isTextDomNode(domNode) {
  return isDomNode(domNode) && domNode.nodeType === 3 /* TEXT_NODE */;
}
```

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
