### PR TITLE
fix: yjs undoManager is not working properly after updating editor

### DIFF
--- a/packages/remirror__extension-yjs/src/yjs-extension.ts
+++ b/packages/remirror__extension-yjs/src/yjs-extension.ts
@@ -10,13 +10,14 @@ import {
   yUndoPlugin,
   yUndoPluginKey,
 } from 'y-prosemirror';
-import type { Doc } from 'yjs';
+import type { Doc, XmlFragment } from 'yjs';
 import { UndoManager } from 'yjs';
 import {
   AcceptUndefined,
   command,
   convertCommand,
   EditorState,
+  EditorView,
   ErrorConstant,
   extension,
   ExtensionPriority,
@@ -174,8 +175,6 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
       getSelection,
       cursorStateField,
       disableUndo,
-      protectedNodes,
-      trackedOrigins,
       selectionBuilder,
     } = this.options;
 
@@ -192,14 +191,61 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
     ];
 
     if (!disableUndo) {
-      const undoManager = new UndoManager(type, {
-        trackedOrigins: new Set([ySyncPluginKey, ...trackedOrigins]),
-        deleteFilter: (item) => defaultDeleteFilter(item, protectedNodes),
-      });
-      plugins.push(yUndoPlugin({ undoManager }));
+      const yUndoPluginInstance = this.createYUndoPlugin(type);
+      plugins.push(yUndoPluginInstance);
     }
 
     return plugins;
+  }
+
+  /**
+   * detailed reason for this method
+   * https://github.com/yjs/y-prosemirror/issues/114 and https://github.com/yjs/y-prosemirror/issues/102
+   *
+   * The implementation of this method is inspired by tiptap.
+   * https://github.com/ueberdosis/tiptap/blob/bdc51d12b513e8d395e2aefa52ad890e4f2478a7/packages/extension-collaboration/src/collaboration.ts#L108
+   */
+  private createYUndoPlugin(type: XmlFragment) {
+    const { trackedOrigins, protectedNodes } = this.options;
+    const undoManager = new UndoManager(type, {
+      trackedOrigins: new Set([ySyncPluginKey, ...trackedOrigins]),
+      deleteFilter: (item) => defaultDeleteFilter(item, protectedNodes),
+    });
+    const yUndoPluginInstance = yUndoPlugin({ undoManager });
+    const originalUndoPluginView = yUndoPluginInstance.spec.view;
+
+    yUndoPluginInstance.spec.view = (view: EditorView) => {
+      const { undoManager } = yUndoPluginKey.getState(view.state);
+
+      if (undoManager.restore) {
+        undoManager.restore();
+        undoManager.restore = () => {};
+      }
+
+      const viewRet = originalUndoPluginView?.(view);
+
+      return {
+        destroy: () => {
+          const hasUndoManSelf = undoManager.trackedOrigins.has(undoManager);
+
+          const observers = undoManager._observers;
+
+          undoManager.restore = () => {
+            if (hasUndoManSelf) {
+              undoManager.trackedOrigins.add(undoManager);
+            }
+
+            undoManager.doc.on('afterTransaction', undoManager.afterTransactionHandler);
+
+            undoManager._observers = observers;
+          };
+
+          viewRet?.destroy?.();
+        },
+      };
+    };
+
+    return yUndoPluginInstance;
   }
 
   /**


### PR DESCRIPTION
### Description
detailed reason for this method

 https://github.com/yjs/y-prosemirror/issues/114 and https://github.com/yjs/y-prosemirror/issues/102

 The implementation of this method is inspired by tiptap.
 https://github.com/ueberdosis/tiptap/blob/bdc51d12b513e8d395e2aefa52ad890e4f2478a7/packages/extension-collaboration/src/collaboration.ts#L108


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
