### PR TITLE
fix(paste-rules): fix a crash when pasting nested content

### DIFF
--- a/.changeset/serious-pumas-destroy.md
+++ b/.changeset/serious-pumas-destroy.md
@@ -1,0 +1,6 @@
+---
+'jest-prosemirror': minor
+'jest-remirror': minor
+---
+
+Add `ProsemirrorTestChain.copied`. This is the copied content of selected content as an object with the `html` and `text` properties. The `text` property is the `text/plain` clipboard data. The `html` property is the `text/html` clipboard data.

--- a/.changeset/slow-pugs-argue.md
+++ b/.changeset/slow-pugs-argue.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Fixes the `Cannot read properties of null (reading 'lastChild')` error when pasting a part of a nested list from ProseMirror into ProseMirror with paste rules.

--- a/.changeset/strong-buses-vanish.md
+++ b/.changeset/strong-buses-vanish.md
@@ -1,0 +1,6 @@
+---
+'jest-prosemirror': minor
+'jest-remirror': minor
+---
+
+Improve `ProsemirrorTestChain.paste`. It's behavior is closer to ProseMirror's paste behavior. It now accepts an object with the `html` and `text` properties. The `text` property is used to set the `text/plain` clipboard data. The `html` property is used to set the `text/html` clipboard data. It also accepts an option `plainText` property which is used to simulate a plain text paste (e.g. press `Ctrl-Shift-V` or `Command-Shift-V`).

--- a/packages/jest-remirror/src/jest-remirror-editor.ts
+++ b/packages/jest-remirror/src/jest-remirror-editor.ts
@@ -1,6 +1,7 @@
 import { prettyDOM } from '@testing-library/dom';
 import {
   backspace,
+  copyContent,
   dispatchTextSelection,
   fireEventAtPosition,
   FireProps,
@@ -242,6 +243,13 @@ export class RemirrorTestChain<Extension extends AnyExtension> {
    */
   get end(): number {
     return this.state.selection.to;
+  }
+
+  /**
+   * The content to write to the clipboard if copy the current selection.
+   */
+  get copied(): { text: string; html: string } {
+    return copyContent({ view: this.view });
   }
 
   /**

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -274,7 +274,7 @@ describe('pasteRules', () => {
     it('should not create a slice with invalid open depth', () => {
       const plugin = pasteRules([
         {
-          regexp: /(@[a-z])/,
+          regexp: /(@[a-z]+)/,
           markType: schema.marks.strong,
           type: 'mark',
         },
@@ -324,7 +324,7 @@ describe('pasteRules', () => {
                       p('C'),
                       ul(
                         ///
-                        li(p(strong('bar'))),
+                        li(p(strong('@bar'))),
                       ),
                     ),
                   ),

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -116,8 +116,7 @@ export function pasteRules(pasteRules: PasteRule[]): Plugin {
         // paste rule might remove some other node from the fragment because of
         // its invalidity. So we need to check the opening to make sure that the
         // slice is still valid.
-        // return fixSliceOpening(slice);
-        return slice;
+        return fixSliceOpening(slice);
       },
       handleDOMEvents: {
         // Handle paste for pasting content.

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -111,6 +111,12 @@ export function pasteRules(pasteRules: PasteRule[]): Plugin {
           }
         }
 
+        // The `slice` passed to `transformPasted` might contain a invalid
+        // fragment (this is fine since slice has openStart and openEnd). The
+        // paste rule might remove some other node from the fragment because of
+        // its invalidity. So we need to check the opening to make sure that the
+        // slice is still valid.
+        // return fixSliceOpening(slice);
         return slice;
       },
       handleDOMEvents: {
@@ -672,4 +678,9 @@ function getDataTransferFiles(event: DragEvent): File[] {
   }
 
   return [];
+}
+
+function fixSliceOpening(slice: Slice): Slice {
+  const max = Slice.maxOpen(slice.content);
+  return max.openStart < slice.openStart || max.openEnd < slice.openEnd ? max : slice;
 }


### PR DESCRIPTION
### Description

This PR fixes the following crash. It took me so long to reproduce it : D 


https://user-images.githubusercontent.com/24715727/206516806-0b2510e1-c184-4e41-9e48-f53bf99de5ce.mp4


This PR also includes some improvement for the JSDOM unit test framework, as I need them to reproduce this bug with JSDOM. Check the changeset files for details. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
 