### PR TITLE
docs: correct link in extension.md

### DIFF
--- a/docs/concepts/extension.md
+++ b/docs/concepts/extension.md
@@ -13,7 +13,7 @@ Each extension provides a wealth of functionality - like **keyboard shortcuts**,
 
 This doc refers to "Extension" as a concept.
 
-You can find a list of Remirror's provided extensions [here](/docs/extensions/index).
+You can find a list of Remirror's provided extensions [here](/docs/extensions/).
 
 :::note
 


### PR DESCRIPTION
This is a simple docs change to fix a broken link on this page: https://remirror.io/docs/concepts/extension/

Clicking the link in Chrome on Macos leads to a 404. Refreshing that 404 then redirects to the same URL without the trailing `/index`. So I assume removing that part will fix the 404.