### PR TITLE
fix(table-extension): apply correct attrs.style

### DIFF
--- a/.changeset/tough-ladybugs-marry.md
+++ b/.changeset/tough-ladybugs-marry.md
@@ -3,4 +3,4 @@
 "@remirror/extension-tables": patch
 ---
 
-3ce5fa6: Update the reference from `attrs.style` to `node.attrs.style` as we need to get the style from the node first and then override the background property.
+Update the reference from `attrs.style` to `node.attrs.style` as we need to get the style from the node first and then override the background property when updating the table cell style.

--- a/.changeset/tough-ladybugs-marry.md
+++ b/.changeset/tough-ladybugs-marry.md
@@ -1,6 +1,6 @@
 ---
-"remirror": patch
-"@remirror/extension-tables": patch
+'remirror': patch
+'@remirror/extension-tables': patch
 ---
 
 Fix a bug where calling `commands.setTableCellBackground` overrides the style attribute of the table cell node.

--- a/.changeset/tough-ladybugs-marry.md
+++ b/.changeset/tough-ladybugs-marry.md
@@ -3,4 +3,4 @@
 "@remirror/extension-tables": patch
 ---
 
-Update the reference from `attrs.style` to `node.attrs.style` as we need to get the style from the node first and then override the background property when updating the table cell style.
+Fix a bug where calling `commands.setTableCellBackground` overrides the style attribute of the table cell node.

--- a/.changeset/tough-ladybugs-marry.md
+++ b/.changeset/tough-ladybugs-marry.md
@@ -1,0 +1,6 @@
+---
+"remirror": patch
+"@remirror/extension-tables": patch
+---
+
+3ce5fa6: Update the reference from `attrs.style` to `node.attrs.style` as we need to get the style from the node first and then override the background property.

--- a/packages/remirror__extension-tables/src/table-utils.ts
+++ b/packages/remirror__extension-tables/src/table-utils.ts
@@ -86,7 +86,7 @@ function setCellAttrs(node: ProsemirrorNode) {
   }
 
   if (node.attrs.background) {
-    attrs.style = `${attrs.style ?? ''}background-color: ${node.attrs.background as string};`;
+    attrs.style = `${node.attrs.style ?? ''}background-color: ${node.attrs.background as string};`;
     attrs['data-background-color'] = node.attrs.background;
   }
 


### PR DESCRIPTION
### Description

Calling `commands.setTableCellBackground` overrides the `style` attribute of the node. It updates the reference from `attrs.style` to `node.attrs.style` as we need to get the style from the node first and then override the `background` property.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

N\A
