### PR TITLE
fix(react-tables): replace table with correct positions 

### DIFF
--- a/.changeset/twenty-pumas-rhyme.md
+++ b/.changeset/twenty-pumas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-react-tables': patch
+---
+
+Use correct positions when replacing if there are multiple tables in the document.

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -170,7 +170,7 @@ export class TableExtension extends BaseTableExtension {
         table,
       });
 
-      replaceNodeAtPosition({ pos, tr, content: controlledTable });
+      replaceNodeAtPosition({ pos: tr.mapping.map(pos), tr, content: controlledTable });
     }
 
     dispatch(tr.setMeta('addToHistory', false));
@@ -267,7 +267,7 @@ export class TableExtension extends BaseTableExtension {
             table,
           });
 
-          replaceNodeAtPosition({ pos, tr, content: controlledTable });
+          replaceNodeAtPosition({ pos: tr.mapping.map(pos), tr, content: controlledTable });
         }
 
         return tr.steps.length > 0 ? tr : undefined;


### PR DESCRIPTION
### Description

use this initial content 
[test-table-content.json.zip](https://github.com/remirror/remirror/files/11505751/test-table-content.json.zip)
and the second table will be nested in the first table

I think the problem is the pos of node doesn't be mapped after tr has been updated.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.


