### PR TITLE
fix(react-components): add wrapper to buttons to eliminate MUI tooltip error

### DIFF
--- a/.changeset/strong-bags-hunt.md
+++ b/.changeset/strong-bags-hunt.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-components': patch
+---
+
+Fixed MUI tooltip error for buttons

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -675,15 +675,7 @@
     "name": "@remirror/extension-yjs",
     "limit": "115 KB",
     "path": "packages/remirror__extension-yjs/dist/remirror-extension-yjs.js",
-    "ignore": [
-      "@remirror/pm",
-      "prosemirror-model",
-      "prosemirror-state",
-      "prosemirror-view",
-      "yjs",
-      "@remirror/core",
-      "@remirror/messages"
-    ],
+    "ignore": ["@remirror/pm", "yjs", "@remirror/core", "@remirror/messages"],
     "running": false,
     "gzip": true
   },

--- a/packages/remirror__react-components/src/buttons/command-button.tsx
+++ b/packages/remirror__react-components/src/buttons/command-button.tsx
@@ -1,4 +1,4 @@
-import { ToggleButton, ToggleButtonProps, Tooltip } from '@mui/material';
+import { Box, ToggleButton, ToggleButtonProps, Tooltip } from '@mui/material';
 import React, { FC, MouseEvent, MouseEventHandler, ReactNode, useCallback } from 'react';
 import { CoreIcon, isString } from '@remirror/core';
 
@@ -58,42 +58,46 @@ export const CommandButton: FC<CommandButtonProps> = ({
 
   return (
     <Tooltip title={`${tooltipText}${shortcutText}`}>
-      <ToggleButton
-        aria-label={labelText}
-        selected={active}
-        disabled={!enabled}
-        onMouseDown={handleMouseDown}
-        color='primary'
-        size='small'
-        sx={{
-          padding: '6px 12px',
-          '&.Mui-selected': {
-            backgroundColor: 'primary.main',
-            color: 'primary.contrastText',
-          },
-          '&.Mui-selected:hover': {
-            backgroundColor: 'primary.dark',
-            color: 'primary.contrastText',
-          },
-          '&:not(:first-of-type)': {
-            marginLeft: '-1px',
-            borderLeft: '1px solid transparent',
-            borderTopLeftRadius: 0,
-            borderBottomLeftRadius: 0,
-          },
-          '&:not(:last-of-type)': {
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0,
-          },
-        }}
-        {...rest}
-        value={commandName}
-        onChange={handleChange}
-      >
-        <CommandButtonBadge icon={commandOptions.icon}>
-          <CommandButtonIcon icon={icon ?? fallbackIcon} />
-        </CommandButtonBadge>
-      </ToggleButton>
+      {/*
+        This Box<span> wrapper fixes an MUI tooltip error when the button is disabled.
+      */}
+      <Box component='span' sx={{ '&:not(:first-of-type)': { marginLeft: '-1px' } }}>
+        <ToggleButton
+          aria-label={labelText}
+          selected={active}
+          disabled={!enabled}
+          onMouseDown={handleMouseDown}
+          color='primary'
+          size='small'
+          sx={{
+            padding: '6px 12px',
+            '&.Mui-selected': {
+              backgroundColor: 'primary.main',
+              color: 'primary.contrastText',
+            },
+            '&.Mui-selected:hover': {
+              backgroundColor: 'primary.dark',
+              color: 'primary.contrastText',
+            },
+            '&:not(:first-of-type)': {
+              borderLeft: '1px solid transparent',
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0,
+            },
+            '&:not(:last-of-type)': {
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
+            },
+          }}
+          {...rest}
+          value={commandName}
+          onChange={handleChange}
+        >
+          <CommandButtonBadge icon={commandOptions.icon}>
+            <CommandButtonIcon icon={icon ?? fallbackIcon} />
+          </CommandButtonBadge>
+        </ToggleButton>
+      </Box>
     </Tooltip>
   );
 };


### PR DESCRIPTION
### Description

Closes #1901

(Added bonus is now tooltips work on inactive buttons as well)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
