### PR TITLE
feat: add `beforeKeyhandler` hook

### DIFF
--- a/packages/remirror__core/__tests__/keymap-extension.spec.ts
+++ b/packages/remirror__core/__tests__/keymap-extension.spec.ts
@@ -25,6 +25,23 @@ test('supports custom keymaps', () => {
     });
 });
 
+test('supports beforeKeyhandler to prevent the execution of keyhandler', () => {
+  const mock: any = jest.fn();
+  const {
+    manager,
+    add,
+    nodes: { p, doc },
+  } = renderEditor<never>([]);
+
+  manager.getExtension(KeymapExtension).addHandler('beforeKeyhandler', () => true);
+
+  add(doc(p('Start<cursor>')))
+    .press('a')
+    .callback(() => {
+      expect(mock).toHaveBeenCalledTimes(0);
+    });
+});
+
 test('supports the default keymap', () => {
   const {
     add,


### PR DESCRIPTION
### Description

I'm writing a slash extension.When a menu navigation appears to add or toggle nodes, if a keyboard shortcut is used at that time, the menu does not disappear, and the current search text can not be deleted. Therefore, I have added a hook function to control whether the keyboard shortcut event occurs and to perform certain actions before it is triggered.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
