### PR TITLE
fix(extension-list): improve the selection of lists on touch screen

### DIFF
--- a/.changeset/smooth-hats-compare.md
+++ b/.changeset/smooth-hats-compare.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-list': patch
+'@remirror/styles': patch
+'@remirror/theme': patch
+---
+
+Improve the selection of lists on touch screen.

--- a/.changeset/soft-games-glow.md
+++ b/.changeset/soft-games-glow.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-list': patch
+---
+
+Fix the dom structure of the bullet list when `enableSpine` is `true`. The `<ul>` element only contains `<li>` elements after this patch.

--- a/packages/remirror__extension-list/src/bullet-list-extension.ts
+++ b/packages/remirror__extension-list/src/bullet-list-extension.ts
@@ -56,7 +56,7 @@ export class BulletListExtension extends NodeExtension<BulletListOptions> {
     }
 
     return (_, view, getPos) => {
-      const dom = document.createElement('ul');
+      const dom = document.createElement('div');
       dom.style.position = 'relative';
 
       const pos = (getPos as () => number)();
@@ -85,7 +85,7 @@ export class BulletListExtension extends NodeExtension<BulletListOptions> {
         dom.append(spine);
       }
 
-      const contentDOM = document.createElement('div');
+      const contentDOM = document.createElement('ul');
       contentDOM.classList.add(ExtensionListTheme.UL_LIST_CONTENT);
       dom.append(contentDOM);
 

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -3612,6 +3612,10 @@ button:active .remirror-menu-pane-shortcut,
   width: 24px;
   display: inline-block;
   text-align: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .remirror-list-item-checkbox {
@@ -3635,6 +3639,10 @@ button:active .remirror-menu-pane-shortcut,
   cursor: pointer;
   display: inline-block;
   vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   transition: background-color 0.25s ease;
   background-color: var(--rmr-color-border);
@@ -3657,6 +3665,10 @@ button:active .remirror-menu-pane-shortcut,
   left: -20px;
   width: 16px;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   transition: border-left-color 0.25s ease;
   border-left-color: var(--rmr-color-border);

--- a/packages/remirror__styles/extension-list.css
+++ b/packages/remirror__styles/extension-list.css
@@ -24,6 +24,10 @@
   width: 24px;
   display: inline-block;
   text-align: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .remirror-list-item-checkbox {
@@ -47,6 +51,10 @@
   cursor: pointer;
   display: inline-block;
   vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   transition: background-color 0.25s ease;
   background-color: var(--rmr-color-border);
@@ -69,6 +77,10 @@
   left: -20px;
   width: 16px;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   transition: border-left-color 0.25s ease;
   border-left-color: var(--rmr-color-border);

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -3641,6 +3641,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     width: 24px;
     display: inline-block;
     text-align: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 
   .remirror-list-item-checkbox {
@@ -3664,6 +3668,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     transition: background-color 0.25s ease;
     background-color: var(--rmr-color-border);
@@ -3686,6 +3694,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     left: -20px;
     width: 16px;
     cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     transition: border-left-color 0.25s ease;
     border-left-color: var(--rmr-color-border);

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -3683,6 +3683,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     width: 24px;
     display: inline-block;
     text-align: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 
   .remirror-list-item-checkbox {
@@ -3706,6 +3710,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     transition: background-color 0.25s ease;
     background-color: var(--rmr-color-border);
@@ -3728,6 +3736,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     left: -20px;
     width: 16px;
     cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     transition: border-left-color 0.25s ease;
     border-left-color: var(--rmr-color-border);

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -3682,6 +3682,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     width: 24px;
     display: inline-block;
     text-align: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 
   .remirror-list-item-checkbox {
@@ -3705,6 +3709,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     cursor: pointer;
     display: inline-block;
     vertical-align: middle;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     transition: background-color 0.25s ease;
     background-color: var(--rmr-color-border);
@@ -3727,6 +3735,10 @@ export const extensionListStyledCss: ReturnType<typeof css> = css`
     left: -20px;
     width: 16px;
     cursor: pointer;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     transition: border-left-color 0.25s ease;
     border-left-color: var(--rmr-color-border);

--- a/packages/remirror__theme/src/extension-list-theme.ts
+++ b/packages/remirror__theme/src/extension-list-theme.ts
@@ -31,6 +31,7 @@ export const LIST_ITEM_MARKER_CONTAINER = css`
   width: 24px;
   display: inline-block;
   text-align: center;
+  user-select: none;
 ` as 'remirror-list-item-marker-container';
 
 export const LIST_ITEM_CHECKBOX = css`
@@ -55,6 +56,7 @@ export const COLLAPSIBLE_LIST_ITEM_BUTTON = css`
   cursor: pointer;
   display: inline-block;
   vertical-align: middle;
+  user-select: none;
 
   transition: background-color 0.25s ease;
   background-color: ${getThemeVar('color', 'border')};
@@ -77,6 +79,7 @@ export const LIST_SPINE = css`
   left: -20px;
   width: 16px;
   cursor: pointer;
+  user-select: none;
 
   transition: border-left-color 0.25s ease;
   border-left-color: ${getThemeVar('color', 'border')};

--- a/packages/storybook-react/stories/extension-list/basic.tsx
+++ b/packages/storybook-react/stories/extension-list/basic.tsx
@@ -1,3 +1,5 @@
+import '@remirror/styles/all.css';
+
 import React from 'react';
 import {
   BulletListExtension,

--- a/packages/storybook-react/stories/extension-list/collapsible.tsx
+++ b/packages/storybook-react/stories/extension-list/collapsible.tsx
@@ -1,3 +1,5 @@
+import '@remirror/styles/all.css';
+
 import React from 'react';
 import {
   BulletListExtension,

--- a/packages/storybook-react/stories/extension-list/toggleable.tsx
+++ b/packages/storybook-react/stories/extension-list/toggleable.tsx
@@ -1,3 +1,5 @@
+import '@remirror/styles/all.css';
+
 import React from 'react';
 import {
   ExtensionTag,


### PR DESCRIPTION

### Description

Add CSS rule `user-select: none` to some no-selectable elements. This improves the selection behavior on touch screen. 


https://user-images.githubusercontent.com/24715727/203003298-69002526-9bdb-4828-bfc4-a3257f8f9458.MP4





Fix the DOM structure of bullet list with spine. `<ul>` should not contains `<div>`. I didn't see any weird bug related, but I think it's a good idea to make it right. 
  - Before: `<ul><div><li>...</li></div></ul>`
  - After: `<div><ul><li>...</li></ul></div>` 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
