### PR TITLE
feat(entity-reference): get references from arbitrary editor states

### DIFF
--- a/.changeset/angry-lions-trade.md
+++ b/.changeset/angry-lions-trade.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-entity-reference': minor
+---
+
+Entity references helpers can use other states than current state

--- a/.changeset/curly-monkeys-shave.md
+++ b/.changeset/curly-monkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-core': patch
+---
+
+Expose `useDocChanged` hook

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -269,10 +269,12 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
    * `joinDisjoinedEntityReferences`.
    */
   @helper()
-  getEntityReferences(): Helper<EntityReferenceMetaData[]> {
+  getEntityReferences(
+    state: EditorState = this.store.getState(),
+  ): Helper<EntityReferenceMetaData[]> {
     const entityReferences = getEntityReferencesFromPluginState({
       extension: this,
-      state: this.store.getState(),
+      state,
     }).flat();
     return joinDisjoinedEntityReferences(entityReferences);
   }
@@ -284,10 +286,13 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
    *
    */
   @helper()
-  getEntityReferenceById(entityReferenceId: string): Helper<EntityReferenceMetaData | undefined> {
+  getEntityReferenceById(
+    entityReferenceId: string,
+    state: EditorState = this.store.getState(),
+  ): Helper<EntityReferenceMetaData | undefined> {
     const entityReferences = getEntityReferencesFromPluginState({
       extension: this,
-      state: this.store.getState(),
+      state,
     }).flat();
     return joinDisjoinedEntityReferences(entityReferences).find(
       (entityReference) => entityReference.id === entityReferenceId,
@@ -301,8 +306,10 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
    *
    */
   @helper()
-  getEntityReferencesAt(pos?: PrimitiveSelection): Helper<EntityReferenceMetaData[]> {
-    const state = this.store.getState();
+  getEntityReferencesAt(
+    pos?: PrimitiveSelection,
+    state: EditorState = this.store.getState(),
+  ): Helper<EntityReferenceMetaData[]> {
     const { doc, selection } = state;
     const { from, to } = getTextSelection(pos ?? selection, doc);
 

--- a/packages/remirror__react-core/src/index.ts
+++ b/packages/remirror__react-core/src/index.ts
@@ -14,6 +14,7 @@ export {
   useChainedCommands,
   useCommands,
   useCurrentSelection,
+  useDocChanged,
   useEditorDomRef,
   useEditorState,
   useEditorView,


### PR DESCRIPTION
### Description

Most of our helpers allow passing an editor state param (which defaults to the current state), this is useful for plugins when you want to execute helpers on `prevState`.

This PR aligns the entity reference helpers with this pattern.

The PR also exposes `useDocChanged` as requested on Discord.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

