### PR TITLE
fix(extension-file): allow `fileSize` to be string

### DIFF
--- a/.changeset/nasty-impalas-search.md
+++ b/.changeset/nasty-impalas-search.md
@@ -1,4 +1,5 @@
 ---
+'remirror': patch
 '@remirror/extension-file': patch
 ---
 

--- a/.changeset/nasty-impalas-search.md
+++ b/.changeset/nasty-impalas-search.md
@@ -1,0 +1,5 @@
+---
+'@remirror/extension-file': patch
+---
+
+Allow file node attr `fileSize` to be a string.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,8 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.markdownlint": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.markdownlint": "explicit"
   },
 
   // Files

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -88,7 +88,7 @@ export class FileExtension extends NodeExtension<FileOptions> {
         url: { default: '', validate: 'string' },
         fileName: { default: '', validate: 'string' },
         fileType: { default: '', validate: 'string' },
-        fileSize: { default: 0, validate: 'number' },
+        fileSize: { default: 0, validate: 'string|number' },
         error: { default: null, validate: 'string|null' },
       },
       selectable: true,


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Allow `fileSize` attribute to be string type so that it's compatible with existing data.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
