### PR TITLE
feat(pm): prosemirror dependencies update

### DIFF
--- a/.changeset/clever-lions-breathe.md
+++ b/.changeset/clever-lions-breathe.md
@@ -1,0 +1,14 @@
+---
+'prosemirror-paste-rules': patch
+'prosemirror-resizable-view': patch
+'prosemirror-suggest': patch
+'prosemirror-trailing-node': patch
+'@remirror/extension-doc': patch
+'@remirror/extension-yjs': patch
+'@remirror/pm': patch
+'remirror': patch
+---
+
+Update ProseMirror packages to latest versions.
+
+Use newly provided `Transform.setDocAttribute` to update doc node attributes, rather than custom step type.

--- a/packages/prosemirror-paste-rules/package.json
+++ b/packages/prosemirror-paste-rules/package.json
@@ -42,12 +42,12 @@
     "@remirror/cli": "1.0.1",
     "prosemirror-model": "^1.19.3",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-view": "^1.31.7"
+    "prosemirror-view": "^1.32.3"
   },
   "peerDependencies": {
     "prosemirror-model": "^1.19.0",
     "prosemirror-state": "^1.4.2",
-    "prosemirror-view": "^1.31.2"
+    "prosemirror-view": "^1.32.3"
   },
   "peerDependenciesMeta": {},
   "publishConfig": {

--- a/packages/prosemirror-resizable-view/package.json
+++ b/packages/prosemirror-resizable-view/package.json
@@ -42,7 +42,7 @@
     "@remirror/core-helpers": "4.0.0-beta.0",
     "@remirror/core-utils": "3.0.0-beta.0",
     "prosemirror-model": "^1.19.3",
-    "prosemirror-view": "^1.31.7"
+    "prosemirror-view": "^1.32.3"
   },
   "devDependencies": {
     "@remirror/cli": "1.0.1"

--- a/packages/prosemirror-suggest/package.json
+++ b/packages/prosemirror-suggest/package.json
@@ -43,12 +43,12 @@
     "@remirror/cli": "1.0.1",
     "prosemirror-model": "^1.19.3",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-view": "^1.31.7"
+    "prosemirror-view": "^1.32.3"
   },
   "peerDependencies": {
     "prosemirror-model": "^1.19.0",
     "prosemirror-state": "^1.4.2",
-    "prosemirror-view": "^1.31.2"
+    "prosemirror-view": "^1.32.3"
   },
   "peerDependenciesMeta": {},
   "publishConfig": {

--- a/packages/prosemirror-trailing-node/package.json
+++ b/packages/prosemirror-trailing-node/package.json
@@ -41,12 +41,12 @@
     "@remirror/cli": "1.0.1",
     "prosemirror-model": "^1.19.3",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-view": "^1.31.7"
+    "prosemirror-view": "^1.32.3"
   },
   "peerDependencies": {
     "prosemirror-model": "^1.19.0",
     "prosemirror-state": "^1.4.2",
-    "prosemirror-view": "^1.31.2"
+    "prosemirror-view": "^1.32.3"
   },
   "peerDependenciesMeta": {},
   "publishConfig": {

--- a/packages/remirror__extension-doc/__tests__/doc-extension.spec.ts
+++ b/packages/remirror__extension-doc/__tests__/doc-extension.spec.ts
@@ -46,6 +46,76 @@ test('supports docAttributes with default values', () => {
   });
 });
 
+describe('commands', () => {
+  describe('setDocAttributes', () => {
+    it('can set all of the known doc attributes', () => {
+      const { add, nodes, attributeNodes, commands, view } = renderEditor([
+        new DocExtension({ docAttributes: ['foo', 'baz'] }),
+      ]);
+      const { p } = nodes;
+      const { doc } = attributeNodes;
+
+      add(doc()(p('')));
+
+      expect(view.state.doc.attrs).toEqual({ foo: null, baz: null });
+
+      commands.setDocAttributes({ foo: 'bar', baz: 'qux' });
+
+      expect(view.state.doc).toEqualProsemirrorNode(
+        //
+        doc({ foo: 'bar', baz: 'qux' })(
+          //
+          p(),
+        ),
+      );
+    });
+
+    it('ignores unknown doc attributes', () => {
+      const { add, nodes, attributeNodes, commands, view } = renderEditor([
+        new DocExtension({ docAttributes: ['foo', 'baz'] }),
+      ]);
+      const { p } = nodes;
+      const { doc } = attributeNodes;
+
+      add(doc()(p('')));
+
+      expect(view.state.doc.attrs).toEqual({ foo: null, baz: null });
+
+      commands.setDocAttributes({ not: 'exists' });
+
+      expect(view.state.doc).toEqualProsemirrorNode(
+        //
+        doc({ foo: null, baz: null })(
+          //
+          p(),
+        ),
+      );
+    });
+
+    it('can set a subset of the known doc attributes', () => {
+      const { add, nodes, attributeNodes, commands, view } = renderEditor([
+        new DocExtension({ docAttributes: ['foo', 'baz'] }),
+      ]);
+      const { p } = nodes;
+      const { doc } = attributeNodes;
+
+      add(doc()(p('')));
+
+      expect(view.state.doc.attrs).toEqual({ foo: null, baz: null });
+
+      commands.setDocAttributes({ baz: 'qux' });
+
+      expect(view.state.doc).toEqualProsemirrorNode(
+        //
+        doc({ foo: null, baz: 'qux' })(
+          //
+          p(),
+        ),
+      );
+    });
+  });
+});
+
 describe('helpers', () => {
   describe('`isDefaultDocNode`', () => {
     it('returns true if the current doc contains the default content', () => {

--- a/packages/remirror__extension-yjs/package.json
+++ b/packages/remirror__extension-yjs/package.json
@@ -46,7 +46,7 @@
     "@remirror/messages": "3.0.0-beta.0",
     "prosemirror-model": "^1.19.3",
     "prosemirror-state": "^1.4.3",
-    "prosemirror-view": "^1.31.7",
+    "prosemirror-view": "^1.32.3",
     "y-prosemirror": "^1.0.19",
     "y-protocols": "^1.0.5"
   },

--- a/packages/remirror__pm/package.json
+++ b/packages/remirror__pm/package.json
@@ -146,8 +146,8 @@
     "prosemirror-suggest": "3.0.0-beta.0",
     "prosemirror-tables": "^1.3.4",
     "prosemirror-trailing-node": "^3.0.0-beta.0",
-    "prosemirror-transform": "^1.7.4",
-    "prosemirror-view": "^1.31.7"
+    "prosemirror-transform": "^1.8.0",
+    "prosemirror-view": "^1.32.3"
   },
   "devDependencies": {
     "@remirror/cli": "1.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         version: 5.16.5
       '@testing-library/react-hooks':
         specifier: ^8.0.1
-        version: 8.0.1(@types/react@18.2.0)(react-dom@18.2.0)(react-test-renderer@18.2.0)(react@18.2.0)
+        version: 8.0.1(react@17.0.2)
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.4.3(@testing-library/dom@9.3.0)
@@ -551,8 +551,8 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3
       prosemirror-view:
-        specifier: ^1.31.7
-        version: 1.31.7
+        specifier: ^1.32.3
+        version: 1.32.3
 
   packages/prosemirror-resizable-view:
     dependencies:
@@ -569,8 +569,8 @@ importers:
         specifier: ^1.19.3
         version: 1.19.3
       prosemirror-view:
-        specifier: ^1.31.7
-        version: 1.31.7
+        specifier: ^1.32.3
+        version: 1.32.3
     devDependencies:
       '@remirror/cli':
         specifier: 1.0.1
@@ -604,8 +604,8 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3
       prosemirror-view:
-        specifier: ^1.31.7
-        version: 1.31.7
+        specifier: ^1.32.3
+        version: 1.32.3
 
   packages/prosemirror-trailing-node:
     dependencies:
@@ -629,8 +629,8 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3
       prosemirror-view:
-        specifier: ^1.31.7
-        version: 1.31.7
+        specifier: ^1.32.3
+        version: 1.32.3
 
   packages/remirror:
     dependencies:
@@ -2539,11 +2539,11 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3
       prosemirror-view:
-        specifier: ^1.31.7
-        version: 1.31.7
+        specifier: ^1.32.3
+        version: 1.32.3
       y-prosemirror:
         specifier: ^1.0.19
-        version: 1.2.1(patch_hash=qmoqv2ukd266e4uf7e6uwxdto4)(prosemirror-model@1.19.3)(prosemirror-state@1.4.3)(prosemirror-view@1.31.7)(y-protocols@1.0.5)(yjs@13.6.1)
+        version: 1.2.1(patch_hash=qmoqv2ukd266e4uf7e6uwxdto4)(prosemirror-model@1.19.3)(prosemirror-state@1.4.3)(prosemirror-view@1.32.3)(y-protocols@1.0.5)(yjs@13.6.1)
       y-protocols:
         specifier: ^1.0.5
         version: 1.0.5
@@ -2684,11 +2684,11 @@ importers:
         specifier: ^3.0.0-beta.0
         version: link:../prosemirror-trailing-node
       prosemirror-transform:
-        specifier: ^1.7.4
-        version: 1.7.4
+        specifier: ^1.8.0
+        version: 1.8.0
       prosemirror-view:
-        specifier: ^1.31.7
-        version: 1.31.7
+        specifier: ^1.32.3
+        version: 1.32.3
     devDependencies:
       '@remirror/cli':
         specifier: 1.0.1
@@ -5137,6 +5137,7 @@ packages:
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5150,6 +5151,7 @@ packages:
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.1):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5163,6 +5165,7 @@ packages:
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5254,6 +5257,7 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5265,6 +5269,7 @@ packages:
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.22.1):
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5276,6 +5281,7 @@ packages:
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5287,6 +5293,7 @@ packages:
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.22.1):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5298,6 +5305,7 @@ packages:
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5309,6 +5317,7 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5320,6 +5329,7 @@ packages:
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.22.1):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5343,6 +5353,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.8):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5357,6 +5368,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.22.1):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5383,6 +5395,7 @@ packages:
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5395,6 +5408,7 @@ packages:
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.22.1):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5407,6 +5421,7 @@ packages:
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5419,6 +5434,7 @@ packages:
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.8):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -5432,6 +5448,7 @@ packages:
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.22.1):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -8836,12 +8853,12 @@ packages:
       semver: 7.5.4
       serve-handler: 6.1.3
       shelljs: 0.8.5
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.76)(esbuild@0.17.19)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.76)(webpack@5.88.2)
       tslib: 2.6.2
       update-notifier: 5.1.0
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
       wait-on: 6.0.1
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
       webpack-bundle-analyzer: 4.5.0
       webpack-dev-server: 4.9.3(webpack@5.88.2)
       webpack-merge: 5.8.0
@@ -8919,7 +8936,7 @@ packages:
       unified: 9.2.2
       unist-util-visit: 2.0.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -9011,7 +9028,7 @@ packages:
       tslib: 2.6.2
       unist-util-visit: 2.0.3
       utility-types: 3.10.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -9052,7 +9069,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
       utility-types: 3.10.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -9085,7 +9102,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.2
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -9245,7 +9262,7 @@ packages:
       react-waypoint: 10.3.0(react@18.2.0)
       sharp: 0.30.7
       tslib: 2.6.2
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/core'
@@ -9557,7 +9574,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
       utility-types: 3.10.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
       webpack-merge: 5.8.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -9622,7 +9639,7 @@ packages:
       shelljs: 0.8.5
       tslib: 2.6.2
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.88.2)
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -13442,6 +13459,27 @@ packages:
       react-test-renderer: 18.2.0(react@18.2.0)
     dev: false
 
+  /@testing-library/react-hooks@8.0.1(react@17.0.2):
+    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0
+      react: ^16.9.0 || ^17.0.0
+      react-dom: ^16.9.0 || ^17.0.0
+      react-test-renderer: ^16.9.0 || ^17.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.6
+      react: 17.0.2
+      react-error-boundary: 3.1.4(react@17.0.2)
+    dev: false
+
   /@testing-library/react@14.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==}
     engines: {node: '>=14'}
@@ -16716,7 +16754,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /core-js-compat@3.30.2:
@@ -16949,7 +16987,7 @@ packages:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /css-select-base-adapter@0.1.1:
@@ -17719,7 +17757,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20231009
+      typescript: 5.4.0-dev.20231105
     dev: false
 
   /duplexer3@0.1.4:
@@ -18004,7 +18042,7 @@ packages:
       esbuild: 0.19.4
       get-tsconfig: 4.7.0
       loader-utils: 2.0.4
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
       webpack-sources: 1.4.3
     dev: false
 
@@ -19040,7 +19078,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /file-name@0.1.0:
@@ -19300,7 +19338,7 @@ packages:
       semver: 7.5.4
       tapable: 1.1.3
       typescript: 5.0.4
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /fork-ts-checker-webpack-plugin@7.3.0(typescript@5.0.4)(webpack@5.88.2):
@@ -23249,7 +23287,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /minimalistic-assert@1.0.1:
@@ -24740,7 +24778,7 @@ packages:
       klona: 2.0.5
       postcss: 8.4.14
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
 
   /postcss-loader@7.0.0(postcss@8.4.14)(webpack@5.88.2):
     resolution: {integrity: sha512-IDyttebFzTSY6DI24KuHUcBjbAev1i+RyICoPEWcAstZsj03r533uMXtDn506l6/wlsRYiS5XBdx7TpccCsyUg==}
@@ -24753,7 +24791,7 @@ packages:
       klona: 2.0.5
       postcss: 8.4.14
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /postcss-merge-idents@5.1.1(postcss@8.4.14):
@@ -25287,7 +25325,7 @@ packages:
     dependencies:
       prosemirror-model: 1.19.3
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
+      prosemirror-transform: 1.8.0
     dev: false
 
   /prosemirror-dev-toolkit@1.1.4(svelte@4.2.1):
@@ -25304,8 +25342,8 @@ packages:
     resolution: {integrity: sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==}
     dependencies:
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
-      prosemirror-view: 1.31.7
+      prosemirror-transform: 1.8.0
+      prosemirror-view: 1.32.3
     dev: false
 
   /prosemirror-gapcursor@1.3.2:
@@ -25314,15 +25352,15 @@ packages:
       prosemirror-keymap: 1.2.2
       prosemirror-model: 1.19.3
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.31.7
+      prosemirror-view: 1.32.3
     dev: false
 
   /prosemirror-history@1.3.2:
     resolution: {integrity: sha512-/zm0XoU/N/+u7i5zepjmZAEnpvjDtzoPWW6VmKptcAnPadN/SStsBjMImdCEbb3seiNTpveziPTIrXQbHLtU1g==}
     dependencies:
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
-      prosemirror-view: 1.31.7
+      prosemirror-transform: 1.8.0
+      prosemirror-view: 1.32.3
       rope-sequence: 1.3.2
     dev: false
 
@@ -25330,7 +25368,7 @@ packages:
     resolution: {integrity: sha512-3LrWJX1+ULRh5SZvbIQlwZafOXqp1XuV21MGBu/i5xsztd+9VD15x6OtN6mdqSFI7/8Y77gYUbQ6vwwJ4mr6QQ==}
     dependencies:
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
+      prosemirror-transform: 1.8.0
     dev: false
 
   /prosemirror-keymap@1.2.2:
@@ -25356,15 +25394,15 @@ packages:
     dependencies:
       prosemirror-model: 1.19.3
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
+      prosemirror-transform: 1.8.0
     dev: false
 
   /prosemirror-state@1.4.3:
     resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
     dependencies:
       prosemirror-model: 1.19.3
-      prosemirror-transform: 1.7.4
-      prosemirror-view: 1.31.7
+      prosemirror-transform: 1.8.0
+      prosemirror-view: 1.32.3
 
   /prosemirror-tables@1.3.4:
     resolution: {integrity: sha512-z6uLSQ1BLC3rgbGwZmpfb+xkdvD7W/UOsURDfognZFYaTtc0gsk7u/t71Yijp2eLflVpffMk6X0u0+u+MMDvIw==}
@@ -25372,8 +25410,8 @@ packages:
       prosemirror-keymap: 1.2.2
       prosemirror-model: 1.19.3
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
-      prosemirror-view: 1.31.7
+      prosemirror-transform: 1.8.0
+      prosemirror-view: 1.32.3
     dev: false
 
   /prosemirror-test-builder@1.1.1:
@@ -25384,17 +25422,17 @@ packages:
       prosemirror-schema-list: 1.3.0
     dev: false
 
-  /prosemirror-transform@1.7.4:
-    resolution: {integrity: sha512-GO38mvqJ2yeI0BbL5E1CdHcly032Dlfn9nHqlnCHqlNf9e9jZwJixxp6VRtOeDZ1uTDpDIziezMKbA41LpAx3A==}
+  /prosemirror-transform@1.8.0:
+    resolution: {integrity: sha512-BaSBsIMv52F1BVVMvOmp1yzD3u65uC3HTzCBQV1WDPqJRQ2LuHKcyfn0jwqodo8sR9vVzMzZyI+Dal5W9E6a9A==}
     dependencies:
       prosemirror-model: 1.19.3
 
-  /prosemirror-view@1.31.7:
-    resolution: {integrity: sha512-Pr7w93yOYmxQwzGIRSaNLZ/1uM6YjnenASzN2H6fO6kGekuzRbgZ/4bHbBTd1u4sIQmL33/TcGmzxxidyPwCjg==}
+  /prosemirror-view@1.32.3:
+    resolution: {integrity: sha512-tP7AUTxisM0m3PDxs6vDWgTjgcbFo4fnwg2M/5NHlgMqUJgBNOqSUZETBZKmLD7AxGN3GZ5yqEzQv9r9VCZKrg==}
     dependencies:
       prosemirror-model: 1.19.3
       prosemirror-state: 1.4.3
-      prosemirror-transform: 1.7.4
+      prosemirror-transform: 1.8.0
 
   /protoduck@4.0.0:
     resolution: {integrity: sha512-9sxuz0YTU/68O98xuDn8NBxTVH9EuMhrBTxZdiBL0/qxRmWhB/5a8MagAebDa+98vluAZTs8kMZibCdezbRCeQ==}
@@ -25623,7 +25661,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /rc@1.2.8:
@@ -25712,7 +25750,7 @@ packages:
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.0.4
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -25767,6 +25805,16 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.1.0
     dev: true
+
+  /react-error-boundary@3.1.4(react@17.0.2):
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.22.6
+      react: 17.0.2
+    dev: false
 
   /react-error-boundary@3.1.4(react@18.2.0):
     resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
@@ -25921,7 +25969,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.6
       react-loadable: /@docusaurus/react-loadable@5.5.2(react@18.2.0)
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /react-refresh@0.14.0:
@@ -28114,6 +28162,30 @@ packages:
       terser: 5.17.6
       webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
 
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.76)(webpack@5.88.2):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.19
+      '@swc/core': 1.3.76
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.17.6
+      webpack: 5.88.2(@swc/core@1.3.76)
+
   /terser@4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
     engines: {node: '>=6.0.0'}
@@ -28324,6 +28396,7 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
     dev: true
 
   /trough@1.0.5:
@@ -28618,8 +28691,8 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
-  /typescript@5.3.0-dev.20231009:
-    resolution: {integrity: sha512-0JwLa29peN3wK/3uUMHTr9bzLwJ7BIloeN3JTyHj0aeyoowNMJXjpVMSTu8geVzfP4RPL9vM/7iyVPrPBmLBaQ==}
+  /typescript@5.4.0-dev.20231105:
+    resolution: {integrity: sha512-TN7QRSjarOvoxvHuZdVmofCnXJYklxsiZ1tyJKiKkghPWXwrkQ68R3NN3vhtS8B+jIeZoETKssmfbmhCl8rwxQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: false
@@ -28942,7 +29015,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /url-parse-lax@1.0.0:
@@ -29383,7 +29456,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
       webpack-dev-middleware: 5.3.1(webpack@5.88.2)
       ws: 8.13.0
     transitivePeerDependencies:
@@ -29424,6 +29497,45 @@ packages:
   /webpack-virtual-modules@0.4.6:
     resolution: {integrity: sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==}
     dev: true
+
+  /webpack@5.88.2(@swc/core@1.3.76):
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.5
+      '@types/estree': 1.0.2
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
+      browserslist: 4.22.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.76)(webpack@5.88.2)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   /webpack@5.88.2(@swc/core@1.3.76)(esbuild@0.17.19):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
@@ -29474,7 +29586,7 @@ packages:
       consola: 2.15.3
       pretty-time: 1.1.0
       std-env: 3.1.1
-      webpack: 5.88.2(@swc/core@1.3.76)(esbuild@0.17.19)
+      webpack: 5.88.2(@swc/core@1.3.76)
     dev: true
 
   /websocket-driver@0.7.4:
@@ -29796,7 +29908,7 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  /y-prosemirror@1.2.1(patch_hash=qmoqv2ukd266e4uf7e6uwxdto4)(prosemirror-model@1.19.3)(prosemirror-state@1.4.3)(prosemirror-view@1.31.7)(y-protocols@1.0.5)(yjs@13.6.1):
+  /y-prosemirror@1.2.1(patch_hash=qmoqv2ukd266e4uf7e6uwxdto4)(prosemirror-model@1.19.3)(prosemirror-state@1.4.3)(prosemirror-view@1.32.3)(y-protocols@1.0.5)(yjs@13.6.1):
     resolution: {integrity: sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==}
     peerDependencies:
       prosemirror-model: ^1.7.1
@@ -29808,7 +29920,7 @@ packages:
       lib0: 0.2.74
       prosemirror-model: 1.19.3
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.31.7
+      prosemirror-view: 1.32.3
       y-protocols: 1.0.5
       yjs: 13.6.1
     dev: false


### PR DESCRIPTION
### Description

Update ProseMirror packages to latest versions.

Use newly provided `Transform.setDocAttribute` to update doc node attributes, rather than custom step type.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
