### PR TITLE
fix: fix the default import for `compute-scroll-into-view`

### DIFF
--- a/.changeset/little-parrots-destroy.md
+++ b/.changeset/little-parrots-destroy.md
@@ -1,0 +1,5 @@
+---
+'multishift': patch
+---
+
+Fix an error `(0 , import_compute_scroll_into_view.default) is not a function` when using create-react-app.

--- a/packages/multishift/src/multishift-utils.ts
+++ b/packages/multishift/src/multishift-utils.ts
@@ -1,10 +1,11 @@
-import computeScrollIntoView from 'compute-scroll-into-view';
+import _computeScrollIntoView from 'compute-scroll-into-view';
 import type { Dispatch, KeyboardEvent, SyntheticEvent } from 'react';
 import warning from 'tiny-warning';
 import { keyName } from 'w3c-keyname';
 import {
   assertGet,
   clamp,
+  defaultImport,
   isArray,
   isEmptyArray,
   isNumber,
@@ -44,6 +45,8 @@ import type {
   MultishiftStateProps,
   SpecialKeyDownPayload,
 } from './multishift-types';
+
+const computeScrollIntoView = defaultImport(_computeScrollIntoView);
 
 /**
  * Dom Node type. See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType


### PR DESCRIPTION
### Description

This PR fixes an error  `(0 , import_compute_scroll_into_view.default) is not a function` when using react-scripts. 

> The issue happens with the getMenuProps() function when i use keyboard arrow keys to select items.
> 
> This issue may also affect other areas where getMenuProps() is being used. Here is the error and the sandbox link

https://user-images.githubusercontent.com/24715727/201912478-b1900888-e2da-44dd-92d4-3dbf2e24d89c.mp4


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
