### PR TITLE
feat(entity-reference): add an `onClick` handler

### DIFF
--- a/.changeset/happy-scissors-sit.md
+++ b/.changeset/happy-scissors-sit.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-tables': patch
+---
+
+`setTableCellBackground` should also apply to table header cells

--- a/.changeset/old-crews-count.md
+++ b/.changeset/old-crews-count.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-entity-reference': minor
+---
+
+Add an `onClick` handler, which can be used mutliple times without overwriting previous handlers.
+
+This differs to the existing constructor option `onClickMark` which can only be used once.

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -33,6 +33,7 @@ import {
 import { decorateEntityReferences } from './utils/decorate-entity-references';
 import { getDisjoinedEntityReferencesFromNode } from './utils/disjoined-entity-references';
 import { joinDisjoinedEntityReferences } from './utils/joined-entity-references';
+import { getShortestEntityReference } from './utils/shortest-entity-reference';
 
 /**
  *  Required props to create entityReference marks decorations.
@@ -69,9 +70,11 @@ const createDecorationSet = (props: StateProps) => {
     blockSeparator: undefined,
     onClickMark: () => {},
   },
+  handlerKeys: ['onClick'],
 })
 export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptions> {
   get name(): string {
+    // TODO: rename this to entityReference for consistency
     return 'entity-reference' as const;
   }
 
@@ -125,6 +128,12 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
 
         if (entityReferences.length === 0) {
           return this.options.onClickMark();
+        }
+
+        const shortest = getShortestEntityReference(entityReferences);
+
+        if (shortest) {
+          this.options.onClick(shortest);
         }
 
         return this.options.onClickMark(entityReferences);

--- a/packages/remirror__extension-entity-reference/src/index.ts
+++ b/packages/remirror__extension-entity-reference/src/index.ts
@@ -1,5 +1,5 @@
 export * from './entity-reference-extension';
 export { centeredEntityReferencePositioner } from './entity-reference-positioners';
-export type { EntityReferenceMetaData } from './types';
+export type { EntityReferenceAttributes, EntityReferenceMetaData } from './types';
 export { findMinMaxRange } from './utils/ranges';
 export { getShortestEntityReference } from './utils/shortest-entity-reference';

--- a/packages/remirror__extension-entity-reference/src/types.ts
+++ b/packages/remirror__extension-entity-reference/src/types.ts
@@ -1,10 +1,13 @@
-import type { AcceptUndefined, Decoration, FromToProps } from '@remirror/core';
+import type { AcceptUndefined, Decoration, FromToProps, Handler } from '@remirror/core';
 
-export interface EntityReferenceMetaData extends FromToProps {
+export interface EntityReferenceAttributes {
   /**
    * Unique identifier of the entity references
    */
   id: string;
+}
+
+export interface EntityReferenceMetaData extends EntityReferenceAttributes, FromToProps {
   /**
    * Text content of the node
    */
@@ -25,6 +28,7 @@ export interface EntityReferenceOptions {
   getStyle?: (entityReferences: EntityReferenceMetaData[][]) => Decoration[];
   blockSeparator?: AcceptUndefined<string>;
   onClickMark?: (entityReferences?: EntityReferenceMetaData[]) => void;
+  onClick?: Handler<(entityReference: EntityReferenceMetaData) => void>;
 }
 
 export interface EntityReferencePluginState extends Required<EntityReferenceOptions> {

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -324,7 +324,7 @@ export class TableExtension extends NodeExtension<TableOptions> {
         return true;
       }
 
-      const found = findParentNodeOfType({ selection, types: 'tableCell' });
+      const found = findParentNodeOfType({ selection, types: ['tableCell', 'tableHeaderCell'] });
 
       if (found) {
         dispatch?.(tr.setNodeMarkup(found.pos, undefined, { ...found.node.attrs, background }));

--- a/packages/storybook-react/stories/extension-entity-reference/basic.tsx
+++ b/packages/storybook-react/stories/extension-entity-reference/basic.tsx
@@ -1,0 +1,102 @@
+import 'remirror/styles/all.css';
+import './styles.css';
+
+import React, { useCallback, useState } from 'react';
+import { cx, uniqueId } from 'remirror';
+import { CodeExtension, EntityReferenceExtension, ItalicExtension } from 'remirror/extensions';
+import {
+  EditorComponent,
+  Remirror,
+  ThemeProvider,
+  useCommands,
+  useExtensionEvent,
+  useHelpers,
+  useRemirror,
+} from '@remirror/react';
+
+const extensions = () => [
+  new EntityReferenceExtension({}),
+  new CodeExtension(),
+  new ItalicExtension(),
+];
+
+const Buttons = () => {
+  const { getEntityReferencesAt } = useHelpers<EntityReferenceExtension>(true);
+  const { addEntityReference } = useCommands<EntityReferenceExtension>();
+
+  const entityReferencesAt = getEntityReferencesAt();
+  const active = entityReferencesAt.length > 0;
+
+  const onClick = useCallback(() => {
+    // Add entity reference
+    const id = uniqueId();
+    addEntityReference(id);
+  }, [addEntityReference]);
+
+  return (
+    <button
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+      className={cx(active && 'active')}
+    >
+      Add Entity Reference
+    </button>
+  );
+};
+
+const ClickPrinter: React.FC = () => {
+  const [lastClickedRef, setLastClickedRef] = useState<string | null>(null);
+
+  useExtensionEvent(
+    EntityReferenceExtension,
+    'onClick',
+    useCallback((data) => {
+      setLastClickedRef(JSON.stringify(data, null, 2));
+    }, []),
+  );
+
+  if (!lastClickedRef) {
+    return null;
+  }
+
+  return (
+    <>
+      <h3>Last clicked entity reference info</h3>
+      <pre>
+        <code>{lastClickedRef}</code>
+      </pre>
+    </>
+  );
+};
+
+const content = `
+  <p>Highlight important and interesting text. They can overlap one-another and be detected on click.</p>
+  <p></p>
+  <p>The assumption is that the <code>id</code> attribute refers to an entity <em>external</em> to Remirror - like a comment</p>
+`;
+
+const Basic = (): JSX.Element => {
+  const { manager, state, onChange } = useRemirror({
+    extensions: extensions,
+    content,
+    stringHandler: 'html',
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror
+        manager={manager}
+        autoFocus
+        onChange={onChange}
+        initialContent={state}
+        autoRender={false}
+      >
+        <Buttons />
+        <EditorComponent />
+        <ClickPrinter />
+      </Remirror>
+    </ThemeProvider>
+  );
+};
+
+export default Basic;

--- a/packages/storybook-react/stories/extension-entity-reference/entity-reference.stories.tsx
+++ b/packages/storybook-react/stories/extension-entity-reference/entity-reference.stories.tsx
@@ -1,7 +1,9 @@
+import Basic from './basic';
 import Highlights from './highlights';
 import ScrollIntoHighlight from './scroll-to-highlight';
 
 export default { title: 'Extensions / EntityReference' };
 
+export { Basic };
 export { Highlights as Highlight };
 export { ScrollIntoHighlight as ScrollIntoHighlight };

--- a/packages/storybook-react/stories/extension-link/click-handler.tsx
+++ b/packages/storybook-react/stories/extension-link/click-handler.tsx
@@ -1,25 +1,45 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useState } from 'react';
 import { LinkExtension } from 'remirror/extensions';
-import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+import { Remirror, ThemeProvider, useExtensionEvent, useRemirror } from '@remirror/react';
+
+const ClickPrinter: React.FC = () => {
+  const [lastClickedLink, setLastClickedLink] = useState<string | null>(null);
+
+  useExtensionEvent(
+    LinkExtension,
+    'onClick',
+    useCallback((_, data) => {
+      setLastClickedLink(JSON.stringify(data, null, 2));
+      return true;
+    }, []),
+  );
+
+  if (!lastClickedLink) {
+    return null;
+  }
+
+  return (
+    <>
+      <h3>Last clicked link info</h3>
+      <pre>
+        <code>{lastClickedLink}</code>
+      </pre>
+    </>
+  );
+};
 
 const ClickHandler = (): JSX.Element => {
-  const linkExtension = useMemo(() => {
-    const extension = new LinkExtension();
-    extension.addHandler('onClick', (_, data) => {
-      alert(`You clicked link: ${JSON.stringify(data)}`);
-      return true;
-    });
-    return extension;
-  }, []);
   const { manager, state } = useRemirror({
-    extensions: () => [linkExtension],
+    extensions: () => [new LinkExtension()],
     content: `Click this <a href="https://remirror.io" target="_blank">link</a>`,
     stringHandler: 'html',
   });
 
   return (
     <ThemeProvider>
-      <Remirror manager={manager} initialContent={state} />
+      <Remirror manager={manager} initialContent={state} autoRender='start'>
+        <ClickPrinter />
+      </Remirror>
     </ThemeProvider>
   );
 };

--- a/website/extension-examples/extension-entity-reference/basic.tsx
+++ b/website/extension-examples/extension-entity-reference/basic.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-entity-reference/basic.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-entity-reference/basic').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Description

Add an `onClick` handler, which can be used mutliple times without overwriting previous handlers.

This differs to the existing constructor option `onClickMark` which can only be used once.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.


