### PR TITLE
Export default mappings for React Renderer and add li

### DIFF
--- a/docs/static-rendering.md
+++ b/docs/static-rendering.md
@@ -31,4 +31,9 @@ The react-render provides a more efficient way to visualize Remirror documents: 
 
 See [storybook](https://remirror.vercel.app/?path=/story/editors-react-renderer-static-html--basic) for example usage.
 
-_Note: Today only the most widely Remirror node types are supported by the react-render. Please file a ticket (or even better PR) if you require further node types._
+### Supported types
+Today only the most widely Remirror node types are supported by the react-render.
+
+You can pass a map of marks and types to the `typeMap` and `markMap` props respectively, and import `reactRendererDefaultTypeMap` and `reactRendererDefaultMarkMap` to retain the default mappings if you only want to add or override.
+
+_Note: Please file a ticket (or even better PR) if you require further node types._

--- a/packages/remirror__react-renderer/src/index.ts
+++ b/packages/remirror__react-renderer/src/index.ts
@@ -1,3 +1,8 @@
 export * from './handlers';
-export { Doc, RemirrorRenderer } from './renderer';
+export {
+  Doc,
+  RemirrorRenderer,
+  defaultTypeMap as reactRendererDefaultTypeMap,
+  defaultMarkMap as reactRendererDefaultMarkMap
+} from './renderer';
 export type { MarkMap } from './types';

--- a/packages/remirror__react-renderer/src/renderer.tsx
+++ b/packages/remirror__react-renderer/src/renderer.tsx
@@ -21,7 +21,7 @@ export const Doc: FC<SubRenderTreeProps> = ({ node, ...props }) => {
   return <div {...(node.attrs ?? object())}>{children}</div>;
 };
 
-const defaultTypeMap: MarkMap = {
+export const defaultTypeMap: MarkMap = {
   blockquote: 'blockquote',
   bulletList: 'ul',
   callout: Callout,
@@ -35,9 +35,10 @@ const defaultTypeMap: MarkMap = {
   codeBlock: CodeBlock,
   orderedList: 'ol',
   text: TextHandler,
+  li: 'li'
 };
 
-const defaultMarkMap: MarkMap = {
+export const defaultMarkMap: MarkMap = {
   italic: 'em',
   bold: 'strong',
   code: 'code',


### PR DESCRIPTION
### Description

Currently, to add new types locally to the React Renderer, we lose all the default mappings. This change allows us to import the default mappings to merge with any custom ones.

(This felt less intrusive than merging the types with the default ones by default)

It also adds a type registration for `li`.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
