### PR TITLE
fix(core): re-check upload placeholder position

### DIFF
--- a/.changeset/quick-mirrors-unite.md
+++ b/.changeset/quick-mirrors-unite.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-file': patch
+'@remirror/core': patch
+---
+
+Make the file uploading robuster by re-checking the placeholder position when the uploading is finished.

--- a/packages/remirror__core/src/builtins/upload-extension/file-placeholder-plugin.ts
+++ b/packages/remirror__core/src/builtins/upload-extension/file-placeholder-plugin.ts
@@ -66,8 +66,12 @@ export function findUploadPlaceholderPos(state: EditorState, id: string): number
     const decorations = set.find(undefined, undefined, (spec) => spec.id === id);
     const pos = decorations?.[0]?.from;
 
-    if (pos != null) {
-      return pos;
+    if (pos != null && pos < state.doc.content.size) {
+      const $pos = state.doc.resolve(pos);
+      const node = $pos.nodeAfter;
+      if (node?.attrs.id === id) {
+        return pos;
+      }
     }
   }
 

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -106,6 +106,7 @@ export class FileExtension extends NodeExtension<FileOptions> {
             const fileName = anchor.getAttribute('data-filename');
             const fileType = anchor.getAttribute('data-filetype');
             const fileSize = anchor.getAttribute('data-filesize');
+            const id = anchor.getAttribute('data-id');
 
             return {
               ...extra.parse(dom),
@@ -113,6 +114,7 @@ export class FileExtension extends NodeExtension<FileOptions> {
               fileName,
               fileType,
               fileSize,
+              id,
             };
           },
         },
@@ -128,6 +130,7 @@ export class FileExtension extends NodeExtension<FileOptions> {
           'data-filename': node.attrs.fileName,
           'data-filetype': node.attrs.fileType,
           'data-filesize': node.attrs.fileSize,
+          'data-id': node.attrs.id,
         };
 
         if (error) {

--- a/packages/remirror__extension-file/src/file-uploaders/slow-file-uploader.ts
+++ b/packages/remirror__extension-file/src/file-uploaders/slow-file-uploader.ts
@@ -17,7 +17,11 @@ export function createSlowFileUploader(): FileUploader<FileAttributes> {
     },
 
     upload: async (context: UploadContext) => {
-      const total = 1000;
+      // We want the upload process to finish in about 8 seconds
+      const total = 8000;
+      // Update the progress every 200ms
+      const chunk = 200;
+
       let loaded = 0;
       context.set('total', total);
       context.set('loaded', loaded);
@@ -27,13 +31,14 @@ export function createSlowFileUploader(): FileUploader<FileAttributes> {
           throw new Error('Canceled');
         }
 
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        loaded += Math.random() * 40;
+        await new Promise((resolve) => setTimeout(resolve, chunk));
+        loaded += 2 * Math.random() * chunk;
         loaded = Math.min(total, loaded);
+        // console.log(`Uploading ${file.name}. Progress: ${Math.floor((100 * loaded) / total)}%`);
         context.set('loaded', loaded);
       }
 
-      const url = URL.createObjectURL(file);
+      const url = URL.createObjectURL(file) + '#uploaded';
       return { ...getDefaultFileAttrs(file), url };
     },
 


### PR DESCRIPTION
 
### Description

If the the file node is moved by cut-and-paste before the upload is finish, the uploaded information won't be update correctly. This PR fixes the issue by (1) add the uploading id to the DOM and paste this attribute, and (2) re-check the placeholder position when the upload is finished 





<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->


_Before:_ 


https://github.com/remirror/remirror/assets/24715727/fbc5a5ed-d0c9-4c34-825e-4ee8b3ead76e


_After:_




https://github.com/remirror/remirror/assets/24715727/2fc51682-3e6a-49f8-b5ea-960d48701089


