### PR TITLE
fix(docs): fix crash in positioner extension storybook

### DIFF
--- a/packages/storybook-react/stories/extension-positioner/basic.tsx
+++ b/packages/storybook-react/stories/extension-positioner/basic.tsx
@@ -93,7 +93,7 @@ const selectionArgs: TemplateArgs = {
   placement: 'bottom',
   label: 'Anchored to the range text selection',
 };
-export const Selection: Story = (args) => <Template {...{ ...selectionArgs, ...args }} />;
+export const Selection: Story = (args) => <Template {...selectionArgs} {...args} />;
 Selection.args = { ...selectionArgs };
 
 const cursorArgs: TemplateArgs = {
@@ -102,7 +102,7 @@ const cursorArgs: TemplateArgs = {
   placement: 'bottom',
   label: 'Anchored to the empty selection (cursor)',
 };
-export const Cursor: Story = (args) => <Template {...{ ...cursorArgs, ...args }} />;
+export const Cursor: Story = (args) => <Template {...cursorArgs} {...args} />;
 Cursor.args = { ...cursorArgs };
 
 const alwaysArgs: TemplateArgs = {
@@ -112,7 +112,7 @@ const alwaysArgs: TemplateArgs = {
   placement: 'bottom',
   label: 'Anchored to the both range and empty selections',
 };
-export const Always: Story = (args) => <Template {...{ ...alwaysArgs, ...args }} />;
+export const Always: Story = (args) => <Template {...alwaysArgs} {...args} />;
 Always.args = { ...alwaysArgs };
 
 const blockArgs: TemplateArgs = {
@@ -121,7 +121,7 @@ const blockArgs: TemplateArgs = {
   placement: 'bottom',
   label: 'Takes the width of the current block node, placement prop can be changed',
 };
-export const Block: Story = (args) => <Template {...{ ...blockArgs, ...args }} />;
+export const Block: Story = (args) => <Template {...blockArgs} {...args} />;
 Block.args = { ...blockArgs };
 
 const emptyBlockArgs: TemplateArgs = {
@@ -131,7 +131,7 @@ const emptyBlockArgs: TemplateArgs = {
   placement: 'bottom',
   label: 'Takes the width of the current EMPTY block node, placement prop can be changed',
 };
-export const EmptyBlock: Story = (args) => <Template {...{ ...emptyBlockArgs, ...args }} />;
+export const EmptyBlock: Story = (args) => <Template {...emptyBlockArgs} {...args} />;
 EmptyBlock.args = { ...emptyBlockArgs };
 
 const emptyBlockStartArgs: TemplateArgs = {
@@ -140,9 +140,7 @@ const emptyBlockStartArgs: TemplateArgs = {
   placement: 'right',
   label: 'Positioned at the start of an EMPTY block node',
 };
-export const EmptyBlockStart: Story = (args) => (
-  <Template {...{ ...emptyBlockStartArgs, ...args }} />
-);
+export const EmptyBlockStart: Story = (args) => <Template {...emptyBlockStartArgs} {...args} />;
 EmptyBlockStart.args = { ...emptyBlockStartArgs };
 
 const emptyBlockEndArgs: TemplateArgs = {
@@ -151,7 +149,7 @@ const emptyBlockEndArgs: TemplateArgs = {
   placement: 'left',
   label: 'Positioned at the end of an EMPTY block node',
 };
-export const EmptyBlockEnd: Story = (args) => <Template {...{ ...emptyBlockEndArgs, ...args }} />;
+export const EmptyBlockEnd: Story = (args) => <Template {...emptyBlockEndArgs} {...args} />;
 EmptyBlockEnd.args = { ...emptyBlockEndArgs };
 
 export default Cursor;

--- a/packages/storybook-react/stories/extension-positioner/basic.tsx
+++ b/packages/storybook-react/stories/extension-positioner/basic.tsx
@@ -87,62 +87,71 @@ const Template: Story = ({ content, positioner, placement, label }: TemplateArgs
   );
 };
 
-export const Selection: Story = Template.bind({});
-Selection.args = {
+const selectionArgs: TemplateArgs = {
   content: '<p>Creates a rect which wraps the current selection.</p>',
   positioner: 'selection',
   placement: 'bottom',
   label: 'Anchored to the range text selection',
 };
+export const Selection: Story = (args) => <Template {...{ ...selectionArgs, ...args }} />;
+Selection.args = { ...selectionArgs };
 
-export const Cursor: Story = Template.bind({});
-Cursor.args = {
+const cursorArgs: TemplateArgs = {
   content: '<p>Creates a rect for the cursor. Is inactive for empty selections.</p>',
   positioner: 'cursor',
   placement: 'bottom',
   label: 'Anchored to the empty selection (cursor)',
 };
+export const Cursor: Story = (args) => <Template {...{ ...cursorArgs, ...args }} />;
+Cursor.args = { ...cursorArgs };
 
-export const Always: Story = Template.bind({});
-Always.args = {
+const alwaysArgs: TemplateArgs = {
   content:
     '<p>Creates a positioner which always shows the position of the selection whether empty or not.</p>',
   positioner: 'always',
   placement: 'bottom',
   label: 'Anchored to the both range and empty selections',
 };
+export const Always: Story = (args) => <Template {...{ ...alwaysArgs, ...args }} />;
+Always.args = { ...alwaysArgs };
 
-export const Block: Story = Template.bind({});
-Block.args = {
+const blockArgs: TemplateArgs = {
   content: '<p>Creates a rect which wraps the entire selected block node.</p>',
   positioner: 'block',
   placement: 'bottom',
   label: 'Takes the width of the current block node, placement prop can be changed',
 };
+export const Block: Story = (args) => <Template {...{ ...blockArgs, ...args }} />;
+Block.args = { ...blockArgs };
 
-export const EmptyBlock: Story = Template.bind({});
-EmptyBlock.args = {
+const emptyBlockArgs: TemplateArgs = {
   content:
     '<p>Creates a rect which wraps the entire selected block node, but only when it is empty.</p>',
   positioner: 'emptyBlock',
   placement: 'bottom',
   label: 'Takes the width of the current EMPTY block node, placement prop can be changed',
 };
+export const EmptyBlock: Story = (args) => <Template {...{ ...emptyBlockArgs, ...args }} />;
+EmptyBlock.args = { ...emptyBlockArgs };
 
-export const EmptyBlockStart: Story = Template.bind({});
-EmptyBlockStart.args = {
+const emptyBlockStartArgs: TemplateArgs = {
   content: '<p>Creates a rect which indicates the <em>start</em> of an empty block node.</p>',
   positioner: 'emptyBlockStart',
   placement: 'right',
   label: 'Positioned at the start of an EMPTY block node',
 };
+export const EmptyBlockStart: Story = (args) => (
+  <Template {...{ ...emptyBlockStartArgs, ...args }} />
+);
+EmptyBlockStart.args = { ...emptyBlockStartArgs };
 
-export const EmptyBlockEnd: Story = Template.bind({});
-EmptyBlockEnd.args = {
+const emptyBlockEndArgs: TemplateArgs = {
   content: '<p>Creates a rect which indicates the <em>end</em> of an empty block node.</p>',
   positioner: 'emptyBlockEnd',
   placement: 'left',
   label: 'Positioned at the end of an EMPTY block node',
 };
+export const EmptyBlockEnd: Story = (args) => <Template {...{ ...emptyBlockEndArgs, ...args }} />;
+EmptyBlockEnd.args = { ...emptyBlockEndArgs };
 
 export default Cursor;


### PR DESCRIPTION
### Description

This PR resolves the crash when you try to visit [https://remirror.io/docs/extensions/positioner-extension/](https://remirror.io/docs/extensions/positioner-extension/).

Storybook arguments are sometimes undefined when the positioner extension template renders. Especially the `positioner` argument does not tolerate `undefined`, causing the page to crash. This appears similar to issue https://github.com/storybookjs/storybook/issues/14732, but for React. Work around the issue by ensuring fallback arguments are available if storybook fails to provide them.

Fixes #2262

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

Before:
![image](https://github.com/remirror/remirror/assets/264920/fa666a50-3d51-400e-b5bc-e379aa9c0ae2)

After:
![image](https://github.com/remirror/remirror/assets/264920/62903672-0159-4c22-acd7-e79bf6482402)

