### PR TITLE
fix(tables): apply table columns sizes when `editable=false`

### DIFF
--- a/.changeset/flat-kids-deny.md
+++ b/.changeset/flat-kids-deny.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-doc': minor
+'@remirror/core-utils': patch
+---
+
+Expose a helper for detecting doc changes from the default

--- a/.changeset/gold-games-act.md
+++ b/.changeset/gold-games-act.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-tables': patch
+---
+
+Apply table columns sizes when view not is editable. Fixes #1937

--- a/packages/remirror__core-utils/src/core-utils.ts
+++ b/packages/remirror__core-utils/src/core-utils.ts
@@ -380,7 +380,7 @@ export function isDocNodeEmpty(node: ProsemirrorNode): boolean {
   );
 }
 
-interface DefaultDocNodeOptions {
+export interface DefaultDocNodeOptions {
   /**
    * When true will not check any of the attributes for any of the nodes.
    */

--- a/packages/remirror__core-utils/src/index.ts
+++ b/packages/remirror__core-utils/src/index.ts
@@ -20,6 +20,7 @@ export {
 export type {
   CreateDocumentNodeProps,
   CustomDocumentProps,
+  DefaultDocNodeOptions,
   FragmentStringHandlerOptions,
   GetMarkRange,
   InvalidContentBlock,

--- a/packages/remirror__extension-doc/src/doc-extension.ts
+++ b/packages/remirror__extension-doc/src/doc-extension.ts
@@ -2,10 +2,15 @@ import {
   ApplySchemaAttributes,
   command,
   CommandFunction,
+  DefaultDocNodeOptions,
   EditorSchema,
+  EditorStateProps,
   entries,
   extension,
   ExtensionPriority,
+  Helper,
+  helper,
+  isDefaultDocNode,
   isPlainObject,
   NodeExtension,
   NodeExtensionSpec,
@@ -144,6 +149,14 @@ export class DocExtension extends NodeExtension<DocOptions> {
       return true;
     };
   }
+
+  @helper()
+  isDefaultDocNode({
+    state = this.store.getState(),
+    options,
+  }: IsDefaultDocNodeHelperOptions = {}): Helper<boolean> {
+    return isDefaultDocNode(state.doc, options);
+  }
 }
 
 interface SetDocAttrStepJSONValue {
@@ -224,6 +237,13 @@ export class SetDocAttributeStep extends Step {
       value: this.value,
     };
   }
+}
+
+interface IsDefaultDocNodeHelperOptions extends Partial<EditorStateProps> {
+  /**
+   * The options passed to the isDefaultDocNode util
+   */
+  options?: DefaultDocNodeOptions;
 }
 
 try {

--- a/packages/storybook-react/stories/extension-tables/not-editable.tsx
+++ b/packages/storybook-react/stories/extension-tables/not-editable.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { TableExtension } from 'remirror/extensions';
+import { EditorComponent, Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const content = `
+  <table>
+    <tr>
+      <td data-colwidth="113"><p>This</p></td>
+      <td data-colwidth="162"><p>editor</p></td>
+      <td><p>is non editable</p></td>
+    </tr>
+    <tr>
+      <td data-colwidth="113"><p>But</p></td>
+      <td data-colwidth="162"><p>table</p></td>
+      <td><p>columns widths are still applied</p></td>
+    </tr>
+    <tr>
+      <td data-colwidth="113"><p></p></td>
+      <td data-colwidth="162"><p></p></td>
+      <td><p></p></td>
+    </tr>
+  </table>
+`;
+
+const NotEditable = (): JSX.Element => {
+  const { manager, state } = useRemirror({ extensions, stringHandler: 'html', content });
+
+  return (
+    <ThemeProvider>
+      <Remirror manager={manager} initialContent={state} editable={false}>
+        <EditorComponent />
+      </Remirror>
+    </ThemeProvider>
+  );
+};
+
+const extensions = () => [new TableExtension()];
+
+export default NotEditable;

--- a/packages/storybook-react/stories/extension-tables/table.stories.tsx
+++ b/packages/storybook-react/stories/extension-tables/table.stories.tsx
@@ -1,4 +1,5 @@
 import Basic from './basic';
+import NotEditable from './not-editable';
 
-export { Basic };
+export { Basic, NotEditable };
 export default { title: 'Extensions / Tables (simple)' };

--- a/website/extension-examples/extension-tables/not-editable.tsx
+++ b/website/extension-examples/extension-tables/not-editable.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-tables/not-editable.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-tables/not-editable').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Description

Fixes #1937

Also adds a helper to the doc extension for determining if the doc content has been changed from the default

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
