### PR TITLE
docs: fix extension imports in example snippet

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -135,6 +135,12 @@ The provided extension is invalid.
 
 The provided preset is invalid.
 
+### RMR0021
+
+> Invalid Content
+
+The content provided to the editor is not supported.
+
 ### RMR0050
 
 > Invalid Name

--- a/docs/getting-started/create-manager.md
+++ b/docs/getting-started/create-manager.md
@@ -86,7 +86,12 @@ HTML is a great format for demo code because it's compact and easy to read. It's
 Hence, you want to persist Remirror's native JSON format, and load this in your editor:
 
 ```tsx
-import { BoldExtension, CalloutExtension, ItalicExtension } from 'remirror/extensions';
+import {
+  BoldExtension,
+  CalloutExtension,
+  ItalicExtension,
+  HeadingExtension,
+} from 'remirror/extensions';
 import { useRemirror } from '@remirror/react';
 
 const remirrorJsonFromStorage = {
@@ -105,6 +110,7 @@ const remirrorJsonFromStorage = {
 
 const { manager, state } = useRemirror({
   extensions: () => [
+    new HeadingExtension(),
     new BoldExtension(),
     new ItalicExtension(),
     new CalloutExtension({ defaultType: 'warn' }),


### PR DESCRIPTION
### Description

Hello! I've notice a minor error when going through the `Getting Started -> Create a Manager` page. The code snippet way down below of the page where it the JSON format won't actually work because it lacked the `HeadingExtension` for the type `heading`, so I've added just that. Or if you feel that we can just delete the content line that works out too.

Please do let me know if I'm doing PR wrong, it's my first time

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
