### PR TITLE
Restore useDocChanged as public api

### DIFF
--- a/packages/remirror__react-core/src/index.ts
+++ b/packages/remirror__react-core/src/index.ts
@@ -14,6 +14,7 @@ export {
   useChainedCommands,
   useCommands,
   useCurrentSelection,
+  useDocChanged,
   useEditorDomRef,
   useEditorState,
   useEditorView,


### PR DESCRIPTION
This was originally done in 1.0.38

### Description

Expose useful hook for developers to use

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
