### PR TITLE
fix(extension-events): fix marks matching for hover event

### DIFF
--- a/.changeset/beige-jokes-juggle.md
+++ b/.changeset/beige-jokes-juggle.md
@@ -2,4 +2,4 @@
 '@remirror/extension-events': patch
 ---
 
-This patch fixes an issue where `useHover` cannot catch the marks with [`inclusive`](https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive) set to `false`.
+This patch fixes an issue where `EventsExtension` cannot get the marks with `inclusive` set to `false` <https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive> for a `hover` event.

--- a/.changeset/beige-jokes-juggle.md
+++ b/.changeset/beige-jokes-juggle.md
@@ -2,4 +2,4 @@
 '@remirror/extension-events': patch
 ---
 
-This patch fixes an issue where `EventsExtension` cannot get the marks with `inclusive` set to `false` <https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive> for a `hover` event.
+This patch fixes an issue where `EventsExtension` cannot get the marks with [`inclusive`](https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive) set to `false` for a `hover` event.

--- a/.changeset/beige-jokes-juggle.md
+++ b/.changeset/beige-jokes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': patch
+---
+
+This patch fixes an issue where `useHover` cannot catch the marks with [`inclusive`](https://prosemirror.net/docs/ref/#model.MarkSpec.inclusive) set to `false`.

--- a/packages/remirror__extension-events/__tests__/events-extension.spec.ts
+++ b/packages/remirror__extension-events/__tests__/events-extension.spec.ts
@@ -152,7 +152,7 @@ describe('events', () => {
     expect(hoverHandler.mock.calls[3]?.[1]?.getNode).toBeFunction();
     expect(hoverHandler.mock.calls[3]?.[1]).toHaveProperty('hovering', false);
     expect(hoverHandler.mock.calls[3]?.[1]?.marks).toHaveLength(1);
-    expect(hoverHandler.mock.calls[2]?.[1]?.marks[0].mark.type.name).toBe('link');
+    expect(hoverHandler.mock.calls[3]?.[1]?.marks[0].mark.type.name).toBe('link');
   });
 
   it('responds to editor `contextmenu` events', () => {

--- a/packages/remirror__extension-events/src/events-extension.ts
+++ b/packages/remirror__extension-events/src/events-extension.ts
@@ -529,7 +529,7 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
       // The marks wrapping the captured position.
       const marks: GetMarkRange[] = [];
 
-      const { inside } = eventPosition;
+      const { inside, pos } = eventPosition;
 
       // This handle the case when the context menu click has no corresponding
       // nodes or marks because it's outside of any editor content.
@@ -538,7 +538,7 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
       }
 
       // Retrieve the resolved position from the current state.
-      const $pos = view.state.doc.resolve(inside);
+      const $pos = view.state.doc.resolve(pos);
 
       // The depth of the current node (which is a direct match)
       const currentNodeDepth = $pos.depth + 1;
@@ -552,7 +552,7 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
       }
 
       // Populate the marks.
-      for (const { type } of $pos.marks()) {
+      for (const { type } of $pos.marksAcross($pos) ?? []) {
         const range = getMarkRange($pos, type);
 
         if (range) {


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

This PR fixes the marks matching when use `useHover`. 

```
useHover((event, {marks}) => { console.log(marks) })
```

I wrote a test case to reproduce the origin bug. 

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
