### PR TITLE
fix: fix lingui runtime crash

### DIFF
--- a/.changeset/unlucky-scissors-provide.md
+++ b/.changeset/unlucky-scissors-provide.md
@@ -1,6 +1,8 @@
 ---
 '@remirror/react-components': patch
 '@remirror/react-core': patch
+'@remirror/extension-react-tables': patch
+'@remirror/extension-react-hooks': patch
 '@remirror/react': patch
 ---
 

--- a/.changeset/unlucky-scissors-provide.md
+++ b/.changeset/unlucky-scissors-provide.md
@@ -1,0 +1,14 @@
+---
+'@remirror/extension-text-color': patch
+'@remirror/extension-callout': patch
+'@remirror/extension-columns': patch
+'@remirror/extension-heading': patch
+'@remirror/react-components': patch
+'@remirror/extension-bidi': patch
+'@remirror/react-core': patch
+'@remirror/messages': patch
+'@remirror/i18n': patch
+'remirror': patch
+---
+
+Fix lingui runtime crash

--- a/.changeset/unlucky-scissors-provide.md
+++ b/.changeset/unlucky-scissors-provide.md
@@ -2,7 +2,7 @@
 '@remirror/react-components': patch
 '@remirror/react-core': patch
 '@remirror/extension-react-tables': patch
-'@remirror/extension-react-hooks': patch
+'@remirror/react-hooks': patch
 '@remirror/react': patch
 ---
 

--- a/.changeset/unlucky-scissors-provide.md
+++ b/.changeset/unlucky-scissors-provide.md
@@ -6,9 +6,10 @@
 '@remirror/react-components': patch
 '@remirror/extension-bidi': patch
 '@remirror/react-core': patch
+'@remirror/react': patch
 '@remirror/messages': patch
 '@remirror/i18n': patch
 'remirror': patch
 ---
 
-Fix lingui runtime crash
+Fix the lingui runtime crash `Cannot read properties of undefined (reading "messages")`.

--- a/.changeset/unlucky-scissors-provide.md
+++ b/.changeset/unlucky-scissors-provide.md
@@ -1,15 +1,7 @@
 ---
-'@remirror/extension-text-color': patch
-'@remirror/extension-callout': patch
-'@remirror/extension-columns': patch
-'@remirror/extension-heading': patch
 '@remirror/react-components': patch
-'@remirror/extension-bidi': patch
 '@remirror/react-core': patch
 '@remirror/react': patch
-'@remirror/messages': patch
-'@remirror/i18n': patch
-'remirror': patch
 ---
 
 Fix the lingui runtime crash `Cannot read properties of undefined (reading "messages")`.

--- a/packages/remirror__react-core/src/hooks/use-i18n.ts
+++ b/packages/remirror__react-core/src/hooks/use-i18n.ts
@@ -11,7 +11,7 @@ export const [I18nProvider, useI18n] = createContextState<UseI18nReturn, I18nPro
   const locale = props.locale ?? 'en';
   const i18n = props.i18n ?? defaultI18n;
   const supportedLocales = props.supportedLocales ?? [locale];
-  const t: I18n['_'] = i18n._;
+  const t: I18n['_'] = i18n._.bind(i18n);
 
   return { locale, i18n, supportedLocales, t };
 });


### PR DESCRIPTION
### Description

Close https://github.com/remirror/remirror/issues/2108

Before: 


<img width="1056" alt="image" src="https://github.com/remirror/remirror/assets/24715727/36b09202-df1d-4650-bd4c-5376401fea88">


After:


<img width="1042" alt="image" src="https://github.com/remirror/remirror/assets/24715727/f373e885-a702-4feb-84d7-5ac4ffa68d37">



<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
