### PR TITLE
docs: replace create-react-app with vite

### DIFF
--- a/docs/5-min-tutorial.md
+++ b/docs/5-min-tutorial.md
@@ -16,11 +16,11 @@ You need to have a recent Node version installed.
 
 ### Installation
 
-First, let's set up a basic React app with [CRA](https://reactjs.org/docs/create-a-new-react-app.html):
+First, let's set up a basic React app with [Vite](https://vitejs.dev/guide/):
 
 ```bash type=installation
-npx create-react-app cra-remirror --template typescript
-cd cra-remirror
+npx create-vite vite-remirror --template react-ts
+cd vite-remirror
 ```
 
 Next, we're installing Remirror:
@@ -50,7 +50,7 @@ export default App;
 Let's run the app:
 
 ```bash
-npm run start
+npm run dev
 ```
 
 :::tip Hooray!


### PR DESCRIPTION
### Description

This PR replaces create-react-app with Vite in the docs. Close https://github.com/remirror/remirror/issues/1970. 

I've see lots of building issues with create-react-app, which won't occur in other webpack-based tools (i.e. Next.js). CRA is not a good default anymore for a React project IMH. I would recommend Next.js and/or Vite today. Vite is more lightweight so I'd like to put it in our tutorial. 

--- 

Here is just a simple benchmark example. While `create-react-app` needs one minute, `create-vite` only needs two seconds. 🤦‍♂️

```bash
$ time npx --yes create-vite vite-remirror-3 --template react-ts
1.672 total
$ time npx --yes create-react-app cra-remirror-3 --template typescript 
1:28.38 total
```

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
