### PR TITLE
fix(paste-rules): update typescript type

### DIFF
--- a/.changeset/popular-maps-fail.md
+++ b/.changeset/popular-maps-fail.md
@@ -2,5 +2,4 @@
 'prosemirror-paste-rules': patch
 ---
 
-Update the type for `BaseRegexPasteRule.getAttributes`. Now you can use `match.groups` in `getAttributes` callback.  
-
+Update the type for `BaseRegexPasteRule.getAttributes`. Now you can use `match.groups` in `getAttributes` callback.

--- a/.changeset/popular-maps-fail.md
+++ b/.changeset/popular-maps-fail.md
@@ -1,0 +1,6 @@
+---
+'prosemirror-paste-rules': patch
+---
+
+Update the type for `BaseRegexPasteRule.getAttributes`. Now you can use `match.groups` in `getAttributes` callback.  
+

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -255,7 +255,7 @@ interface BaseContentPasteRule extends BaseRegexPasteRule {
    */
   getAttributes?:
     | Record<string, unknown>
-    | ((match: string[], isReplacement: boolean) => Record<string, unknown> | undefined);
+    | ((match: RegExpExecArray, isReplacement: boolean) => Record<string, unknown> | undefined);
 }
 
 /**


### PR DESCRIPTION
### Description

This PR allows users to write TS code like something below in TypeScript 4.9:

```ts

  createPasteRules(): NodePasteRule[] {
    return [
      {
        type: 'node',
        nodeType: this.store.schema.nodes.tweet,
        regexp: TWITTER_STATUS_REGEX,
        getAttributes: (match: RegExpMatchArray) => {
          const url = `https://twitter.com/${match.groups?.user_id}/status/${match.groups?.tweet_id}`
          return {url, 'data-preview': '1'}
        },
      },
    ]
  }

```

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
