### PR TITLE
fix(paste-rules): don't replace non-text block

### DIFF
--- a/.changeset/clean-dragons-reply.md
+++ b/.changeset/clean-dragons-reply.md
@@ -1,0 +1,8 @@
+---
+'prosemirror-paste-rules': patch
+'remirror': patch
+'@remirror/pm': patch
+'@remirror/core': patch
+---
+
+Mark paste rule won't replace selection if the pasted content is not a text block.

--- a/packages/prosemirror-paste-rules/src/index.ts
+++ b/packages/prosemirror-paste-rules/src/index.ts
@@ -1,2 +1,1 @@
 export * from './paste-rules-plugin';
-export * from './paste-rules-plugin';

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -64,7 +64,10 @@ export function pasteRules(pasteRules: PasteRule[]): Plugin {
 
           const firstChild = slice.content.childCount === 1 ? slice.content.firstChild : null;
           const textContent = firstChild?.textContent ?? '';
-          const canBeReplaced = !view.state.selection.empty && textContent && firstChild?.isInline;
+          const canBeReplaced =
+            !view.state.selection.empty &&
+            textContent &&
+            (firstChild?.isInline || firstChild?.textContent);
           const match = findMatches(textContent, rule.regexp)[0];
 
           if (canBeReplaced && match && rule.type === 'mark' && rule.replaceSelection) {

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -62,9 +62,9 @@ export function pasteRules(pasteRules: PasteRule[]): Plugin {
             continue;
           }
 
-          const textContent = slice.content.firstChild?.textContent ?? '';
-          const canBeReplaced =
-            !view.state.selection.empty && slice.content.childCount === 1 && textContent;
+          const firstChild = slice.content.childCount === 1 ? slice.content.firstChild : null;
+          const textContent = firstChild?.textContent ?? '';
+          const canBeReplaced = !view.state.selection.empty && textContent && firstChild?.isInline;
           const match = findMatches(textContent, rule.regexp)[0];
 
           if (canBeReplaced && match && rule.type === 'mark' && rule.replaceSelection) {


### PR DESCRIPTION
### Description


If a mark paste rule has `replaceSelection` enabled, and a `<blockquote><p>Text</p></blockquote>` is pasted into the editor, the `replaceSelection` should not be triggered because otherwise the `<blockquote>` will be ignored. 


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
