### PR TITLE
Allow disabling the placeholder

### DIFF
--- a/packages/remirror__extension-placeholder/src/placeholder-extension.ts
+++ b/packages/remirror__extension-placeholder/src/placeholder-extension.ts
@@ -23,6 +23,11 @@ export interface PlaceholderOptions {
    * then you will also need to apply your own styles.
    */
   emptyNodeClass?: string;
+
+  /**
+   * Disable the placeholder extension.
+   */
+  disabled?: boolean;
 }
 
 export interface PlaceholderPluginState extends Required<PlaceholderOptions> {
@@ -37,6 +42,7 @@ export interface PlaceholderPluginState extends Required<PlaceholderOptions> {
   defaultOptions: {
     emptyNodeClass: ExtensionPlaceholderTheme.IS_EMPTY,
     placeholder: '',
+    disabled: false,
   },
 })
 export class PlaceholderExtension extends PlainExtension<PlaceholderOptions> {
@@ -123,7 +129,11 @@ function applyState(props: ApplyStateProps) {
 function createDecorationSet(props: SharedProps) {
   const { extension, state } = props;
   const { empty } = extension.pluginKey.getState(state) as PlaceholderPluginState;
-  const { emptyNodeClass, placeholder } = extension.options;
+  const { emptyNodeClass, placeholder, disabled } = extension.options;
+
+  if (disabled) {
+    return null;
+  }
 
   if (!empty) {
     return null;

--- a/packages/remirror__preset-react/src/react-extension.ts
+++ b/packages/remirror__preset-react/src/react-extension.ts
@@ -39,6 +39,7 @@ export class ReactExtension extends PlainExtension<ReactExtensionOptions> {
     const {
       emptyNodeClass,
       placeholder,
+      disabled,
       defaultBlockNode,
       defaultContentNode,
       defaultEnvironment,
@@ -50,6 +51,7 @@ export class ReactExtension extends PlainExtension<ReactExtensionOptions> {
       new PlaceholderExtension({
         emptyNodeClass,
         placeholder,
+        disabled,
         priority: ExtensionPriority.Low,
       }),
       new ReactComponentExtension({


### PR DESCRIPTION
### Summary

When at least two users are collaborating (for example using the `WebrtcProvider`) and a user selects all and deletes the document becomes `empty`. This triggers the `PlaceholderExtension` which creates a decoration node for the placeholder message. Typing (collaborative) becomes disabled in the editing user window until they hit `enter`. This is because the node position / selection is confused and YJS can't sync.  

This allows you to disable the decorations in the placeholder. In general, I feel like this approach solves the issue (which is why I've opened this PR) but doesn't feel ergonomic. It would be better to remove the extension altogether in this case.

Fixes https://github.com/remirror/remirror/issues/1993
