### PR TITLE
refactor(jest-prosemirror): append element to DOM before EditorView initialization in `createEditor`

### DIFF
--- a/.changeset/honest-socks-sip.md
+++ b/.changeset/honest-socks-sip.md
@@ -1,0 +1,5 @@
+---
+'jest-prosemirror': minor
+---
+
+The editor element in `createEditor` is now appended to `document.body` before `EditorView` is initialized. This allows the use of `createEditor` with plugins that depend on the DOM.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -68,8 +68,7 @@
       "prosemirror-model",
       "prosemirror-state",
       "prosemirror-view",
-      "@remirror/core-constants",
-      "@remirror/core-helpers"
+      "@remirror/core-constants"
     ],
     "running": false,
     "gzip": true

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -112,7 +112,9 @@ export function createEditor(
 ): ProsemirrorTestChain {
   const { plugins = [], rules = [], autoClean = true, ...editorOptions } = options;
   const element = document.createElement('div');
+
   document.body.append(element);
+
   const state = createState(taggedDocument, [...plugins, inputRules({ rules })]);
   const view = new EditorView(element, {
     state,

--- a/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-editor.ts
@@ -112,14 +112,13 @@ export function createEditor(
 ): ProsemirrorTestChain {
   const { plugins = [], rules = [], autoClean = true, ...editorOptions } = options;
   const element = document.createElement('div');
+  document.body.append(element);
   const state = createState(taggedDocument, [...plugins, inputRules({ rules })]);
   const view = new EditorView(element, {
     state,
     plugins: [],
     ...editorOptions,
   }) as TestEditorView;
-
-  document.body.append(element);
 
   if (autoClean) {
     cleanupItems.add([view, element]);


### PR DESCRIPTION
### Description

Some `ProseMirror` plugins rely on the editor's outer DOM structure. For instance, if a plugin's [`view`](https://prosemirror.net/docs/ref/#state.PluginSpec.view) method uses something like `view.dom.parentElement`, it can lead to errors during tests because `parentElement` is `null` when the editor is created with `createEditor`. Appending the element to the DOM ensures plugins that depend on the DOM structure can be tested without issues, improving the robustness and reliability of the createEditor utility function.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

