### PR TITLE
fix(events): catch when `posFromDOM` returns -1

### DIFF
--- a/.changeset/sweet-radios-relax.md
+++ b/.changeset/sweet-radios-relax.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': patch
+---
+
+Catch when `posFromDom` returns -1, which causes a thrown error when attempting to resolve the pos

--- a/packages/remirror__extension-events/src/events-utils.ts
+++ b/packages/remirror__extension-events/src/events-utils.ts
@@ -5,7 +5,13 @@ import { EditorView } from '@remirror/core';
  * inside the editor.
  */
 function posAtDOM(view: EditorView, node: Node, offset: number, bias?: number): number | null {
-  return (view as any).docView.posFromDOM(node, offset, bias);
+  const pos = (view as any).docView.posFromDOM(node, offset, bias);
+
+  if (pos === null || pos < 0) {
+    return null;
+  }
+
+  return pos;
 }
 
 /**


### PR DESCRIPTION
### Description

`viewDes.posFromDom` [can return -1](https://github.com/ProseMirror/prosemirror-view/blob/master/src/viewdesc.ts#L248) which causes a RangeError to be thrown when we try to resolve the position.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

