### PR TITLE
feat: make `extension` decorator backwards compatible when called as function

### DIFF
--- a/.changeset/smart-garlics-bow.md
+++ b/.changeset/smart-garlics-bow.md
@@ -1,0 +1,8 @@
+---
+'@remirror/core': patch
+'remirror': patch
+---
+
+💥 BREAKING 💥: Remove deprecated decorator `extensionDecorator`. Please use `extension` instead
+
+Make `extension` decorator backwards compatible when called directly as a function.

--- a/docs/concepts/extension.md
+++ b/docs/concepts/extension.md
@@ -77,7 +77,7 @@ Options are used to configure the extension at runtime. They come in four differ
 import {
   CustomHandler,
   Dynamic,
-  extensionDecoration,
+  extension,
   ExtensionPriority,
   Handler,
   PlainExtension,

--- a/docs/concepts/keymap.md
+++ b/docs/concepts/keymap.md
@@ -18,13 +18,13 @@ The following is an example where the enter key can be customised to ignore all 
 The `next` method allows full control beyond the return value. It allows both calling all lower priority key bindings regardless of whether true or false has been called.
 
 ```tsx
-import { BaseExtensionOptions, extensionDecorator, KeyBindings, PlainExtension } from 'remirror';
+import { BaseExtensionOptions, extension, KeyBindings, PlainExtension } from 'remirror';
 
 interface CustomKeymapExtensionOptions {
   override?: boolean;
 }
 
-@extensionDecorator({ defaultOptions: { override: false } })
+@extension({ defaultOptions: { override: false } })
 export class CustomKeymapExtension extends PlainExtension<CustomKeymapExtensionOptions> {
   get name() {
     return 'customKeymap' as const;

--- a/docs/concepts/priority.md
+++ b/docs/concepts/priority.md
@@ -26,9 +26,9 @@ Now your customExtension will have a priority level that's higher than other ext
 If you have full control of the extension you can also set the `defaultPriority` as a static property with the `extension.
 
 ```ts
-import { Extension, extensionDecorator, ExtensionPriority } from 'remirror';
+import { Extension, extension, ExtensionPriority } from 'remirror';
 
-@extensionDecorator({
+@extension({
   // Now every custom extension created will have a `High` priority than default.
   defaultPriority: ExtensionPriority.High,
 })

--- a/packages/remirror__core-types/src/annotation-types.ts
+++ b/packages/remirror__core-types/src/annotation-types.ts
@@ -118,13 +118,13 @@ export type AcceptUndefined<Type> = Type & AcceptUndefinedAnnotation;
  * created to automate this.
  *
  * ```ts
- * import { PlainExtension, extensionDecorator } from 'remirror';
+ * import { PlainExtension, extension } from 'remirror';
  * interface CustomOptions {
  *   simple: boolean; // Automatically a dynamic property
  *   onChange: Handler<(value: string) => void>;
  * }
  *
- * @extensionDecorator({ handlerKeys: ['onChange'] }) class CustomExtension
+ * @extension({ handlerKeys: ['onChange'] }) class CustomExtension
  * extends PlainExtension<CustomOptions> {get name() {return 'custom' as const;
  *   }
  * }

--- a/packages/remirror__core/__tests__/decorators.spec.ts
+++ b/packages/remirror__core/__tests__/decorators.spec.ts
@@ -51,7 +51,6 @@ describe('@extension', () => {
           return 'test' as const;
         }
       },
-      { kind: 'class' } as any,
     );
 
     expect(TestExtension.staticKeys).toEqual(['type']);

--- a/packages/remirror__core/src/extension/extension-decorator.ts
+++ b/packages/remirror__core/src/extension/extension-decorator.ts
@@ -201,8 +201,3 @@ export function extension<Options extends Shape = EmptyShape>(
     return Cast<Type>(Constructor);
   };
 }
-
-/**
- * @deprecated use `extension` instead.
- */
-export const extensionDecorator = extension;

--- a/packages/remirror__core/src/extension/extension-decorator.ts
+++ b/packages/remirror__core/src/extension/extension-decorator.ts
@@ -156,9 +156,11 @@ export function extension<Options extends Shape = EmptyShape>(
 ) {
   return <Type extends AnyExtensionConstructor>(
     ReadonlyConstructor: Type,
-    context: ClassDecoratorContext<Type>,
+    context?: ClassDecoratorContext<Type>,
   ): Type => {
-    if (context.kind !== 'class') {
+    // context may be undefined if this decorator is called as a function
+    // which is supported for backward compatibility
+    if (context && context.kind !== 'class') {
       throw new Error(`The extension decorator can only be used on a class.`);
     }
 


### PR DESCRIPTION
### Description

💥 BREAKING 💥: Remove deprecated decorator `extensionDecorator`. Please use `extension` instead

Make `extension` decorator backwards compatible when called directly as a function.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
