### PR TITLE
fix(entity-reference): add extra attributes via commands

### DIFF
--- a/.changeset/cold-peaches-beg.md
+++ b/.changeset/cold-peaches-beg.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-entity-reference': patch
+---
+
+Allow the adding of extra attributes via `addEntityReference` and return those attributes via the helpers

--- a/packages/remirror__extension-entity-reference/__tests__/entity-reference-extension.spec.ts
+++ b/packages/remirror__extension-entity-reference/__tests__/entity-reference-extension.spec.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import { pmBuild } from 'jest-prosemirror';
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import { createCoreManager } from 'remirror/extensions';
-import { prosemirrorNodeToHtml, uniqueArray } from '@remirror/core';
+import { BaseExtensionOptions, prosemirrorNodeToHtml, uniqueArray } from '@remirror/core';
 
 import { EntityReferenceExtension } from '../';
 import { EntityReferenceOptions } from '../src/types';
@@ -11,7 +11,9 @@ extensionValidityTest(EntityReferenceExtension);
 
 const DUMMY_TEXT = 'Lorem Ipsum is simply dummy text of the printing and typesetting industry.';
 
-function create(options: EntityReferenceOptions = {}) {
+interface Options extends EntityReferenceOptions, BaseExtensionOptions {}
+
+function create(options: Options = {}) {
   const { onClick, ...rest } = options;
 
   const entityReferenceExtension = new EntityReferenceExtension(rest);
@@ -397,6 +399,45 @@ describe('EntityReference marks', () => {
       view.someProp('handleClickOn', (fn) => fn(view, 5, node, 1, {} as MouseEvent, false));
       expect(onClick).toHaveBeenCalledTimes(1);
       expect(onClick).toHaveBeenCalledWith(entityReference2);
+    });
+  });
+
+  describe('extra attributes', () => {
+    beforeEach(() => {
+      ({
+        add,
+        nodes: { doc, p },
+        selectText,
+        helpers,
+        commands,
+        view,
+      } = create({
+        extraAttributes: {
+          entityType: {
+            default: null,
+            parseDOM: (dom: any) => dom.getAttribute('data-entity-type'),
+            toDOM: (attrs: any) => ['data-entity-type', attrs.entityType],
+          },
+        },
+      }));
+    });
+
+    it('can add and return extra attributes', () => {
+      add(doc(p('testing text')));
+      const entityReference = {
+        id: 'testId',
+        from: 1,
+        to: 8,
+        text: 'testing',
+        attrs: {
+          entityType: 'comment',
+        },
+      };
+      selectText({ from: entityReference.from, to: entityReference.to });
+      commands.addEntityReference(entityReference.id, entityReference.attrs);
+      const entityReferenceFromDoc = helpers.getEntityReferenceById(entityReference.id);
+
+      expect(entityReferenceFromDoc).toEqual(entityReference);
     });
   });
 });

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -15,6 +15,7 @@ import {
   MarkExtensionSpec,
   MarkSpecOverride,
   PrimitiveSelection,
+  ProsemirrorAttributes,
   ProsemirrorNode,
   Transaction,
   uniqueId,
@@ -170,10 +171,10 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
   }
 
   @command()
-  addEntityReference(id?: string): CommandFunction {
+  addEntityReference(id?: string, attrs: ProsemirrorAttributes = {}): CommandFunction {
     return ({ state, tr, dispatch }) => {
       const { from, to } = state.selection;
-      const newMark = this.type.create({ id: id ?? uniqueId() });
+      const newMark = this.type.create({ ...attrs, id: id ?? uniqueId() });
       try {
         tr = tr.addMark(from, to, newMark);
       } catch (error: any) {

--- a/packages/remirror__extension-entity-reference/src/types.ts
+++ b/packages/remirror__extension-entity-reference/src/types.ts
@@ -1,4 +1,10 @@
-import type { AcceptUndefined, Decoration, FromToProps, Handler } from '@remirror/core';
+import type {
+  AcceptUndefined,
+  Decoration,
+  FromToProps,
+  Handler,
+  ProsemirrorAttributes,
+} from '@remirror/core';
 
 export interface EntityReferenceAttributes {
   /**
@@ -12,6 +18,11 @@ export interface EntityReferenceMetaData extends EntityReferenceAttributes, From
    * Text content of the node
    */
   text: string;
+
+  /**
+   * Only present if you have configured extra attributes for the entity reference mark
+   */
+  attrs?: ProsemirrorAttributes;
 }
 
 export type OmitId<Type extends EntityReferenceMetaData> = Omit<Type, 'id'>;

--- a/packages/remirror__extension-entity-reference/src/utils/disjoined-entity-references.ts
+++ b/packages/remirror__extension-entity-reference/src/utils/disjoined-entity-references.ts
@@ -16,10 +16,20 @@ export function getDisjoinedEntityReferencesFromNode(
   markTypeName: string,
 ): EntityReferenceMetaData[] {
   const isEntityReference = (mark: Mark) => mark.type.name === markTypeName;
-  return node.marks.filter(isEntityReference).map((mark: Mark) => ({
-    from: pos,
-    to: pos + Math.max(node.textContent.length, 1),
-    id: mark.attrs.id,
-    text: node.textContent,
-  }));
+  return node.marks.filter(isEntityReference).map((mark: Mark) => {
+    const { id, ...rest } = mark.attrs;
+
+    const metaData: EntityReferenceMetaData = {
+      from: pos,
+      to: pos + Math.max(node.textContent.length, 1),
+      id,
+      text: node.textContent,
+    };
+
+    if (Object.keys(rest).length > 0) {
+      metaData.attrs = rest;
+    }
+
+    return metaData;
+  });
 }


### PR DESCRIPTION
### Description

Currently entity reference commands only allow you to add the `id` attributes.

This change fixes that to allow for additional attributes, and returns those attributes via the helpers

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

