### PR TITLE
fix(core): don't call `super()` conditional

### DIFF
--- a/.changeset/hot-drinks-knock.md
+++ b/.changeset/hot-drinks-knock.md
@@ -2,4 +2,4 @@
 '@remirror/core-helpers': patch
 ---
 
-This is a workaround for the Babel issue when using create-react-app with Remirror. See https://github.com/remirror/remirror/issues/1970 for more details.
+This is a workaround for a Babel issue when using create-react-app with Remirror. See https://github.com/remirror/remirror/issues/1970 for more details.

--- a/.changeset/hot-drinks-knock.md
+++ b/.changeset/hot-drinks-knock.md
@@ -1,0 +1,5 @@
+---
+'@remirror/core-helpers': patch
+---
+
+This is a workaround for the Babel issue when using create-react-app with Remirror. See https://github.com/remirror/remirror/issues/1970 for more details.

--- a/packages/remirror__core-helpers/src/core-errors.ts
+++ b/packages/remirror__core-helpers/src/core-errors.ts
@@ -109,15 +109,8 @@ export class RemirrorError extends BaseError {
    * The constructor is intentionally kept private to prevent being extended from.
    */
   private constructor({ code, message, disableLogging = false }: RemirrorErrorOptions = {}) {
-    let errorCode: ErrorConstant;
-
-    if (isErrorConstant(code)) {
-      errorCode = code;
-      super(createErrorMessage(errorCode, message));
-    } else {
-      errorCode = ErrorConstant.CUSTOM;
-      super(createErrorMessage(errorCode, message));
-    }
+    const errorCode: ErrorConstant = isErrorConstant(code) ? code : ErrorConstant.CUSTOM;
+    super(createErrorMessage(errorCode, message));
 
     this.errorCode = errorCode;
     this.url = `${ERROR_INFORMATION_URL}#${errorCode.toLowerCase()}`;


### PR DESCRIPTION
### Description

This is a workaround for https://github.com/remirror/remirror/issues/1970, by removing the `__super = (...args) => ...` function in the compiled code. 

The compiled code before this PR:

```
// remirror/packages/remirror__core-helpers/dist/remirror-core-helpers.js
var RemirrorError = class extends BaseError2 {
  constructor({ code, message, disableLogging = false } = {}) {
    var __super = (...args) => {
      super(...args);
      __publicField(this, "errorCode");
      __publicField(this, "url");
    };
    let errorCode;
    if (isErrorConstant(code)) {
      errorCode = code;
      __super(createErrorMessage(errorCode, message));
    } else {
      errorCode = ErrorConstant.CUSTOM;
      __super(createErrorMessage(errorCode, message));
    }
```

After this PR:

```
// remirror/packages/remirror__core-helpers/dist/remirror-core-helpers.js
var RemirrorError = class extends BaseError2 {
  constructor({ code, message, disableLogging = false } = {}) {
    const errorCode = isErrorConstant(code) ? code : ErrorConstant.CUSTOM;
    super(createErrorMessage(errorCode, message));
```


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
