### PR TITLE
fix(events-extension): click events cannot be obtained for individual string links

### DIFF
--- a/.changeset/wild-days-tickle.md
+++ b/.changeset/wild-days-tickle.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-events': patch
+---
+
+enable click events for individual string link.

--- a/packages/remirror__extension-events/__tests__/events-extension.spec.ts
+++ b/packages/remirror__extension-events/__tests__/events-extension.spec.ts
@@ -3,7 +3,12 @@ import { fireEvent } from '@testing-library/dom';
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import { LinkExtension } from 'remirror/extensions';
 
-import { ContextMenuEventHandlerState, EventsExtension, HoverEventHandlerState } from '../';
+import {
+  ClickMarkHandlerState,
+  ContextMenuEventHandlerState,
+  EventsExtension,
+  HoverEventHandlerState,
+} from '../';
 
 extensionValidityTest(EventsExtension);
 
@@ -85,6 +90,24 @@ describe('events', () => {
       expect(clickHandler).toHaveBeenCalled();
     },
   );
+
+  it('click events can be obtained for individual string link', () => {
+    const eventsExtension = new EventsExtension();
+    const editor = renderEditor([eventsExtension, new LinkExtension()]);
+    const { doc, p } = editor.nodes;
+    const { link } = editor.attributeMarks;
+    const { view, add } = editor;
+    const clickHandler: any = jest.fn((_: MouseEvent, __: ClickMarkHandlerState) => true);
+    eventsExtension.addHandler('clickMark', clickHandler);
+    const node = p('1', link({ href: 'https://example.com' })('l'));
+
+    add(doc(node));
+
+    view.someProp('handleClickOn', (fn) => fn(view, 2, node, 0, {} as MouseEvent, true));
+    expect(clickHandler).toHaveBeenCalledTimes(1);
+    expect(clickHandler.mock.calls[0]?.[1].getMark).toBeFunction();
+    expect(clickHandler.mock.calls[0]?.[1].getMark('link')).toBeDefined();
+  });
 
   it('should not throw when clicked on before first state called', () => {
     const eventsExtension = new EventsExtension();

--- a/packages/remirror__extension-events/src/events-extension.ts
+++ b/packages/remirror__extension-events/src/events-extension.ts
@@ -630,7 +630,7 @@ function createClickMarkState(props: CreateClickMarkStateProps): ClickMarkHandle
     return clickState;
   }
 
-  for (const { type } of $pos.marks()) {
+  for (const { type } of $pos.marksAcross($pos) ?? []) {
     const range = getMarkRange($pos, type);
 
     if (range) {


### PR DESCRIPTION
### Description
reproduction video

https://github.com/remirror/remirror/assets/45024986/b33400a0-ec3d-455a-aa9c-9522492f54f8

### Checklist


- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
