### PR TITLE
fix: prevent command injection when calling formatFiles 

### DIFF
--- a/support/scripts/src/generate-configs.ts
+++ b/support/scripts/src/generate-configs.ts
@@ -554,7 +554,7 @@ async function generatePackageTsConfigs() {
 
         // Add the file created to the list of files to prettify at the end of
         // the script being run.
-        filesToPrettify.push(tsconfigFiles.map((tsconfig) => tsconfig.filepath).join(' '));
+        filesToPrettify.push(...tsconfigFiles.map((tsconfig) => tsconfig.filepath));
       }),
     );
   }
@@ -615,7 +615,7 @@ async function main() {
   log.debug('Prettifying the updated and created files');
 
   // Format all the files which have been created before exiting.
-  await formatFiles(filesToPrettify.join(' '), { silent: true, formatter: 'prettier' });
+  await formatFiles(filesToPrettify, { silent: true, formatter: 'prettier' });
 }
 
 // Run the script and listen for any errors.

--- a/support/scripts/src/generate-icons.ts
+++ b/support/scripts/src/generate-icons.ts
@@ -300,10 +300,10 @@ async function writeIconModule() {
  */
 async function run() {
   log.debug(chalk`Generating icons for {grey \`@remirror/react-components\`}`);
-  const formatPath = [coreIconsPath, coreComponentsPath, allIconsPath, allComponentsPath].join(' ');
+  const formatPaths = [coreIconsPath, coreComponentsPath, allIconsPath, allComponentsPath];
 
   await writeIconModule();
-  await formatFiles(formatPath, { silent: true });
+  await formatFiles(formatPaths, { silent: true });
 
   log.debug(chalk`{green Icons generated} 🙌`);
 }

--- a/support/scripts/src/generate-intl.ts
+++ b/support/scripts/src/generate-intl.ts
@@ -32,7 +32,7 @@ async function run() {
     await createIndexFile(locale);
   }
 
-  await formatFiles(filesToFormat.join(' '), { formatter: 'prettier' });
+  await formatFiles(filesToFormat, { formatter: 'prettier' });
 }
 
 run().catch((error) => log.fatal(error));

--- a/support/scripts/src/helpers.ts
+++ b/support/scripts/src/helpers.ts
@@ -5,7 +5,7 @@ import { getPackages } from '@manypkg/get-packages';
 import assert from 'assert';
 import camelCaseKeys from 'camelcase-keys';
 import chalk from 'chalk';
-import { exec as _exec } from 'child_process';
+import { execFile as _execFile } from 'child_process';
 import fs from 'fs';
 import { diff } from 'jest-diff';
 import isEqual from 'lodash.isequal';
@@ -30,7 +30,7 @@ const minLevel = cliArgs.logLevel ?? process.env.LOG_LEVEL ?? 'debug';
  */
 export const log: Logger = new Logger({ minLevel });
 
-export const exec = promisify(_exec);
+export const execFile = promisify(_execFile);
 export const rm = promisify(_rm);
 const separator = '__';
 
@@ -116,7 +116,7 @@ export async function formatFiles(
 
   if (formatter !== 'prettier') {
     promises.push(
-      exec(`eslint --fix ${path}`, {
+      execFile(`eslint`, [`--fix`, path], {
         // @ts-expect-error
         stdio: 'pipe',
       }),
@@ -125,7 +125,7 @@ export async function formatFiles(
 
   if (formatter !== 'eslint') {
     promises.push(
-      exec(`prettier --loglevel warn ${path} --write`, {
+      execFile(`prettier`, [`--loglevel`, `warn`, path, `--write`], {
         // @ts-expect-error
         stdio: 'pipe',
       }),

--- a/support/scripts/src/helpers.ts
+++ b/support/scripts/src/helpers.ts
@@ -5,7 +5,7 @@ import { getPackages } from '@manypkg/get-packages';
 import assert from 'assert';
 import camelCaseKeys from 'camelcase-keys';
 import chalk from 'chalk';
-import { execFile as _execFile } from 'child_process';
+import { exec as _exec, execFile as _execFile } from 'child_process';
 import fs from 'fs';
 import { diff } from 'jest-diff';
 import isEqual from 'lodash.isequal';
@@ -30,6 +30,7 @@ const minLevel = cliArgs.logLevel ?? process.env.LOG_LEVEL ?? 'debug';
  */
 export const log: Logger = new Logger({ minLevel });
 
+export const exec = promisify(_exec);
 export const execFile = promisify(_execFile);
 export const rm = promisify(_rm);
 const separator = '__';

--- a/support/scripts/src/helpers.ts
+++ b/support/scripts/src/helpers.ts
@@ -107,17 +107,18 @@ interface FormatFilesOptions {
 }
 
 /**
- * Format the provided files with `prettier` and `eslint`.
+ * Format the provided file or files with `prettier` and `eslint`.
  */
 export async function formatFiles(
-  path = '',
+  path: string | string[],
   { silent = false, formatter = 'all' }: FormatFilesOptions = {},
 ): Promise<void> {
   const promises: Array<Promise<{ stdout: string; stderr: string }>> = [];
+  const paths: string[] = typeof path === 'string' ? [path] : path;
 
   if (formatter !== 'prettier') {
     promises.push(
-      execFile(`eslint`, [`--fix`, path], {
+      execFile(`eslint`, [`--fix`, ...paths], {
         // @ts-expect-error
         stdio: 'pipe',
       }),
@@ -126,7 +127,7 @@ export async function formatFiles(
 
   if (formatter !== 'eslint') {
     promises.push(
-      execFile(`prettier`, [`--loglevel`, `warn`, path, `--write`], {
+      execFile(`prettier`, [`--loglevel`, `warn`, ...paths, `--write`], {
         // @ts-expect-error
         stdio: 'pipe',
       }),


### PR DESCRIPTION
### Description

Prevent command injection from `path` when calling `formatFiles`. (Although admittedly it is unlikely to happen currently.)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
