### PR TITLE
fix(link): disable link click handler when contenteditable is false

### DIFF
--- a/.changeset/hip-mugs-report.md
+++ b/.changeset/hip-mugs-report.md
@@ -1,6 +1,6 @@
 ---
-"remirror": patch
-"@remirror/extension-link": patch
+'remirror': patch
+'@remirror/extension-link': patch
 ---
 
 Disable link click handler when contenteditable is `false`. This fixes an issue that causes clicking a link in an uneditable editor will open the link twice.

--- a/.changeset/hip-mugs-report.md
+++ b/.changeset/hip-mugs-report.md
@@ -1,0 +1,6 @@
+---
+"remirror": patch
+"@remirror/extension-link": patch
+---
+
+Disable link click handler when contenteditable is `false`. This fixes an issue that causes clicking a link in an uneditable editor will open the link twice.

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -519,6 +519,12 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
           return true;
         }
 
+        // If editable is false, the openLinkOnClick handler or the selectTextOnClick handler should
+        // not be triggered or it will conflict with the default browser event
+        if (!this.store.view.editable) {
+          return;
+        }
+
         let handled = false;
 
         if (this.options.openLinkOnClick) {


### PR DESCRIPTION
### Description

I set the prop `openLinkOnClick` which is one of the options for LinkExtension to true and set 'contenteditable' to false,then I click this link mark, there would be a new tab and the current tab has also been redirected.

So I think the click should be disabled when contenteditable is false and let default browser event happen.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
