### PR TITLE
fix: enable to remove the list which is after a table node

### DIFF
--- a/packages/remirror__extension-list/src/list-commands.ts
+++ b/packages/remirror__extension-list/src/list-commands.ts
@@ -686,16 +686,10 @@ export function listBackspace({ view }: CommandFunctionProps): boolean {
   }
 
   {
-    const $cursor = (view.state.selection as TextSelection).$cursor;
+    const cursorState = getListItemCursorState();
 
-    if (!$cursor || $cursor.parentOffset > 0) {
-      return false;
-    }
-
-    const range = $cursor.blockRange();
-
-    if (!range || !isListItemNode(range.parent) || range.startIndex !== 0) {
-      return false;
+    if (!cursorState) {
+      return cursorState;
     }
   }
 
@@ -708,17 +702,29 @@ export function listBackspace({ view }: CommandFunctionProps): boolean {
   }
 
   {
-    const $cursor = (view.state.selection as TextSelection).$cursor;
+    const cursorState = getListItemCursorState();
 
-    if (!$cursor || $cursor.parentOffset > 0) {
-      return false;
+    if (!cursorState) {
+      return cursorState;
     }
 
-    const range = $cursor.blockRange();
+    // get list node
+    const list = cursorState.$cursor.node(-2);
 
-    if (!range || !isListItemNode(range.parent) || range.startIndex !== 0) {
-      return false;
+    // list should have only one list item
+    if (list.childCount <= 1) {
+      liftListItem(cursorState.range.parent.type)(view.state, view.dispatch);
     }
+  }
+
+  {
+    const cursorState = getListItemCursorState();
+
+    if (!cursorState) {
+      return cursorState;
+    }
+
+    const { $cursor, range } = cursorState;
 
     // Handle the backspace key in a three-levels list correctly:
     // * A
@@ -737,4 +743,24 @@ export function listBackspace({ view }: CommandFunctionProps): boolean {
   joinBackward(view.state, view.dispatch, view);
 
   return true;
+
+  function getListItemCursorState() {
+    if (!view) {
+      return false;
+    }
+
+    const $cursor = (view.state.selection as TextSelection).$cursor;
+
+    if (!$cursor || $cursor.parentOffset > 0) {
+      return false;
+    }
+
+    const range = $cursor.blockRange();
+
+    if (!range || !isListItemNode(range.parent) || range.startIndex !== 0) {
+      return false;
+    }
+
+    return { $cursor, range };
+  }
 }


### PR DESCRIPTION
### Description

Inspired by Milkdown/milkdown#1003

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
