### PR TITLE
fix(core-utils): don't throw error if window doesn't exist

### DIFF
--- a/.changeset/red-kids-breathe.md
+++ b/.changeset/red-kids-breathe.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-utils': patch
+---
+
+Fixes a bug that causes `ReferenceError: window is not defined` when parsing HTML on the server.

--- a/packages/remirror__core-utils/src/core-utils.ts
+++ b/packages/remirror__core-utils/src/core-utils.ts
@@ -1237,16 +1237,12 @@ export function getDocument(): Document {
 }
 
 /**
- * Try to retrieve the window from the given HTML element or the global scope.
- *
  * @internal
  */
-export function maybeGetWindow(
-  element?: Element | null,
+export function maybeGetWindowFromDocument(
   document?: Document | null,
 ): (Window & typeof globalThis) | null | undefined {
   return (
-    element?.ownerDocument?.defaultView ??
     document?.defaultView ??
     (typeof window !== 'undefined' ? window : undefined) ??
     getDomDocument()?.defaultView
@@ -1256,17 +1252,32 @@ export function maybeGetWindow(
 /**
  * @internal
  */
-export function getWindow(
-  element?: Element | null,
-  document?: Document | null,
-): Window & typeof globalThis {
-  const view = maybeGetWindow(element, document) ?? getDocument().defaultView;
+export function maybeGetWindowFromElement(
+  element?: Element | HTMLElement | null,
+): (Window & typeof globalThis) | null | undefined {
+  return maybeGetWindowFromDocument(element?.ownerDocument);
+}
+
+/**
+ * @internal
+ */
+export function getWindowFromDocument(document?: Document | null): Window & typeof globalThis {
+  const view = maybeGetWindowFromDocument(document) ?? getDocument().defaultView;
 
   if (view) {
     return view;
   }
 
   throw new Error('Unable to retrieve the window from the global scope');
+}
+
+/**
+ * @internal
+ */
+export function getWindowFromElement(
+  element?: Element | HTMLElement | null,
+): Window & typeof globalThis {
+  return getWindowFromDocument(element?.ownerDocument);
 }
 
 export interface CustomDocumentProps {
@@ -1293,7 +1304,7 @@ export function prosemirrorNodeToDom(
 }
 
 function elementFromString(html: string, document?: Document): HTMLElement {
-  const parser = new (getWindow(undefined, document).DOMParser)();
+  const parser = new (getWindowFromDocument(document).DOMParser)();
   return parser.parseFromString(`<body>${html}</body>`, 'text/html').body;
 }
 

--- a/packages/remirror__core-utils/src/core-utils.ts
+++ b/packages/remirror__core-utils/src/core-utils.ts
@@ -1227,6 +1227,39 @@ export function getDocument(): Document {
   );
 }
 
+/**
+ * Try to retrieve the window from the given HTML element or the global scope.
+ *
+ * @internal
+ */
+export function maybeGetWindow(
+  element?: Element | null,
+  document?: Document | null,
+): (Window & typeof globalThis) | null | undefined {
+  return (
+    element?.ownerDocument?.defaultView ??
+    document?.defaultView ??
+    (typeof window !== 'undefined' ? window : undefined) ??
+    getDomDocument()?.defaultView
+  );
+}
+
+/**
+ * @internal
+ */
+export function getWindow(
+  element?: Element | null,
+  document?: Document | null,
+): Window & typeof globalThis {
+  const view = maybeGetWindow(element, document) ?? getDocument().defaultView;
+
+  if (view) {
+    return view;
+  }
+
+  throw new Error('Unable to retrieve the window from the global scope');
+}
+
 export interface CustomDocumentProps {
   /**
    * The root or custom document to use when referencing the dom.
@@ -1251,7 +1284,7 @@ export function prosemirrorNodeToDom(
 }
 
 function elementFromString(html: string, document?: Document): HTMLElement {
-  const parser = new ((document || getDocument())?.defaultView ?? window).DOMParser();
+  const parser = new (getWindow(undefined, document).DOMParser)();
   return parser.parseFromString(`<body>${html}</body>`, 'text/html').body;
 }
 

--- a/packages/remirror__core-utils/src/dom-utils.ts
+++ b/packages/remirror__core-utils/src/dom-utils.ts
@@ -2,7 +2,7 @@ import parse from 'parenthesis';
 import { clamp, findMatches, includes, isNumber, isObject, isString } from '@remirror/core-helpers';
 import { KebabCase, StringKey } from '@remirror/core-types';
 
-import { getMatchString, getWindow, maybeGetWindow } from './core-utils';
+import { getMatchString, getWindowFromElement, maybeGetWindowFromElement } from './core-utils';
 
 /**
  * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
@@ -34,7 +34,7 @@ export function getStyle(
   element: HTMLElement,
   property: KebabCase<StringKey<CSSStyleDeclaration>>,
 ): string {
-  const view = maybeGetWindow(element);
+  const view = maybeGetWindowFromElement(element);
   return view?.getComputedStyle(element)?.getPropertyValue(property) ?? '';
 }
 
@@ -100,14 +100,14 @@ export function getFontSize(element?: Element | null): string {
     return getStyle(element, 'font-size') || getFontSize(element.parentElement);
   }
 
-  const view = maybeGetWindow(element);
+  const view = maybeGetWindowFromElement(element);
   return view ? getStyle(view.document.documentElement, 'font-size') : '';
 }
 
 type UnitConvertor = (value: number, unit: string) => number;
 
 function createUnitConverter(element?: Element | null): UnitConvertor {
-  const view = getWindow();
+  const view = getWindowFromElement(element);
   const root = view.document.documentElement || view.document.body;
 
   return (value: number, unit: string) => {
@@ -257,7 +257,7 @@ export function convertPixelsToDomUnit(
   to: DomSizeUnit,
   element?: Element | null,
 ): number {
-  const view = getWindow(element);
+  const view = getWindowFromElement(element);
   const root = view.document.documentElement || view.document.body;
   const pixelValue = extractPixelSize(size, element);
 

--- a/packages/remirror__extension-code-block/__tests__/code-block-extension.node.spec.ts
+++ b/packages/remirror__extension-code-block/__tests__/code-block-extension.node.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ */
+
+import { JSDOM } from 'jsdom';
+import { CodeBlockExtension, createCoreManager } from 'remirror/src/extensions';
+import { htmlToProsemirrorNode } from '@remirror/core';
+
+describe('schema', () => {
+  const extensions = [new CodeBlockExtension()];
+  const manager = createCoreManager(extensions);
+
+  it('throws an error when parsing HTML in Node.js environment without browser API', () => {
+    expect(typeof document).toBe('undefined');
+    expect(typeof window).toBe('undefined');
+
+    const parse = () =>
+      htmlToProsemirrorNode({
+        schema: manager.schema,
+        content: '<pre><code>echo hello world</code></pre>',
+      });
+    expect(parse).toThrow(/Unable to retrieve the document from the global scope/);
+  });
+
+  it('parses HTML in Node.js environment', () => {
+    const node = htmlToProsemirrorNode({
+      document: new JSDOM().window.document,
+      schema: manager.schema,
+      content: '<pre><code>echo hello world</code></pre>',
+    });
+    expect(node.toJSON()).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'codeBlock',
+          attrs: {
+            language: 'markup',
+            wrap: false,
+          },
+          content: [
+            {
+              text: 'echo hello world',
+              type: 'text',
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/remirror__extension-code-block/package.json
+++ b/packages/remirror__extension-code-block/package.json
@@ -54,7 +54,9 @@
   },
   "devDependencies": {
     "@remirror/pm": "^2.0.0",
+    "@types/jsdom": "^16.2.13",
     "@types/prettier": "^2.3.2",
+    "jsdom": "^17.0.0",
     "prettier": "^2.3.2"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,8 +844,10 @@ importers:
       '@remirror/messages': ^2.0.1
       '@remirror/pm': ^2.0.0
       '@remirror/theme': ^2.0.0
+      '@types/jsdom': ^16.2.13
       '@types/prettier': ^2.3.2
       '@types/refractor': ^3.0.2
+      jsdom: ^17.0.0
       prettier: ^2.3.2
       refractor: ^3.3.1
     dependencies:
@@ -857,7 +859,9 @@ importers:
       refractor: 3.6.0
     devDependencies:
       '@remirror/pm': link:../remirror__pm
+      '@types/jsdom': 16.2.13
       '@types/prettier': 2.4.1
+      jsdom: 17.0.0
       prettier: 2.4.1
 
   packages/remirror__extension-codemirror5:
@@ -12453,7 +12457,7 @@ packages:
       mississippi: 2.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 5.3.0
       unique-filename: 1.1.1
@@ -12473,7 +12477,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12517,7 +12521,7 @@ packages:
       mississippi: 1.3.1
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 4.1.6
       unique-filename: 1.1.1
@@ -22271,7 +22275,7 @@ packages:
       npm-package-arg: 5.1.2
       npm-pick-manifest: 1.0.4
       osenv: 0.1.5
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       promise-retry: 1.1.1
       protoduck: 4.0.0
       safe-buffer: 5.2.1
@@ -23484,6 +23488,17 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise-retry/1.1.1:
     resolution: {integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=}


### PR DESCRIPTION
### Description

Make `getStyle` and `getFontSize` robuster in server env. 

We shouldn't directly use the global variable `window` before checking the existing of it, otherwise, we could get the `ReferenceError: window is not defined` error in the server environment. 



<!-- Describe your changes in detail and reference any issues it addresses-->


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
