### PR TITLE
fix: revert prettier back to v2.8.8

### DIFF
--- a/.changeset/tiny-points-sing.md
+++ b/.changeset/tiny-points-sing.md
@@ -1,0 +1,9 @@
+---
+'@remirror/extension-code-block': patch
+'@remirror/react': patch
+'remirror': patch
+---
+
+Revert the `prettier` dependency to v2.8.8 in `@remirror/extension-code-block`.
+
+Prettier v3 has changed all APIs to be asynchronous. ProseMirror's APIs are mostly synchronous, so using Prettier v3's API would be challenging (although possible). `@prettier/sync` provides a synchronous Prettier v3 API, but this library can only be used in a Node.js environment, so we cannot use it either.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -189,6 +189,7 @@
     "path": "packages/remirror__extension-code-block/dist/remirror-extension-code-block.js",
     "ignore": [
       "@remirror/pm",
+      "@types/prettier",
       "prettier",
       "@remirror/core",
       "@remirror/messages",
@@ -615,7 +616,6 @@
     "ignore": [
       "@remirror/pm",
       "@remirror/core",
-      "@remirror/extension-events",
       "@remirror/extension-positioner",
       "@remirror/messages",
       "@remirror/theme"

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -616,6 +616,7 @@
     "ignore": [
       "@remirror/pm",
       "@remirror/core",
+      "@remirror/extension-events",
       "@remirror/extension-positioner",
       "@remirror/messages",
       "@remirror/theme"

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "nyc": "^15.1.0",
     "playwright": "^1.34.3",
     "playwright-testing-library": "^4.5.0",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "prettier-plugin-packagejson": "^2.4.3",
     "remirror": "2.0.35",
     "rimraf": "^4.4.1",

--- a/packages/remirror/package.json
+++ b/packages/remirror/package.json
@@ -129,13 +129,18 @@
   },
   "devDependencies": {
     "@remirror/pm": "^2.0.8",
-    "prettier": "^3.0.0"
+    "@types/prettier": "^2.7.2",
+    "prettier": "^2.8.8"
   },
   "peerDependencies": {
     "@remirror/pm": "^2.0.8",
-    "prettier": "^3.0.0"
+    "@types/prettier": "^2.7.2",
+    "prettier": "^2.8.8"
   },
   "peerDependenciesMeta": {
+    "@types/prettier": {
+      "optional": true
+    },
     "prettier": {
       "optional": true
     }

--- a/packages/remirror__core/__dts__/extension-types.dts.ts
+++ b/packages/remirror__core/__dts__/extension-types.dts.ts
@@ -69,9 +69,9 @@ commands.free(0);
 const commandOutput: void = commands.free();
 commands.notChainable('works');
 
-const love: Chainable['love'] = (value: number) => ({}) as Chainable;
+const love: Chainable['love'] = (value: number) => ({} as Chainable);
 // @ts-expect-error
-const loveFail: Chainable['love'] = (value: string) => ({}) as Chainable;
+const loveFail: Chainable['love'] = (value: string) => ({} as Chainable);
 
 const chain: Chainable = object();
 

--- a/packages/remirror__extension-code-block/__tests__/code-block-extension.spec.ts
+++ b/packages/remirror__extension-code-block/__tests__/code-block-extension.spec.ts
@@ -1,6 +1,7 @@
-import Prettier from '@prettier/sync';
 import { pmBuild } from 'jest-prosemirror';
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
+import typescriptPlugin from 'prettier/parser-typescript';
+import { default as Prettier } from 'prettier/standalone';
 import refractor from 'refractor/core.js';
 import graphql from 'refractor/lang/graphql.js';
 import javascript from 'refractor/lang/javascript.js';
@@ -339,6 +340,7 @@ describe('commands', () => {
       if (getLanguage({ fallback: 'text', language }) === 'typescript') {
         return Prettier.formatWithCursor(source, {
           cursorOffset,
+          plugins: [typescriptPlugin],
           parser: 'typescript',
           singleQuote: true,
         });

--- a/packages/remirror__extension-code-block/package.json
+++ b/packages/remirror__extension-code-block/package.json
@@ -46,7 +46,6 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.22.3",
-    "@prettier/sync": "^0.3.0",
     "@remirror/core": "^2.0.19",
     "@remirror/messages": "^2.0.6",
     "@remirror/theme": "^2.0.9",
@@ -56,14 +55,19 @@
   "devDependencies": {
     "@remirror/pm": "^2.0.8",
     "@types/jsdom": "^16.2.15",
+    "@types/prettier": "^2.7.2",
     "jsdom": "^17.0.0",
-    "prettier": "^3.0.0"
+    "prettier": "^2.8.8"
   },
   "peerDependencies": {
     "@remirror/pm": "^2.0.8",
-    "prettier": "^3.0.0"
+    "@types/prettier": "^2.7.2",
+    "prettier": "^2.8.8"
   },
   "peerDependenciesMeta": {
+    "@types/prettier": {
+      "optional": true
+    },
     "@types/refractor": {
       "optional": true
     },

--- a/packages/remirror__extension-code-block/src/formatter.ts
+++ b/packages/remirror__extension-code-block/src/formatter.ts
@@ -5,11 +5,28 @@
  * `@remirror/extension-code-block/formatter`.
  */
 
-import Prettier from '@prettier/sync';
 import type { BuiltInParserName, CursorOptions, CursorResult } from 'prettier';
+import babelPlugin from 'prettier/parser-babel';
+import graphqlPlugin from 'prettier/parser-graphql';
+import htmlPlugin from 'prettier/parser-html';
+import markdownPlugin from 'prettier/parser-markdown';
+import cssPlugin from 'prettier/parser-postcss';
+import typescriptPlugin from 'prettier/parser-typescript';
+import yamlPlugin from 'prettier/parser-yaml';
+import { default as Prettier } from 'prettier/standalone';
 
 import type { FormattedContent, FormatterProps } from './code-block-types';
 
+// TODO load this asynchronously
+const plugins = [
+  babelPlugin,
+  htmlPlugin,
+  typescriptPlugin,
+  markdownPlugin,
+  graphqlPlugin,
+  cssPlugin,
+  yamlPlugin,
+];
 const options: Partial<CursorOptions> = {
   bracketSpacing: true,
   arrowParens: 'always',
@@ -38,10 +55,11 @@ interface FormatCodeProps {
 /**
  * Wrapper around the prettier formatWithCursor.
  */
-function formatCode({ parser, source, cursorOffset }: FormatCodeProps): CursorResult {
+function formatCode({ parser, source, cursorOffset }: FormatCodeProps) {
   return Prettier.formatWithCursor(source, {
     ...options,
     cursorOffset,
+    plugins,
     parser,
   });
 }

--- a/packages/remirror__extension-react-tables/src/views/table-controller-cell-view.tsx
+++ b/packages/remirror__extension-react-tables/src/views/table-controller-cell-view.tsx
@@ -8,11 +8,7 @@ export class TableControllerCellView implements NodeView {
   public dom: HTMLElement;
   public contentDOM: HTMLElement;
 
-  constructor(
-    public node: ProsemirrorNode,
-    public view: EditorView,
-    public getPos: () => number,
-  ) {
+  constructor(public node: ProsemirrorNode, public view: EditorView, public getPos: () => number) {
     this.contentDOM = h('div', { contentEditable: false });
     this.dom = TableControllerCell({
       view,

--- a/packages/remirror__extension-tables/__tests__/tsconfig.json
+++ b/packages/remirror__extension-tables/__tests__/tsconfig.json
@@ -38,6 +38,9 @@
       "path": "../../remirror__core/src"
     },
     {
+      "path": "../../remirror__extension-events/src"
+    },
+    {
       "path": "../../remirror__extension-positioner/src"
     },
     {

--- a/packages/remirror__extension-tables/__tests__/tsconfig.json
+++ b/packages/remirror__extension-tables/__tests__/tsconfig.json
@@ -38,9 +38,6 @@
       "path": "../../remirror__core/src"
     },
     {
-      "path": "../../remirror__extension-events/src"
-    },
-    {
       "path": "../../remirror__extension-positioner/src"
     },
     {

--- a/packages/remirror__extension-tables/src/tsconfig.json
+++ b/packages/remirror__extension-tables/src/tsconfig.json
@@ -20,9 +20,6 @@
       "path": "../../remirror__core/src"
     },
     {
-      "path": "../../remirror__extension-events/src"
-    },
-    {
       "path": "../../remirror__extension-positioner/src"
     },
     {

--- a/packages/remirror__extension-tables/src/tsconfig.json
+++ b/packages/remirror__extension-tables/src/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../../remirror__core/src"
     },
     {
+      "path": "../../remirror__extension-events/src"
+    },
+    {
       "path": "../../remirror__extension-positioner/src"
     },
     {

--- a/packages/remirror__styles/all.css
+++ b/packages/remirror__styles/all.css
@@ -28,11 +28,8 @@
   white-space: nowrap;
   color: var(--rmr-color-text);
   background-color: var(--rmr-color-background);
-  transition:
-    color 0.15s ease-in-out,
-    background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   font-size: 100%;
 }
 
@@ -398,9 +395,7 @@ button:active .remirror-menu-pane-shortcut,
 }
 
 .remirror-animated-popover {
-  transition:
-    opacity 250ms ease-in-out,
-    transform 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
   opacity: 0;
   transform-origin: top center;
   transform: translate3d(0, -20px, 0);
@@ -3540,9 +3535,7 @@ button:active .remirror-menu-pane-shortcut,
   padding-bottom: 8px;
   margin: 0 auto;
   border-radius: 8px;
-  box-shadow:
-    hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-    hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+  box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
   background-color: white;
   z-index: 10;
   max-height: 250px;
@@ -3795,9 +3788,7 @@ button:active .remirror-menu-pane-shortcut,
   padding-bottom: 8px;
   margin: 0 auto;
   border-radius: 8px;
-  box-shadow:
-    hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-    hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+  box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
   background-color: white;
   z-index: 10;
   max-height: 250px;

--- a/packages/remirror__styles/components.css
+++ b/packages/remirror__styles/components.css
@@ -28,11 +28,8 @@
   white-space: nowrap;
   color: var(--rmr-color-text);
   background-color: var(--rmr-color-background);
-  transition:
-    color 0.15s ease-in-out,
-    background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   font-size: 100%;
 }
 
@@ -398,9 +395,7 @@ button:active .remirror-menu-pane-shortcut,
 }
 
 .remirror-animated-popover {
-  transition:
-    opacity 250ms ease-in-out,
-    transform 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
   opacity: 0;
   transform-origin: top center;
   transform: translate3d(0, -20px, 0);

--- a/packages/remirror__styles/extension-emoji.css
+++ b/packages/remirror__styles/extension-emoji.css
@@ -39,9 +39,7 @@
   padding-bottom: 8px;
   margin: 0 auto;
   border-radius: 8px;
-  box-shadow:
-    hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-    hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+  box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
   background-color: white;
   z-index: 10;
   max-height: 250px;

--- a/packages/remirror__styles/extension-mention-atom.css
+++ b/packages/remirror__styles/extension-mention-atom.css
@@ -42,9 +42,7 @@
   padding-bottom: 8px;
   margin: 0 auto;
   border-radius: 8px;
-  box-shadow:
-    hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-    hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+  box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
   background-color: white;
   z-index: 10;
   max-height: 250px;

--- a/packages/remirror__styles/src/dom.tsx
+++ b/packages/remirror__styles/src/dom.tsx
@@ -37,11 +37,8 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
     white-space: nowrap;
     color: var(--rmr-color-text);
     background-color: var(--rmr-color-background);
-    transition:
-      color 0.15s ease-in-out,
-      background-color 0.15s ease-in-out,
-      border-color 0.15s ease-in-out,
-      box-shadow 0.15s ease-in-out;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+      border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     font-size: 100%;
   }
 
@@ -407,9 +404,7 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
   }
 
   .remirror-animated-popover {
-    transition:
-      opacity 250ms ease-in-out,
-      transform 250ms ease-in-out;
+    transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
     opacity: 0;
     transform-origin: top center;
     transform: translate3d(0, -20px, 0);
@@ -3561,9 +3556,7 @@ export const extensionEmojiStyledCss: ReturnType<typeof css> = css`
     padding-bottom: 8px;
     margin: 0 auto;
     border-radius: 8px;
-    box-shadow:
-      hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-      hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+    box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
     background-color: white;
     z-index: 10;
     max-height: 250px;
@@ -3826,9 +3819,7 @@ export const extensionMentionAtomStyledCss: ReturnType<typeof css> = css`
     padding-bottom: 8px;
     margin: 0 auto;
     border-radius: 8px;
-    box-shadow:
-      hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-      hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+    box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
     background-color: white;
     z-index: 10;
     max-height: 250px;

--- a/packages/remirror__styles/src/emotion.tsx
+++ b/packages/remirror__styles/src/emotion.tsx
@@ -39,11 +39,8 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
     white-space: nowrap;
     color: var(--rmr-color-text);
     background-color: var(--rmr-color-background);
-    transition:
-      color 0.15s ease-in-out,
-      background-color 0.15s ease-in-out,
-      border-color 0.15s ease-in-out,
-      box-shadow 0.15s ease-in-out;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+      border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     font-size: 100%;
   }
 
@@ -409,9 +406,7 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
   }
 
   .remirror-animated-popover {
-    transition:
-      opacity 250ms ease-in-out,
-      transform 250ms ease-in-out;
+    transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
     opacity: 0;
     transform-origin: top center;
     transform: translate3d(0, -20px, 0);
@@ -3587,9 +3582,7 @@ export const extensionEmojiStyledCss: ReturnType<typeof css> = css`
     padding-bottom: 8px;
     margin: 0 auto;
     border-radius: 8px;
-    box-shadow:
-      hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-      hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+    box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
     background-color: white;
     z-index: 10;
     max-height: 250px;
@@ -3872,9 +3865,7 @@ export const extensionMentionAtomStyledCss: ReturnType<typeof css> = css`
     padding-bottom: 8px;
     margin: 0 auto;
     border-radius: 8px;
-    box-shadow:
-      hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-      hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+    box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
     background-color: white;
     z-index: 10;
     max-height: 250px;

--- a/packages/remirror__styles/src/styled-components.tsx
+++ b/packages/remirror__styles/src/styled-components.tsx
@@ -38,11 +38,8 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
     white-space: nowrap;
     color: var(--rmr-color-text);
     background-color: var(--rmr-color-background);
-    transition:
-      color 0.15s ease-in-out,
-      background-color 0.15s ease-in-out,
-      border-color 0.15s ease-in-out,
-      box-shadow 0.15s ease-in-out;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+      border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
     font-size: 100%;
   }
 
@@ -408,9 +405,7 @@ export const componentsStyledCss: ReturnType<typeof css> = css`
   }
 
   .remirror-animated-popover {
-    transition:
-      opacity 250ms ease-in-out,
-      transform 250ms ease-in-out;
+    transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
     opacity: 0;
     transform-origin: top center;
     transform: translate3d(0, -20px, 0);
@@ -3586,9 +3581,7 @@ export const extensionEmojiStyledCss: ReturnType<typeof css> = css`
     padding-bottom: 8px;
     margin: 0 auto;
     border-radius: 8px;
-    box-shadow:
-      hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-      hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+    box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
     background-color: white;
     z-index: 10;
     max-height: 250px;
@@ -3871,9 +3864,7 @@ export const extensionMentionAtomStyledCss: ReturnType<typeof css> = css`
     padding-bottom: 8px;
     margin: 0 auto;
     border-radius: 8px;
-    box-shadow:
-      hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-      hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+    box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
     background-color: white;
     z-index: 10;
     max-height: 250px;

--- a/packages/remirror__theme/src/components-theme.ts
+++ b/packages/remirror__theme/src/components-theme.ts
@@ -41,11 +41,8 @@ export const BUTTON = css`
   white-space: nowrap;
   color: ${text};
   background-color: ${background};
-  transition:
-    color 0.15s ease-in-out,
-    background-color 0.15s ease-in-out,
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
   font-size: 100%;
   &[aria-disabled='true'] {
     cursor: auto;
@@ -414,9 +411,7 @@ export const POPOVER = css`
 ` as 'remirror-popover';
 
 export const ANIMATED_POPOVER = css`
-  transition:
-    opacity 250ms ease-in-out,
-    transform 250ms ease-in-out;
+  transition: opacity 250ms ease-in-out, transform 250ms ease-in-out;
   opacity: 0;
   transform-origin: top center;
   transform: translate3d(0, -20px, 0);

--- a/packages/remirror__theme/src/extension-emoji-theme.ts
+++ b/packages/remirror__theme/src/extension-emoji-theme.ts
@@ -38,9 +38,7 @@ export const EMOJI_POPUP_WRAPPER = css`
   padding-bottom: 8px;
   margin: 0 auto;
   border-radius: 8px;
-  box-shadow:
-    hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-    hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+  box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
   background-color: white;
   z-index: 10;
   max-height: 250px;

--- a/packages/remirror__theme/src/extension-mention-atom-theme.ts
+++ b/packages/remirror__theme/src/extension-mention-atom-theme.ts
@@ -41,9 +41,7 @@ export const MENTION_ATOM_POPUP_WRAPPER = css`
   padding-bottom: 8px;
   margin: 0 auto;
   border-radius: 8px;
-  box-shadow:
-    hsla(205, 70%, 15%, 0.25) 0 4px 8px,
-    hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
+  box-shadow: hsla(205, 70%, 15%, 0.25) 0 4px 8px, hsla(205, 70%, 15%, 0.31) 0px 0px 1px;
   background-color: white;
   z-index: 10;
   max-height: 250px;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -320,11 +320,11 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0(playwright@1.34.3)
       prettier:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.8.8
+        version: 2.8.8
       prettier-plugin-packagejson:
         specifier: ^2.4.3
-        version: 2.4.3(prettier@3.0.0)
+        version: 2.4.3(prettier@2.8.8)
       remirror:
         specifier: 2.0.35
         version: link:packages/remirror
@@ -807,9 +807,12 @@ importers:
       '@remirror/pm':
         specifier: ^2.0.8
         version: link:../remirror__pm
+      '@types/prettier':
+        specifier: ^2.7.2
+        version: 2.7.2
       prettier:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.8.8
+        version: 2.8.8
 
   packages/remirror__cli:
     dependencies:
@@ -1013,7 +1016,7 @@ importers:
         version: link:../remirror__react-core
       prosemirror-dev-toolkit:
         specifier: ^1.1.4
-        version: 1.1.4(svelte@4.1.2)
+        version: 1.1.4(svelte@4.1.1)
     devDependencies:
       '@remirror/pm':
         specifier: ^2.0.8
@@ -1166,9 +1169,6 @@ importers:
       '@babel/runtime':
         specifier: ^7.22.3
         version: 7.22.3
-      '@prettier/sync':
-        specifier: ^0.3.0
-        version: 0.3.0(prettier@3.0.0)
       '@remirror/core':
         specifier: ^2.0.19
         version: link:../remirror__core
@@ -1191,12 +1191,15 @@ importers:
       '@types/jsdom':
         specifier: ^16.2.15
         version: 16.2.15
+      '@types/prettier':
+        specifier: ^2.7.2
+        version: 2.7.2
       jsdom:
         specifier: ^17.0.0
         version: 17.0.0
       prettier:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.8.8
+        version: 2.8.8
 
   packages/remirror__extension-codemirror5:
     dependencies:
@@ -3718,8 +3721,8 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6(postcss@8.4.14)
       prettier:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.8.8
+        version: 2.8.8
       remixicon:
         specifier: ^2.5.0
         version: 2.5.0
@@ -11500,14 +11503,6 @@ packages:
       - supports-color
     dev: false
 
-  /@prettier/sync@0.3.0(prettier@3.0.0):
-    resolution: {integrity: sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==}
-    peerDependencies:
-      prettier: ^3.0.0
-    dependencies:
-      prettier: 3.0.0
-    dev: false
-
   /@react-spring/mock-raf@1.1.1:
     resolution: {integrity: sha512-SPgq9cenqdkqzxg1zYKEOkao5Boob2sG8QTxiSoHT7NyZoTZKnDcalvRtW9AmZBcbUHy8UtqCKfBWKyB2PSlmQ==}
     dev: false
@@ -16871,8 +16866,8 @@ packages:
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
 
-  /decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+  /decode-uri-component@0.2.0:
+    resolution: {integrity: sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==}
     engines: {node: '>=0.10'}
     dev: false
 
@@ -17317,7 +17312,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.2.0-dev.20230802
+      typescript: 5.2.0-dev.20230803
     dev: false
 
   /duplexer3@0.1.4:
@@ -22356,13 +22351,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
-  /magic-string@0.30.2:
-    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
-    dev: false
-
   /make-dir@1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
     engines: {node: '>=4'}
@@ -24617,7 +24605,7 @@ packages:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
 
-  /prettier-plugin-packagejson@2.4.3(prettier@3.0.0):
+  /prettier-plugin-packagejson@2.4.3(prettier@2.8.8):
     resolution: {integrity: sha512-kPeeviJiwy0BgOSk7No8NmzzXfW4R9FYWni6ziA5zc1kGVVrKnBzMZdu2TUhI+I7h8/5Htt3vARYOk7KKJTTNQ==}
     peerDependencies:
       prettier: '>= 1.16.0'
@@ -24625,7 +24613,7 @@ packages:
       prettier:
         optional: true
     dependencies:
-      prettier: 3.0.0
+      prettier: 2.8.8
       sort-package-json: 2.4.1
       synckit: 0.8.5
     dev: false
@@ -24633,11 +24621,6 @@ packages:
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  /prettier@3.0.0:
-    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
-    engines: {node: '>=14'}
     hasBin: true
 
   /pretty-error@4.0.0:
@@ -24782,12 +24765,12 @@ packages:
       prosemirror-transform: 1.7.4
     dev: false
 
-  /prosemirror-dev-toolkit@1.1.4(svelte@4.1.2):
+  /prosemirror-dev-toolkit@1.1.4(svelte@4.1.1):
     resolution: {integrity: sha512-iHM57hCq7gLwRCfBe9aaI9zSsJCawCPKCJwxQNonTtazXjPDo7y6NxS2CKzTlODJVvQ8DvlWcR+ncC5lJDBO9A==}
     dependencies:
       html: 1.0.0
       prosemirror-model: 1.19.3
-      svelte-tree-view: 1.4.2(svelte@4.1.2)
+      svelte-tree-view: 1.4.2(svelte@4.1.1)
     transitivePeerDependencies:
       - svelte
     dev: false
@@ -26786,7 +26769,7 @@ packages:
     deprecated: See https://github.com/lydell/source-map-resolve#deprecated
     dependencies:
       atob: 2.1.2
-      decode-uri-component: 0.2.2
+      decode-uri-component: 0.2.0
       resolve-url: 0.2.1
       source-map-url: 0.4.1
       urix: 0.1.0
@@ -27303,16 +27286,16 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-tree-view@1.4.2(svelte@4.1.2):
+  /svelte-tree-view@1.4.2(svelte@4.1.1):
     resolution: {integrity: sha512-z3yQq+/4CceyefVj03t9BG9AiZ7syovmRRo96aj8V65d1FsRS/BL2AxzcD4vl5GJg7o9qbz2mWWJzyFWENISCQ==}
     peerDependencies:
       svelte: '>=3'
     dependencies:
-      svelte: 4.1.2
+      svelte: 4.1.1
     dev: false
 
-  /svelte@4.1.2:
-    resolution: {integrity: sha512-/evA8U6CgOHe5ZD1C1W3va9iJG7mWflcCdghBORJaAhD2JzrVERJty/2gl0pIPrJYBGZwZycH6onYf+64XXF9g==}
+  /svelte@4.1.1:
+    resolution: {integrity: sha512-Enick5fPFISLoVy0MFK45cG+YlQt6upw8skEK9zzTpJnH1DqEv8xOZwizCGSo3Q6HZ7KrZTM0J18poF7aQg5zw==}
     engines: {node: '>=16'}
     dependencies:
       '@ampproject/remapping': 2.2.1
@@ -27326,7 +27309,7 @@ packages:
       estree-walker: 3.0.3
       is-reference: 3.0.1
       locate-character: 3.0.0
-      magic-string: 0.30.2
+      magic-string: 0.30.0
       periscopic: 3.1.0
     dev: false
 
@@ -28006,8 +27989,8 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
-  /typescript@5.2.0-dev.20230802:
-    resolution: {integrity: sha512-rBvAnzaaMhwBAS2UaKejYhaED3VM74/xng/+xcVSst0PbkJBqggj19w/gwJ/4q07oOjKMgwunklsSjwe+iw2ZA==}
+  /typescript@5.2.0-dev.20230803:
+    resolution: {integrity: sha512-DwCyutWHyT7Il7xpJCxtx4/S5F4qjAo2SE6QDRSLhEUtBFGwGHTHCvuyfm9KNrdwn67jGitdlw4gpbSTVVjoww==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false

--- a/support/scripts/package.json
+++ b/support/scripts/package.json
@@ -94,7 +94,7 @@
     "postcss": "^8.4.24",
     "postcss-loader": "^6.2.1",
     "postcss-nested": "^5.0.6",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "remixicon": "^2.5.0",
     "rimraf": "^4.4.1",
     "semver": "^7.5.1",

--- a/support/scripts/src/generate-icons.ts
+++ b/support/scripts/src/generate-icons.ts
@@ -167,8 +167,8 @@ function generateIconExport(iconName: string, iconData: IconTree[] | undefined, 
   return `\
 /**
  * ${description} ![${capitalCase(
-   iconName,
- )}](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/${cdnPath})
+    iconName,
+  )}](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/${cdnPath})
  */
 export const ${iconName}: IconTree[] = ${JSON.stringify(iconData ?? [])};`;
 }
@@ -184,8 +184,8 @@ function generateComponentExport(componentName: string, iconName: string, cdnPat
   return `\
 /**
  * ${description} ![${capitalCase(
-   componentName,
- )}](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/${cdnPath})
+    componentName,
+  )}](https://cdn.jsdelivr.net/npm/remixicon@2.5.0/icons/${cdnPath})
  */
 export const ${componentName}: IconType = (props) => {
   return GenIcon(${iconName})(props);


### PR DESCRIPTION


### Description

This reverts https://github.com/remirror/remirror/pull/2139

Prettier v3 has changed all APIs to be asynchronous. ProseMirror's APIs are mostly synchronous, so using Prettier v3's API would be challenging (although possible). @prettier/sync provides a synchronous Prettier v3 API, but this library can only be used in a Node.js environment, so we cannot use it either.


<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
