### PR TITLE
docs: fix typo in extension.md

### DIFF
--- a/docs/concepts/extension.md
+++ b/docs/concepts/extension.md
@@ -35,7 +35,7 @@ There are three types of `Extension`.
 
 ## Lifecycle Methods
 
-Extensions can customise the editor via these **LifeCycle Methods**. Even core functionality like the creation of `Schema` is added to `remirror` via and `Extension`. The following is an outline of the lifecycle methods you can use while working with `remirror`.
+Extensions can customise the editor via these **LifeCycle Methods**. Even core functionality like the creation of `Schema` is added to `remirror` via an `Extension`. The following is an outline of the lifecycle methods you can use while working with `remirror`.
 
 ### `onCreate`
 


### PR DESCRIPTION
Fix typo in extension.md

### Description
Small typo fix on the extension documentation page.
<!-- Describe your changes in detail and reference any issues it addresses-->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [X] My code follows the code style of this project and `pnpm fix` completed successfully.
- [X] I have updated the documentation where necessary.
- [X] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots
n/a
<!-- Delete this section if not applicable -->
