### PR TITLE
feat: add theme customization support for react-editors

### DIFF
--- a/.changeset/ten-wolves-own.md
+++ b/.changeset/ten-wolves-own.md
@@ -1,0 +1,5 @@
+---
+'@remirror/react-editors': patch
+---
+
+Add a new prop `theme` to `MarkdownEditor`, `SocialEditor` and `WysiwygEditor`.

--- a/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
+++ b/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
@@ -1,9 +1,9 @@
-import "@remirror/styles/all.css";
+import '@remirror/styles/all.css';
 
-import React, { FC, PropsWithChildren, useCallback } from "react";
-import jsx from "refractor/lang/jsx.js";
-import typescript from "refractor/lang/typescript.js";
-import { ExtensionPriority } from "remirror";
+import React, { FC, PropsWithChildren, useCallback } from 'react';
+import jsx from 'refractor/lang/jsx.js';
+import typescript from 'refractor/lang/typescript.js';
+import { ExtensionPriority } from 'remirror';
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -21,22 +21,21 @@ import {
   StrikeExtension,
   TableExtension,
   TrailingNodeExtension,
-} from "remirror/extensions";
+} from 'remirror/extensions';
 import {
   EditorComponent,
   MarkdownToolbar,
   Remirror,
   ThemeProvider,
   useRemirror,
-} from "@remirror/react";
-import { AllStyledComponent } from "@remirror/styles/emotion";
+} from '@remirror/react';
+import { AllStyledComponent } from '@remirror/styles/emotion';
 
-import { ReactEditorProps } from "../types";
+import { ReactEditorProps } from '../types';
 
-export default { title: "Editors / Markdown" };
+export default { title: 'Editors / Markdown' };
 
-export interface MarkdownEditorProps
-  extends Partial<Omit<ReactEditorProps, "stringHandler">> {}
+export interface MarkdownEditorProps extends Partial<Omit<ReactEditorProps, 'stringHandler'>> {}
 
 /**
  * The editor which is used to create the annotation. Supports formatting.
@@ -73,12 +72,12 @@ export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
        */
       new HardBreakExtension(),
     ],
-    [placeholder]
+    [placeholder],
   );
 
   const { manager } = useRemirror({
     extensions,
-    stringHandler: "markdown",
+    stringHandler: 'markdown',
   });
 
   return (

--- a/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
+++ b/packages/remirror__react-editors/src/markdown/markdown-editor.tsx
@@ -1,9 +1,9 @@
-import '@remirror/styles/all.css';
+import "@remirror/styles/all.css";
 
-import React, { FC, PropsWithChildren, useCallback } from 'react';
-import jsx from 'refractor/lang/jsx.js';
-import typescript from 'refractor/lang/typescript.js';
-import { ExtensionPriority } from 'remirror';
+import React, { FC, PropsWithChildren, useCallback } from "react";
+import jsx from "refractor/lang/jsx.js";
+import typescript from "refractor/lang/typescript.js";
+import { ExtensionPriority } from "remirror";
 import {
   BlockquoteExtension,
   BoldExtension,
@@ -21,21 +21,22 @@ import {
   StrikeExtension,
   TableExtension,
   TrailingNodeExtension,
-} from 'remirror/extensions';
+} from "remirror/extensions";
 import {
   EditorComponent,
   MarkdownToolbar,
   Remirror,
   ThemeProvider,
   useRemirror,
-} from '@remirror/react';
-import { AllStyledComponent } from '@remirror/styles/emotion';
+} from "@remirror/react";
+import { AllStyledComponent } from "@remirror/styles/emotion";
 
-import { ReactEditorProps } from '../types';
+import { ReactEditorProps } from "../types";
 
-export default { title: 'Editors / Markdown' };
+export default { title: "Editors / Markdown" };
 
-export interface MarkdownEditorProps extends Partial<Omit<ReactEditorProps, 'stringHandler'>> {}
+export interface MarkdownEditorProps
+  extends Partial<Omit<ReactEditorProps, "stringHandler">> {}
 
 /**
  * The editor which is used to create the annotation. Supports formatting.
@@ -43,6 +44,7 @@ export interface MarkdownEditorProps extends Partial<Omit<ReactEditorProps, 'str
 export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
   placeholder,
   children,
+  theme,
   ...rest
 }) => {
   const extensions = useCallback(
@@ -56,7 +58,10 @@ export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
       new BlockquoteExtension(),
       new BulletListExtension({ enableSpine: true }),
       new OrderedListExtension(),
-      new ListItemExtension({ priority: ExtensionPriority.High, enableCollapsible: true }),
+      new ListItemExtension({
+        priority: ExtensionPriority.High,
+        enableCollapsible: true,
+      }),
       new CodeExtension(),
       new CodeBlockExtension({ supportedLanguages: [jsx, typescript] }),
       new TrailingNodeExtension(),
@@ -68,17 +73,17 @@ export const MarkdownEditor: FC<PropsWithChildren<MarkdownEditorProps>> = ({
        */
       new HardBreakExtension(),
     ],
-    [placeholder],
+    [placeholder]
   );
 
   const { manager } = useRemirror({
     extensions,
-    stringHandler: 'markdown',
+    stringHandler: "markdown",
   });
 
   return (
     <AllStyledComponent>
-      <ThemeProvider>
+      <ThemeProvider theme={theme}>
         <Remirror manager={manager} autoFocus {...rest}>
           <MarkdownToolbar />
           <EditorComponent />

--- a/packages/remirror__react-editors/src/social/social-editor.tsx
+++ b/packages/remirror__react-editors/src/social/social-editor.tsx
@@ -1,20 +1,14 @@
-import React, {
-  FC,
-  PropsWithChildren,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
-import { IdentifierSchemaAttributes } from "remirror";
+import React, { FC, PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { IdentifierSchemaAttributes } from 'remirror';
 import {
   EmojiExtension,
   MentionAtomExtension,
   MentionAtomNodeAttributes,
   PlaceholderExtension,
   wysiwygPreset,
-} from "remirror/extensions";
-import data from "svgmoji/emoji.json";
-import { TableExtension } from "@remirror/extension-react-tables";
+} from 'remirror/extensions';
+import data from 'svgmoji/emoji.json';
+import { TableExtension } from '@remirror/extension-react-tables';
 import {
   EditorComponent,
   EmojiPopupComponent,
@@ -24,27 +18,27 @@ import {
   TableComponents,
   ThemeProvider,
   useRemirror,
-} from "@remirror/react";
-import { AllStyledComponent } from "@remirror/styles/emotion";
+} from '@remirror/react';
+import { AllStyledComponent } from '@remirror/styles/emotion';
 
-import { BubbleMenu } from "../components/bubble-menu";
-import { TopToolbar } from "../components/top-toolbar";
-import { ReactEditorProps } from "../types";
+import { BubbleMenu } from '../components/bubble-menu';
+import { TopToolbar } from '../components/top-toolbar';
+import { ReactEditorProps } from '../types';
 
 const extraAttributes: IdentifierSchemaAttributes[] = [
   {
-    identifiers: ["mention", "emoji"],
-    attributes: { role: { default: "presentation" } },
+    identifiers: ['mention', 'emoji'],
+    attributes: { role: { default: 'presentation' } },
   },
-  { identifiers: ["mention"], attributes: { href: { default: null } } },
+  { identifiers: ['mention'], attributes: { href: { default: null } } },
 ];
 
 export interface SocialEditorProps
   extends Partial<ReactEditorProps>,
-    Pick<MentionComponentProps, "users" | "tags"> {}
+    Pick<MentionComponentProps, 'users' | 'tags'> {}
 
 interface MentionComponentProps<
-  UserData extends MentionAtomNodeAttributes = MentionAtomNodeAttributes
+  UserData extends MentionAtomNodeAttributes = MentionAtomNodeAttributes,
 > {
   users?: UserData[];
   tags?: string[];
@@ -54,23 +48,21 @@ function MentionComponent({ users, tags }: MentionComponentProps) {
   const [mentionState, setMentionState] = useState<MentionAtomState | null>();
   const tagItems = useMemo(
     () => (tags ?? []).map((tag) => ({ id: tag, label: `#${tag}` })),
-    [tags]
+    [tags],
   );
   const items = useMemo(() => {
     if (!mentionState) {
       return [];
     }
 
-    const allItems = mentionState.name === "at" ? users : tagItems;
+    const allItems = mentionState.name === 'at' ? users : tagItems;
 
     if (!allItems) {
       return [];
     }
 
-    const query = mentionState.query.full.toLowerCase() ?? "";
-    return allItems
-      .filter((item) => item.label.toLowerCase().includes(query))
-      .sort();
+    const query = mentionState.query.full.toLowerCase() ?? '';
+    return allItems.filter((item) => item.label.toLowerCase().includes(query)).sort();
   }, [mentionState, users, tagItems]);
 
   return <MentionAtomPopupComponent onChange={setMentionState} items={items} />;
@@ -91,14 +83,14 @@ export const SocialEditor: FC<PropsWithChildren<SocialEditorProps>> = ({
       new TableExtension(),
       new MentionAtomExtension({
         matchers: [
-          { name: "at", char: "@" },
-          { name: "tag", char: "#" },
+          { name: 'at', char: '@' },
+          { name: 'tag', char: '#' },
         ],
       }),
-      new EmojiExtension({ plainText: false, data, moji: "noto" }),
+      new EmojiExtension({ plainText: false, data, moji: 'noto' }),
       ...wysiwygPreset(),
     ],
-    [placeholder]
+    [placeholder],
   );
 
   const { manager } = useRemirror({

--- a/packages/remirror__react-editors/src/social/social-editor.tsx
+++ b/packages/remirror__react-editors/src/social/social-editor.tsx
@@ -1,14 +1,20 @@
-import React, { FC, PropsWithChildren, useCallback, useMemo, useState } from 'react';
-import { IdentifierSchemaAttributes } from 'remirror';
+import React, {
+  FC,
+  PropsWithChildren,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { IdentifierSchemaAttributes } from "remirror";
 import {
   EmojiExtension,
   MentionAtomExtension,
   MentionAtomNodeAttributes,
   PlaceholderExtension,
   wysiwygPreset,
-} from 'remirror/extensions';
-import data from 'svgmoji/emoji.json';
-import { TableExtension } from '@remirror/extension-react-tables';
+} from "remirror/extensions";
+import data from "svgmoji/emoji.json";
+import { TableExtension } from "@remirror/extension-react-tables";
 import {
   EditorComponent,
   EmojiPopupComponent,
@@ -18,24 +24,27 @@ import {
   TableComponents,
   ThemeProvider,
   useRemirror,
-} from '@remirror/react';
-import { AllStyledComponent } from '@remirror/styles/emotion';
+} from "@remirror/react";
+import { AllStyledComponent } from "@remirror/styles/emotion";
 
-import { BubbleMenu } from '../components/bubble-menu';
-import { TopToolbar } from '../components/top-toolbar';
-import { ReactEditorProps } from '../types';
+import { BubbleMenu } from "../components/bubble-menu";
+import { TopToolbar } from "../components/top-toolbar";
+import { ReactEditorProps } from "../types";
 
 const extraAttributes: IdentifierSchemaAttributes[] = [
-  { identifiers: ['mention', 'emoji'], attributes: { role: { default: 'presentation' } } },
-  { identifiers: ['mention'], attributes: { href: { default: null } } },
+  {
+    identifiers: ["mention", "emoji"],
+    attributes: { role: { default: "presentation" } },
+  },
+  { identifiers: ["mention"], attributes: { href: { default: null } } },
 ];
 
 export interface SocialEditorProps
   extends Partial<ReactEditorProps>,
-    Pick<MentionComponentProps, 'users' | 'tags'> {}
+    Pick<MentionComponentProps, "users" | "tags"> {}
 
 interface MentionComponentProps<
-  UserData extends MentionAtomNodeAttributes = MentionAtomNodeAttributes,
+  UserData extends MentionAtomNodeAttributes = MentionAtomNodeAttributes
 > {
   users?: UserData[];
   tags?: string[];
@@ -45,21 +54,23 @@ function MentionComponent({ users, tags }: MentionComponentProps) {
   const [mentionState, setMentionState] = useState<MentionAtomState | null>();
   const tagItems = useMemo(
     () => (tags ?? []).map((tag) => ({ id: tag, label: `#${tag}` })),
-    [tags],
+    [tags]
   );
   const items = useMemo(() => {
     if (!mentionState) {
       return [];
     }
 
-    const allItems = mentionState.name === 'at' ? users : tagItems;
+    const allItems = mentionState.name === "at" ? users : tagItems;
 
     if (!allItems) {
       return [];
     }
 
-    const query = mentionState.query.full.toLowerCase() ?? '';
-    return allItems.filter((item) => item.label.toLowerCase().includes(query)).sort();
+    const query = mentionState.query.full.toLowerCase() ?? "";
+    return allItems
+      .filter((item) => item.label.toLowerCase().includes(query))
+      .sort();
   }, [mentionState, users, tagItems]);
 
   return <MentionAtomPopupComponent onChange={setMentionState} items={items} />;
@@ -71,6 +82,7 @@ export const SocialEditor: FC<PropsWithChildren<SocialEditorProps>> = ({
   children,
   users,
   tags,
+  theme,
   ...rest
 }) => {
   const extensions = useCallback(
@@ -79,21 +91,25 @@ export const SocialEditor: FC<PropsWithChildren<SocialEditorProps>> = ({
       new TableExtension(),
       new MentionAtomExtension({
         matchers: [
-          { name: 'at', char: '@' },
-          { name: 'tag', char: '#' },
+          { name: "at", char: "@" },
+          { name: "tag", char: "#" },
         ],
       }),
-      new EmojiExtension({ plainText: false, data, moji: 'noto' }),
+      new EmojiExtension({ plainText: false, data, moji: "noto" }),
       ...wysiwygPreset(),
     ],
-    [placeholder],
+    [placeholder]
   );
 
-  const { manager } = useRemirror({ extensions, extraAttributes, stringHandler });
+  const { manager } = useRemirror({
+    extensions,
+    extraAttributes,
+    stringHandler,
+  });
 
   return (
     <AllStyledComponent>
-      <ThemeProvider>
+      <ThemeProvider theme={theme}>
         <Remirror manager={manager} {...rest}>
           <TopToolbar />
           <EditorComponent />

--- a/packages/remirror__react-editors/src/types.ts
+++ b/packages/remirror__react-editors/src/types.ts
@@ -1,8 +1,9 @@
-import type { CreateEditorStateProps } from 'remirror';
-import type { RemirrorProps } from '@remirror/react';
+import type { CreateEditorStateProps } from "remirror";
+import type { RemirrorProps, UseThemeProps } from "@remirror/react";
 
 export interface ReactEditorProps
-  extends Pick<CreateEditorStateProps, 'stringHandler'>,
-    Pick<RemirrorProps, 'initialContent' | 'editable' | 'autoFocus' | 'hooks'> {
+  extends Pick<CreateEditorStateProps, "stringHandler">,
+    Pick<RemirrorProps, "initialContent" | "editable" | "autoFocus" | "hooks"> {
   placeholder?: string;
+  theme?: UseThemeProps["theme"];
 }

--- a/packages/remirror__react-editors/src/types.ts
+++ b/packages/remirror__react-editors/src/types.ts
@@ -1,9 +1,9 @@
-import type { CreateEditorStateProps } from "remirror";
-import type { RemirrorProps, UseThemeProps } from "@remirror/react";
+import type { CreateEditorStateProps } from 'remirror';
+import type { RemirrorProps, UseThemeProps } from '@remirror/react';
 
 export interface ReactEditorProps
-  extends Pick<CreateEditorStateProps, "stringHandler">,
-    Pick<RemirrorProps, "initialContent" | "editable" | "autoFocus" | "hooks"> {
+  extends Pick<CreateEditorStateProps, 'stringHandler'>,
+    Pick<RemirrorProps, 'initialContent' | 'editable' | 'autoFocus' | 'hooks'> {
   placeholder?: string;
-  theme?: UseThemeProps["theme"];
+  theme?: UseThemeProps['theme'];
 }

--- a/packages/remirror__react-editors/src/wysiwyg/wysiwyg-editor.tsx
+++ b/packages/remirror__react-editors/src/wysiwyg/wysiwyg-editor.tsx
@@ -1,18 +1,18 @@
-import React, { FC, PropsWithChildren, useCallback } from "react";
-import { PlaceholderExtension, wysiwygPreset } from "remirror/extensions";
-import { TableExtension } from "@remirror/extension-react-tables";
+import React, { FC, PropsWithChildren, useCallback } from 'react';
+import { PlaceholderExtension, wysiwygPreset } from 'remirror/extensions';
+import { TableExtension } from '@remirror/extension-react-tables';
 import {
   EditorComponent,
   Remirror,
   TableComponents,
   ThemeProvider,
   useRemirror,
-} from "@remirror/react";
-import { AllStyledComponent } from "@remirror/styles/emotion";
+} from '@remirror/react';
+import { AllStyledComponent } from '@remirror/styles/emotion';
 
-import { BubbleMenu } from "../components/bubble-menu";
-import { TopToolbar } from "../components/top-toolbar";
-import { ReactEditorProps } from "../types";
+import { BubbleMenu } from '../components/bubble-menu';
+import { TopToolbar } from '../components/top-toolbar';
+import { ReactEditorProps } from '../types';
 
 export interface WysiwygEditorProps extends Partial<ReactEditorProps> {}
 
@@ -24,12 +24,8 @@ export const WysiwygEditor: FC<PropsWithChildren<WysiwygEditorProps>> = ({
   ...rest
 }) => {
   const extensions = useCallback(
-    () => [
-      new PlaceholderExtension({ placeholder }),
-      new TableExtension(),
-      ...wysiwygPreset(),
-    ],
-    [placeholder]
+    () => [new PlaceholderExtension({ placeholder }), new TableExtension(), ...wysiwygPreset()],
+    [placeholder],
   );
 
   const { manager } = useRemirror({ extensions, stringHandler });

--- a/packages/remirror__react-editors/src/wysiwyg/wysiwyg-editor.tsx
+++ b/packages/remirror__react-editors/src/wysiwyg/wysiwyg-editor.tsx
@@ -1,18 +1,18 @@
-import React, { FC, PropsWithChildren, useCallback } from 'react';
-import { PlaceholderExtension, wysiwygPreset } from 'remirror/extensions';
-import { TableExtension } from '@remirror/extension-react-tables';
+import React, { FC, PropsWithChildren, useCallback } from "react";
+import { PlaceholderExtension, wysiwygPreset } from "remirror/extensions";
+import { TableExtension } from "@remirror/extension-react-tables";
 import {
   EditorComponent,
   Remirror,
   TableComponents,
   ThemeProvider,
   useRemirror,
-} from '@remirror/react';
-import { AllStyledComponent } from '@remirror/styles/emotion';
+} from "@remirror/react";
+import { AllStyledComponent } from "@remirror/styles/emotion";
 
-import { BubbleMenu } from '../components/bubble-menu';
-import { TopToolbar } from '../components/top-toolbar';
-import { ReactEditorProps } from '../types';
+import { BubbleMenu } from "../components/bubble-menu";
+import { TopToolbar } from "../components/top-toolbar";
+import { ReactEditorProps } from "../types";
 
 export interface WysiwygEditorProps extends Partial<ReactEditorProps> {}
 
@@ -20,18 +20,23 @@ export const WysiwygEditor: FC<PropsWithChildren<WysiwygEditorProps>> = ({
   placeholder,
   stringHandler,
   children,
+  theme,
   ...rest
 }) => {
   const extensions = useCallback(
-    () => [new PlaceholderExtension({ placeholder }), new TableExtension(), ...wysiwygPreset()],
-    [placeholder],
+    () => [
+      new PlaceholderExtension({ placeholder }),
+      new TableExtension(),
+      ...wysiwygPreset(),
+    ],
+    [placeholder]
   );
 
   const { manager } = useRemirror({ extensions, stringHandler });
 
   return (
     <AllStyledComponent>
-      <ThemeProvider>
+      <ThemeProvider theme={theme}>
         <Remirror manager={manager} {...rest}>
           <TopToolbar />
           <EditorComponent />


### PR DESCRIPTION
### Description

- Added  theme customization support for @remirror/react-editors

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
