### PR TITLE
ci: downgrade runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   # Lint the project
   lint:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
   # Typecheck the project
   typecheck:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
   # Unit test
   unit_test:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3
@@ -97,7 +97,7 @@ jobs:
   # Build the project and run tests on built files.
   build_test:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [16.x, 18.x]
@@ -123,7 +123,7 @@ jobs:
   # Check that package sizes are within their boundaries
   size_check:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   deploy_docs:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/v1' || github.ref == 'refs/heads/main' || github.event.pull_request
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
   # Run the e2e playwright tests
   playwright:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         server: [next, docs, storybook-react]

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/labeler@main
         if: "!contains(github.head_ref, 'changeset-release')"

--- a/.github/workflows/label-sponsors.yml
+++ b/.github/workflows/label-sponsors.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   label_sponsors:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: JasonEtco/is-sponsor-label-action@v1
         with:

--- a/.github/workflows/pr-name-linter.yml
+++ b/.github/workflows/pr-name-linter.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint-pr-name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish-pr.yml
+++ b/.github/workflows/publish-pr.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   publish_comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/publish' && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR') }}
     steps:
       - name: get pr information

--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -17,7 +17,7 @@ jobs:
   npm:
     if: github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout code repository

--- a/.github/workflows/publish-v3.yml
+++ b/.github/workflows/publish-v3.yml
@@ -17,7 +17,7 @@ jobs:
   npm:
     if: github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout code repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
   npm:
     if: github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout code repository

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   rebase:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   deploy_docs:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout code repository

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -21,7 +21,7 @@ jobs:
   # Update package versions with changesets.
   version:
     timeout-minutes: 50
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ false == contains(github.ref, 'changeset') && github.repository == 'remirror/remirror' }}
     steps:
       - name: checkout code repository


### PR DESCRIPTION
### Description

Downgrade the runner from ubuntu-latest to ubuntu-20.04. This should avoid the following error based on [this issue](https://github.com/actions/runner-images/issues/6709#issuecomment-1361269639).

> The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
> [source](https://github.com/remirror/remirror/actions/runs/7177092226)

<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
