### PR TITLE
feat(mention-atom): add leaf text for mention atom nodes

### DIFF
--- a/.changeset/friendly-pears-promise.md
+++ b/.changeset/friendly-pears-promise.md
@@ -1,0 +1,10 @@
+---
+'@remirror/extension-mention-atom': patch
+'@remirror/core-types': patch
+'remirror': patch
+'@remirror/core': patch
+---
+
+Return a mention atom' label via leaf text, so it is returned in the plain text of a document.
+
+Allow this to be overriden via the `nodeOverrides` API

--- a/packages/remirror__core-types/src/core-types.ts
+++ b/packages/remirror__core-types/src/core-types.ts
@@ -238,6 +238,7 @@ export type NodeSpecOverride = Pick<
   | 'defining'
   | 'isolating'
   | 'parseDOM'
+  | 'leafText'
 >;
 
 /**

--- a/packages/remirror__extension-mention-atom/__tests__/mention-atom-extension.spec.ts
+++ b/packages/remirror__extension-mention-atom/__tests__/mention-atom-extension.spec.ts
@@ -32,6 +32,10 @@ describe('schema', () => {
     `);
   });
 
+  it('creates the correct plain text, including the mention label', () => {
+    expect(p('Hello ', mentionAtom()).textContent).toBe('Hello @test');
+  });
+
   it('parses the dom structure and finds itself', () => {
     const node = htmlToProsemirrorNode({
       schema,

--- a/packages/remirror__extension-mention-atom/src/mention-atom-extension.ts
+++ b/packages/remirror__extension-mention-atom/src/mention-atom-extension.ts
@@ -13,6 +13,7 @@ import {
   NodeExtension,
   NodeExtensionSpec,
   NodeSpecOverride,
+  NodeWithAttributes,
   NodeWithPosition,
   omitExtraAttributes,
   pick,
@@ -150,6 +151,7 @@ export class MentionAtomExtension extends NodeExtension<MentionAtomOptions> {
       selectable: this.options.selectable,
       draggable: this.options.draggable,
       atom: true,
+      leafText: (node: NodeWithAttributes) => node.attrs.label,
       ...override,
       attrs: {
         ...extra.defaults(),


### PR DESCRIPTION
### Description

And a leaf text handler for Mention Atom nodes, so they appear in plain text presentations of the document.

Allow `leafText` to be overridden by the "node overrides" API

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
