### PR TITLE
fix(extension-image): insert image at the drop position

### DIFF
--- a/.changeset/shaggy-suns-rhyme.md
+++ b/.changeset/shaggy-suns-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-image': patch
+---
+
+Insert images at the drop position.

--- a/packages/remirror__extension-image/src/image-extension.ts
+++ b/packages/remirror__extension-image/src/image-extension.ts
@@ -10,6 +10,7 @@ import {
   getTextSelection,
   invariant,
   isElementDomNode,
+  isNumber,
   NodeExtension,
   NodeExtensionSpec,
   NodeSpecOverride,
@@ -228,7 +229,7 @@ export class ImageExtension extends NodeExtension<ImageOptions> {
     };
   }
 
-  private fileUploadFileHandler(files: File[], event: ClipboardEvent | DragEvent) {
+  private fileUploadFileHandler(files: File[], event: ClipboardEvent | DragEvent, pos?: number) {
     const { preferPastedTextContent, uploadHandler } = this.options;
 
     if (
@@ -249,6 +250,10 @@ export class ImageExtension extends NodeExtension<ImageOptions> {
 
     const uploads = uploadHandler(filesWithProgress);
 
+    if (isNumber(pos)) {
+      chain.selectText(pos);
+    }
+
     for (const upload of uploads) {
       chain.uploadImage(upload);
     }
@@ -263,7 +268,10 @@ export class ImageExtension extends NodeExtension<ImageOptions> {
       {
         type: 'file',
         regexp: /image/i,
-        fileHandler: ({ files, event }) => this.fileUploadFileHandler(files, event),
+        fileHandler: (props): boolean => {
+          const pos = props.type === 'drop' ? props.pos : undefined;
+          return this.fileUploadFileHandler(props.files, props.event, pos);
+        },
       },
     ];
   }

--- a/packages/storybook-react/stories/extension-image/basic.tsx
+++ b/packages/storybook-react/stories/extension-image/basic.tsx
@@ -1,10 +1,10 @@
 import 'remirror/styles/all.css';
 
 import React from 'react';
-import { ImageExtension } from 'remirror/extensions';
+import { DropCursorExtension, ImageExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-const extensions = () => [new ImageExtension()];
+const extensions = () => [new ImageExtension(), new DropCursorExtension()];
 
 const Basic = (): JSX.Element => {
   const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
@@ -33,6 +33,15 @@ const Basic = (): JSX.Element => {
             {
               type: 'text',
               text: 'You can see a green image above.',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Drag and drop an image file to editor to insert it.',
             },
           ],
         },

--- a/packages/storybook-react/stories/extension-image/resizable.tsx
+++ b/packages/storybook-react/stories/extension-image/resizable.tsx
@@ -1,10 +1,10 @@
 import 'remirror/styles/all.css';
 
 import React from 'react';
-import { ImageExtension } from 'remirror/extensions';
+import { DropCursorExtension, ImageExtension } from 'remirror/extensions';
 import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
 
-const extensions = () => [new ImageExtension({ enableResizing: true })];
+const extensions = () => [new ImageExtension({ enableResizing: true }), new DropCursorExtension()];
 
 const Resizable = (): JSX.Element => {
   const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
@@ -33,6 +33,15 @@ const Resizable = (): JSX.Element => {
             {
               type: 'text',
               text: 'You can see a resizable image above. Move your mouse over the image and drag the resizing handler to resize it.',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'Drag and drop an image file to editor to insert it.',
             },
           ],
         },


### PR DESCRIPTION
### Description


Close https://github.com/remirror/remirror/issues/1929



<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Before:


https://user-images.githubusercontent.com/24715727/199087602-1fea6f91-09fd-4dc9-b847-fdfd4b982836.mp4



After:

https://user-images.githubusercontent.com/24715727/199087609-f802d816-89dc-4374-9225-aa3f2bf195fd.mp4

<!-- Delete this section if not applicable -->
