### PR TITLE
refactor(core): don't reconfigure plugins when updating keymap

### DIFF
--- a/.changeset/silver-cats-tickle.md
+++ b/.changeset/silver-cats-tickle.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core': patch
+---
+
+When updating keymap bindings (e.g. with `useKeymap(...)` React hook), `KeymapExtension` won't trigger an editor state update anymore and it also won't [reconfigure](https://prosemirror.net/docs/ref/#state.EditorState.reconfigure) all plugins. This could bring a significant performance boost because some plugins (e.g. `YjsExtension`) are expensive to reconfigure.


### PR DESCRIPTION
### Description

This PR is a performance optimization by NOT calling `this.store.updateExtensionPlugins` when updating keymaps. See the changeset file for more details. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
 