### PR TITLE
fix(docs): correct jest-remirror reference

### DIFF
--- a/packages/jest-prosemirror/readme.md
+++ b/packages/jest-prosemirror/readme.md
@@ -137,7 +137,7 @@ Create a test prosemirror editor.
 The call to create editor can be chained with various commands to enable testing of the editor at each step without the need for intermediate holding variables.
 
 ```ts
-import { createEditor, doc, p } from 'jest-remirror';
+import { createEditor, doc, p } from 'jest-prosemirror';
 import { suggest } from 'prosemirror-suggest';
 
 test('`keyBindings`', () => {


### PR DESCRIPTION
### Description
There's an import from `jest-remirror` in the docs for `jest-prosemirror`, fairly sure this is a typo.

### Checklist
- [X] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [X] My code follows the code style of this project and `pnpm fix` completed successfully.
- [X] I have updated the documentation where necessary.
- [X] New code is unit tested and all current tests pass when running `pnpm test`.
