### PR TITLE
docs: fix the broken image story

### DIFF
--- a/packages/remirror__core/src/builtins/upload-extension/file-upload.ts
+++ b/packages/remirror__core/src/builtins/upload-extension/file-upload.ts
@@ -187,7 +187,7 @@ function onFileLoaded<NodeAttributes extends AbstractNodeAttributes>({
   setUploadPlaceholderAction(tr, { type: ActionType.REMOVE_PLACEHOLDER, id });
   const fileAttrs: NodeAttributes = { ...fileNode.attrs, ...attrs, id: null };
   // We need to update the node to trigger the render function, which will accept
-  // differnt properties during and after the upload progress.
+  // different properties during and after the upload progress.
   tr.setNodeMarkup(placeholderPos, undefined, fileAttrs);
   view.dispatch(tr);
 }

--- a/packages/storybook-react/stories/extension-image/basic.tsx
+++ b/packages/storybook-react/stories/extension-image/basic.tsx
@@ -6,9 +6,8 @@ import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const extensions = () => [new ImageExtension()];
 
-const Basic = ({ delaySeconds = 1 }: { delaySeconds: number }): JSX.Element => {
+const Basic = (): JSX.Element => {
   const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
-  const proxySrc = `https://deelay.me/${delaySeconds * 1000}/${imageSrc}`;
 
   const { manager, state, onChange } = useRemirror({
     extensions,
@@ -23,7 +22,7 @@ const Basic = ({ delaySeconds = 1 }: { delaySeconds: number }): JSX.Element => {
               attrs: {
                 height: 160,
                 width: 400,
-                src: proxySrc,
+                src: imageSrc,
               },
             },
           ],

--- a/packages/storybook-react/stories/extension-image/image.stories.tsx
+++ b/packages/storybook-react/stories/extension-image/image.stories.tsx
@@ -1,19 +1,13 @@
 import type { Story } from '@storybook/react';
 
 import BasicComponent from './basic';
-import ResizableCompoment from './resizable';
+import ResizableComponent from './resizable';
 import WithFigcaption from './with-figcaption';
 
-const Basic: Story<{ delaySeconds: number }> = BasicComponent.bind({});
-Basic.args = {
-  delaySeconds: 1,
-};
+const Basic: Story = BasicComponent.bind({});
 Basic.storyName = 'Basic';
 
-const Resizable: Story<{ delaySeconds: number }> = ResizableCompoment.bind({});
-Resizable.args = {
-  delaySeconds: 1,
-};
+const Resizable: Story = ResizableComponent.bind({});
 Resizable.storyName = 'Resizable';
 
 export { Basic, Resizable, WithFigcaption };

--- a/packages/storybook-react/stories/extension-image/resizable.tsx
+++ b/packages/storybook-react/stories/extension-image/resizable.tsx
@@ -6,9 +6,8 @@ import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
 const extensions = () => [new ImageExtension({ enableResizing: true })];
 
-const Resizable = ({ delaySeconds = 1 }: { delaySeconds: number }): JSX.Element => {
+const Resizable = (): JSX.Element => {
   const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
-  const proxySrc = `https://deelay.me/${delaySeconds * 1000}/${imageSrc}`;
 
   const { manager, state, onChange } = useRemirror({
     extensions,
@@ -23,7 +22,7 @@ const Resizable = ({ delaySeconds = 1 }: { delaySeconds: number }): JSX.Element 
               attrs: {
                 height: 160,
                 width: 400,
-                src: proxySrc,
+                src: imageSrc,
               },
             },
           ],

--- a/support/root/jest-playwright.config.cjs
+++ b/support/root/jest-playwright.config.cjs
@@ -3,7 +3,7 @@
 const { E2E_DEBUG, E2E_COVERAGE, E2E_BROWSER = 'chromium' } = process.env;
 
 /** @type {?} */
-const browsers = E2E_BROWSER.split(',')
+const browsers = E2E_BROWSER.split(',');
 const collectCoverage = E2E_COVERAGE === 'true';
 const debug = E2E_DEBUG === 'true';
 
@@ -20,4 +20,4 @@ const config = {
   collectCoverage,
 };
 
-module.exports = config
+module.exports = config;


### PR DESCRIPTION
### Description

https://deelay.me/, which I used to test image layout shifting, returns 502 now. This PR removes deelay.me and fixes the broken storybook. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
