### PR TITLE
fix(react-table): prevent controller cell content with `filterTransaction`

### DIFF
--- a/.changeset/honest-lobsters-stare.md
+++ b/.changeset/honest-lobsters-stare.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-react-tables': patch
+---
+
+Prevent controller cell content with `filterTransaction`

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -366,4 +366,23 @@ export class TableControllerCellExtension extends BaseTableControllerCellExtensi
   createExtensions() {
     return [];
   }
+
+  createPlugin(): CreateExtensionPlugin {
+    return {
+      filterTransaction: (tr) => {
+        const controllerCellsWithContent = getChangedNodes(tr, {
+          descend: true,
+          predicate: (node: ProsemirrorNode) => {
+            if (node.type !== this.type) {
+              return false;
+            }
+
+            return node.textContent !== '';
+          },
+        });
+
+        return controllerCellsWithContent.length === 0;
+      },
+    };
+  }
 }


### PR DESCRIPTION
### Description

Using the arrows keys you can navigate to a controller cell and add text in it

https://user-images.githubusercontent.com/2003804/195443030-838051cb-bd66-4748-85eb-30b475ff96cb.mov

I tried changing the `content` definition in the node spec, however that resulted in adding an additional table column on key press.

I also tried prevent the cell `selectable: false`, but that means you can no longer delete columns/rows.

Filter transaction seems to work reliably, so I have used that approach.

I'm open to alternative suggestions!

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
