### PR TITLE
fix(code-block): remove  isolating  from codeBlock

### DIFF
--- a/.changeset/six-tips-learn.md
+++ b/.changeset/six-tips-learn.md
@@ -1,0 +1,6 @@
+---
+"remirror": patch
+"@remirror/extension-code-block": patch
+---
+
+Remove `isolating: true` from the spce of `codeBlock` node type.

--- a/.changeset/six-tips-learn.md
+++ b/.changeset/six-tips-learn.md
@@ -1,6 +1,6 @@
 ---
-"remirror": patch
-"@remirror/extension-code-block": patch
+'remirror': patch
+'@remirror/extension-code-block': patch
 ---
 
-Remove `isolating: true` from the spce of `codeBlock` node type.
+Remove `isolating: true` from the spec of `codeBlock` node type.

--- a/packages/remirror__extension-code-block/src/code-block-extension.ts
+++ b/packages/remirror__extension-code-block/src/code-block-extension.ts
@@ -84,7 +84,6 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
       content: 'text*',
       marks: '',
       defining: true,
-      isolating: true,
       draggable: false,
       ...override,
       code: true,


### PR DESCRIPTION
### Description

When the isolating attribute is set on the codeBlock, deleting the leading line of text causes the cursor to select the code block instead of staying with the line of code immediately following it. This behavior is confusing to me.

In `tiptap` and `prosemirror-schema-basic`, the isolating attribute is not set on codeBlock, and I think the behavior resulting from their settings is intuitive.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
