### PR TITLE
feat(jest-remirror): polyfill for `element.scrollIntoView`

### DIFF
--- a/.changeset/lovely-carpets-jog.md
+++ b/.changeset/lovely-carpets-jog.md
@@ -1,0 +1,5 @@
+---
+'jest-remirror': patch
+---
+
+Add jsdom polyfill for `element.scrollIntoView`.

--- a/packages/jest-remirror/src/jsdom-polyfills.ts
+++ b/packages/jest-remirror/src/jsdom-polyfills.ts
@@ -18,6 +18,7 @@ export function jsdomPolyfill(): void {
   supportInnerTextInAnchors();
   supportRanges();
   supportAdjustableSizes();
+  supportScrollIntoView();
 }
 
 /**
@@ -209,4 +210,13 @@ function supportAdjustableSizes() {
       value: document.documentElement.scrollHeight,
     },
   });
+}
+
+/**
+ * Add support for `element.scrollIntoView` in jsdom.
+ *
+ * See also https://github.com/jsdom/jsdom/issues/1695
+ */
+function supportScrollIntoView() {
+  Element.prototype.scrollIntoView = () => {};
 }


### PR DESCRIPTION
### Description

This PR adds a polyfill for `element.scrollIntoView` in JSDOM environment. I see this issue outside the Remirror repo but I think it's not a bad idea to polyfill it on the Remirror side. 

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
