### PR TITLE
fix: plugins of tableExtension can be updated when editable has been changed

### DIFF
--- a/.changeset/grumpy-clocks-begin.md
+++ b/.changeset/grumpy-clocks-begin.md
@@ -1,0 +1,7 @@
+---
+'@remirror/extension-react-tables': patch
+'@remirror/extension-events': patch
+'@remirror/extension-tables': patch
+---
+
+add editable event hook and fix the bug in react table caused by the update of the "editable".

--- a/packages/remirror__extension-events/src/events-extension.ts
+++ b/packages/remirror__extension-events/src/events-extension.ts
@@ -176,6 +176,12 @@ export interface EventsOptions {
    * which was hovered at the current position.
    */
   hover?: Handler<HoverEventHandler>;
+
+  /**
+   * Listen for editable changed and pass through previous editable state and
+   * current editable state
+   */
+  editable?: Handler<EditableEventHandler>;
 }
 
 export type FocusEventHandler = (event: FocusEvent) => boolean | undefined | void;
@@ -204,6 +210,7 @@ export type HoverEventHandler = (
   event: MouseEvent,
   state: HoverEventHandlerState,
 ) => boolean | undefined | void;
+export type EditableEventHandler = (currentEditable: boolean) => void;
 
 /**
  * The events extension which listens to events which occur within the
@@ -233,6 +240,7 @@ export type HoverEventHandler = (
     'copy',
     'cut',
     'paste',
+    'editable',
   ],
   handlerKeyOptions: {
     blur: { earlyReturnValue: true },
@@ -461,6 +469,20 @@ export class EventsExtension extends PlainExtension<EventsOptions> {
 
           paste: (_, event: Event) => this.options.paste(event as ClipboardEvent) || false,
         },
+      },
+      view: (_view: EditorView) => {
+        let prevEditable = _view.editable;
+        const options = this.options;
+        return {
+          update(view) {
+            const currentEditable = view.editable;
+
+            if (currentEditable !== prevEditable) {
+              options.editable(currentEditable);
+              prevEditable = currentEditable;
+            }
+          },
+        };
       },
     };
   }

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -131,8 +131,6 @@ export class TableExtension extends BaseTableExtension {
   }
 
   onView(view: EditorView): void {
-    super.onView(view);
-
     // We have multiple node types which share a eom table_row in this
     // extension. In order to make the function `tableNodeTypes` from
     // `prosemirror-extension-tables` return the correct node type, we

--- a/packages/remirror__extension-tables/package.json
+++ b/packages/remirror__extension-tables/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@babel/runtime": "^7.22.3",
     "@remirror/core": "^2.0.18",
+    "@remirror/extension-events": "^2.1.15",
     "@remirror/extension-positioner": "^2.1.8",
     "@remirror/messages": "^2.0.5",
     "@remirror/theme": "^2.0.9"

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -6,7 +6,6 @@ import {
   convertCommand,
   CreateExtensionPlugin,
   EditorState,
-  EditorView,
   extension,
   ExtensionPriority,
   ExtensionTag,
@@ -22,6 +21,7 @@ import {
   ProsemirrorPlugin,
   StateUpdateLifecycleProps,
 } from '@remirror/core';
+import { CreateEventHandlers } from '@remirror/extension-events';
 import { TextSelection } from '@remirror/pm/state';
 import {
   addColumnAfter,
@@ -124,10 +124,12 @@ export class TableExtension extends NodeExtension<TableOptions> {
     }
   }
 
-  onView(_: EditorView): void {
-    if (this.store.helpers.isViewEditable() === false) {
-      this.store.updateExtensionPlugins(this);
-    }
+  createEventHandlers(): CreateEventHandlers {
+    return {
+      editable: () => {
+        this.store.updateExtensionPlugins(this);
+      },
+    };
   }
 
   /**

--- a/packages/storybook-react/stories/extension-react-tables/basic.tsx
+++ b/packages/storybook-react/stories/extension-react-tables/basic.tsx
@@ -124,10 +124,16 @@ const Table = ({
   extensions: () => AnyExtension[];
 }): JSX.Element => {
   const { manager, state } = useRemirror({ extensions });
-
+  const [editable, setEditable] = useState(true);
   return (
     <ThemeProvider>
-      <Remirror manager={manager} initialContent={state}>
+      <button
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => setEditable(!editable)}
+      >
+        Toggle editable (currently {editable.toString()})
+      </button>
+      <Remirror manager={manager} initialContent={state} editable={editable}>
         <EditorComponent />
         <TableComponents />
         <CommandMenu />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2139,6 +2139,9 @@ importers:
       '@remirror/core':
         specifier: ^2.0.18
         version: link:../remirror__core
+      '@remirror/extension-events':
+        specifier: ^2.1.15
+        version: link:../remirror__extension-events
       '@remirror/extension-positioner':
         specifier: ^2.1.8
         version: link:../remirror__extension-positioner
@@ -17962,7 +17965,7 @@ packages:
     dependencies:
       semver: 7.5.1
       shelljs: 0.8.5
-      typescript: 5.2.0-dev.20230727
+      typescript: 5.2.0-dev.20230728
     dev: false
 
   /duplexer3@0.1.4:
@@ -28974,8 +28977,8 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
-  /typescript@5.2.0-dev.20230727:
-    resolution: {integrity: sha512-HTNqxwU5roYnvWrrdTxKLREZ+fygKOpf7q2DAhfZntqgyQNxZzZdDypigMS8tNmeQN2X/ohbNzX9PnhHoCCmfw==}
+  /typescript@5.2.0-dev.20230728:
+    resolution: {integrity: sha512-pI6gdSexHd/ESfy6Vwmd6bdId1UIYl1fkE8d2o/n/frQCeD6oupH93WTh0syCk3mYMpnx++flvR1X2WHJS1oVg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false


### PR DESCRIPTION
### Description

The table plugin can not be updated when the editable state changes.So I add an editable state change event and use it into tableExtension.
I also believe that more plugins may need to respond correctly to changes in the editable state.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
