### PR TITLE
feat(tables): add opt-in `Tab` and `Shift-Tab` keyboard shortcuts

### DIFF
--- a/.changeset/weak-tigers-share.md
+++ b/.changeset/weak-tigers-share.md
@@ -1,0 +1,6 @@
+---
+'@remirror/extension-tables': minor
+'remirror': patch
+---
+
+Add a `tabKeyboardShortcuts` option to `TableExtension` to enable `Tab` and `Shift-Tab` keyboard shortcuts for navigating between table cells. Defaults to `false`.

--- a/packages/remirror__extension-tables/src/table-extensions.ts
+++ b/packages/remirror__extension-tables/src/table-extensions.ts
@@ -13,6 +13,8 @@ import {
   Helper,
   helper,
   isElementDomNode,
+  keyBinding,
+  KeyBindingProps,
   NodeExtension,
   NodeSpecOverride,
   nonChainable,
@@ -36,6 +38,7 @@ import {
   deleteTable,
   fixTables,
   fixTablesKey,
+  goToNextCell,
   isCellSelection,
   mergeCells,
   rowIsHeader,
@@ -77,6 +80,13 @@ export interface TableOptions {
    * The options passed to the column resizing plugin
    */
   resizeableOptions?: TableResizableOptions;
+
+  /**
+   * Whether to use Tab and Shift-Tab to navigate between cells
+   *
+   * @defaultValue: false
+   */
+  tabKeyboardShortcuts?: boolean;
 }
 
 let tablesEnabled = false;
@@ -85,6 +95,7 @@ let tablesEnabled = false;
   defaultOptions: {
     resizable: true,
     resizeableOptions: {},
+    tabKeyboardShortcuts: false,
   },
   defaultPriority: ExtensionPriority.Default,
 })
@@ -449,6 +460,22 @@ export class TableExtension extends NodeExtension<TableOptions> {
       dispatch?.(tr);
       return true;
     };
+  }
+
+  @keyBinding<TableExtension>({
+    shortcut: 'Tab',
+    isActive: (options) => options.tabKeyboardShortcuts,
+  })
+  goToNextCell(props: KeyBindingProps): boolean {
+    return convertCommand(goToNextCell(1))(props);
+  }
+
+  @keyBinding<TableExtension>({
+    shortcut: 'Shift-Tab',
+    isActive: (options) => options.tabKeyboardShortcuts,
+  })
+  goToPreviousCell(props: KeyBindingProps): boolean {
+    return convertCommand(goToNextCell(-1))(props);
   }
 
   /**


### PR DESCRIPTION
### Description

Add a `tabKeyboardShortcuts` option to `TableExtension` to enable `Tab` and `Shift-Tab` keyboard shortcuts for navigating between table cells. 

Defaults to `false`.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
