### PR TITLE
fix(storybook): edit dialog on "edit-dialog" from "extension-link" stories disappears

### DIFF
--- a/packages/storybook-react/stories/extension-link/edit-dialog.tsx
+++ b/packages/storybook-react/stories/extension-link/edit-dialog.tsx
@@ -165,7 +165,6 @@ const FloatingLinkToolbar = () => {
         positioner='always'
         placement='bottom'
         enabled={isEditing}
-        renderOutsideEditor
       >
         <DelayAutoFocusInput
           style={{ zIndex: 20 }}


### PR DESCRIPTION
The popup does not appear if the floating wrapper is rendered outside the editor. Probably there's some bug somewhere, but for now this fixes it in the storybook.

### Description

There's some issue on this story from the storybook: https://remirror.vercel.app/?path=/story/extensions-link--edit-dialog

The popup does not appear when trying to edit the link (click on the link, then on the "pencil" icon). The popup appears, but immediately disappears.

That only happens if the floating wrapper is rendered outside the editor. Probably there's some bug somewhere, but for now this PR just fixes it in the storybook.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots
[Screencast from 28-02-24 13:47:17.webm](https://github.com/remirror/remirror/assets/3533970/9deb8738-051d-454e-972f-ba5d63593fe5)

