### PR TITLE
fix: remove explicit validate properties

### DIFF
--- a/.changeset/dirty-penguins-help.md
+++ b/.changeset/dirty-penguins-help.md
@@ -1,0 +1,33 @@
+---
+'@remirror/extension-entity-reference': patch
+'@remirror/extension-node-formatting': patch
+'@remirror/extension-text-highlight': patch
+'@remirror/extension-mention-atom': patch
+'@remirror/extension-react-tables': patch
+'@remirror/extension-codemirror5': patch
+'@remirror/extension-codemirror6': patch
+'@remirror/extension-font-family': patch
+'@remirror/extension-code-block': patch
+'@remirror/extension-text-color': patch
+'@remirror/extension-font-size': patch
+'@remirror/extension-text-case': patch
+'@remirror/extension-callout': patch
+'@remirror/extension-columns': patch
+'@remirror/extension-heading': patch
+'@remirror/extension-mention': patch
+'@remirror/extension-tables': patch
+'@remirror/extension-embed': patch
+'@remirror/extension-emoji': patch
+'@remirror/extension-image': patch
+'@remirror/extension-bidi': patch
+'@remirror/extension-file': patch
+'@remirror/extension-link': patch
+'@remirror/extension-list': patch
+'@remirror/extension-doc': patch
+---
+
+Drop the explicit `validate` property, added to attributes in 2.0.39
+
+Some users have reported issues with legacy JSON data in JavaScript repos where attribute types have not been strictly checked (i.e. calling a command with a string attribute value instead of a number).
+
+The XSS issue in ProseMirror has been largely resolved since the changes added in prosemirror-model 1.22.1, which actively guards against corrupted-attribute XSS attacks in DOMSerializer. This makes the additional protection of an explicit `validate` attribute largely redundant.

--- a/packages/remirror__extension-bidi/src/bidi-extension.ts
+++ b/packages/remirror__extension-bidi/src/bidi-extension.ts
@@ -191,7 +191,7 @@ export class BidiExtension extends PlainExtension<BidiOptions> {
   private dir(): SchemaAttributesObject {
     return {
       default: this.options.defaultDirection ?? null,
-      validate: 'string',
+
       parseDOM: (element) => element.getAttribute('dir') ?? this.getDirection(element.textContent),
       toDOM: (_, { node }) => {
         if (!node) {

--- a/packages/remirror__extension-callout/src/callout-extension.ts
+++ b/packages/remirror__extension-callout/src/callout-extension.ts
@@ -93,8 +93,8 @@ export class CalloutExtension extends NodeExtension<CalloutOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        type: { default: defaultType, validate: 'string' },
-        emoji: { default: defaultEmoji, validate: 'string' },
+        type: { default: defaultType },
+        emoji: { default: defaultEmoji },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-code-block/src/code-block-extension.ts
+++ b/packages/remirror__extension-code-block/src/code-block-extension.ts
@@ -90,8 +90,8 @@ export class CodeBlockExtension extends NodeExtension<CodeBlockOptions> {
 
       attrs: {
         ...extra.defaults(),
-        language: { default: this.options.defaultLanguage, validate: 'string' },
-        wrap: { default: this.options.defaultWrap, validate: 'boolean' },
+        language: { default: this.options.defaultLanguage },
+        wrap: { default: this.options.defaultWrap },
       },
       parseDOM: [
         // Add support for github code blocks.

--- a/packages/remirror__extension-codemirror5/src/codemirror-extension.ts
+++ b/packages/remirror__extension-codemirror5/src/codemirror-extension.ts
@@ -52,7 +52,7 @@ export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOption
       attrs: {
         ...extra.defaults(),
         codeMirrorConfig: { default: undefined },
-        language: { default: undefined, validate: 'string|null' },
+        language: { default: undefined },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
+++ b/packages/remirror__extension-codemirror6/src/codemirror-extension.ts
@@ -52,7 +52,7 @@ export class CodeMirrorExtension extends NodeExtension<CodeMirrorExtensionOption
       code: true,
       attrs: {
         ...extra.defaults(),
-        language: { default: '', validate: 'string' },
+        language: { default: '' },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-columns/src/columns-extension.ts
+++ b/packages/remirror__extension-columns/src/columns-extension.ts
@@ -149,31 +149,24 @@ export class ColumnsExtension extends NodeExtension<ColumnsOptions> {
         ...extra.defaults(),
         count: {
           default: this.options.defaults.count,
-          validate: 'string|number|null',
         },
         fill: {
           default: this.options.defaults.fill,
-          validate: 'string|null',
         },
         gap: {
           default: this.options.defaults.gap,
-          validate: 'string|null',
         },
         ruleColor: {
           default: this.options.defaults.ruleColor,
-          validate: 'string|null',
         },
         ruleStyle: {
           default: this.options.defaults.ruleStyle,
-          validate: 'string|null',
         },
         ruleWidth: {
           default: this.options.defaults.ruleWidth,
-          validate: 'string|null',
         },
         width: {
           default: this.options.defaults.width,
-          validate: 'string|null',
         },
       },
       parseDOM: [
@@ -242,7 +235,7 @@ export class ColumnsExtension extends NodeExtension<ColumnsOptions> {
   createSchemaAttributes(): IdentifierSchemaAttributes[] {
     const columnSpan: SchemaAttributesObject = {
       default: null,
-      validate: 'string|null',
+
       parseDOM: (node) => node.getAttribute('column-span') ?? 'none',
       toDOM: (attrs) =>
         attrs.columnSpan ? ['column-span', attrs.columnSpan === 'all' ? 'all' : 'none'] : null,

--- a/packages/remirror__extension-doc/src/doc-extension.ts
+++ b/packages/remirror__extension-doc/src/doc-extension.ts
@@ -117,11 +117,11 @@ export class DocExtension extends NodeExtension<DocOptions> {
 
     if (isPlainObject(docAttributes)) {
       for (const [key, value] of entries(docAttributes)) {
-        attrs[key] = { default: value, validate: 'string|null' };
+        attrs[key] = { default: value };
       }
     } else {
       for (const key of docAttributes) {
-        attrs[key] = { default: null, validate: 'string|null' };
+        attrs[key] = { default: null };
       }
     }
 

--- a/packages/remirror__extension-embed/src/iframe-extension.ts
+++ b/packages/remirror__extension-embed/src/iframe-extension.ts
@@ -73,14 +73,12 @@ export class IframeExtension extends NodeExtension<IframeOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        src: defaultSource
-          ? { default: defaultSource, validate: 'string' }
-          : { validate: 'string|null' },
-        allowFullScreen: { default: true, validate: 'boolean' },
-        frameBorder: { default: 0, validate: 'number' },
-        type: { default: 'custom', validate: 'string' },
-        width: { default: null, validate: 'number|null' },
-        height: { default: null, validate: 'number|null' },
+        src: defaultSource ? { default: defaultSource } : {},
+        allowFullScreen: { default: true },
+        frameBorder: { default: 0 },
+        type: { default: 'custom' },
+        width: { default: null },
+        height: { default: null },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-emoji/src/emoji-extension.ts
+++ b/packages/remirror__extension-emoji/src/emoji-extension.ts
@@ -84,7 +84,7 @@ export class EmojiExtension extends NodeExtension<EmojiOptions> {
       inline: true,
 
       atom: true,
-      attrs: { ...extra.defaults(), code: { validate: 'string|null' } },
+      attrs: { ...extra.defaults(), code: {} },
       parseDOM: [
         {
           tag: `span[${EMOJI_DATA_ATTRIBUTE}`,

--- a/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
+++ b/packages/remirror__extension-entity-reference/src/entity-reference-extension.ts
@@ -86,7 +86,7 @@ export class EntityReferenceExtension extends MarkExtension<EntityReferenceOptio
       excludes: '',
       attrs: {
         ...extra.defaults(),
-        id: { default: '', validate: 'string' },
+        id: { default: '' },
       },
       toDOM: (mark: Mark) => [
         'span',

--- a/packages/remirror__extension-file/src/file-extension.tsx
+++ b/packages/remirror__extension-file/src/file-extension.tsx
@@ -84,12 +84,12 @@ export class FileExtension extends NodeExtension<FileOptions> {
     return {
       attrs: {
         ...extra.defaults(),
-        id: { default: null, validate: 'string|null' },
-        url: { default: '', validate: 'string' },
-        fileName: { default: '', validate: 'string' },
-        fileType: { default: '', validate: 'string' },
-        fileSize: { default: 0, validate: 'string|number' },
-        error: { default: null, validate: 'string|null' },
+        id: { default: null },
+        url: { default: '' },
+        fileName: { default: '' },
+        fileType: { default: '' },
+        fileSize: { default: 0 },
+        error: { default: null },
       },
       selectable: true,
       draggable: true,

--- a/packages/remirror__extension-font-family/src/font-family-extension.ts
+++ b/packages/remirror__extension-font-family/src/font-family-extension.ts
@@ -38,7 +38,7 @@ export class FontFamilyExtension extends MarkExtension {
   createMarkSpec(extra: ApplySchemaAttributes, override: MarkSpecOverride): MarkExtensionSpec {
     return {
       ...override,
-      attrs: { ...extra.defaults(), fontFamily: { default: null, validate: 'string|null' } },
+      attrs: { ...extra.defaults(), fontFamily: { default: null } },
       parseDOM: [
         {
           tag: `span[${FONT_FAMILY_ATTRIBUTE}]`,

--- a/packages/remirror__extension-font-size/src/font-size-extension.ts
+++ b/packages/remirror__extension-font-size/src/font-size-extension.ts
@@ -68,7 +68,7 @@ export class FontSizeExtension extends MarkExtension<FontSizeOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        size: { default: this.options.defaultSize, validate: 'string|number|null' },
+        size: { default: this.options.defaultSize },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-heading/__tests__/heading-extension.spec.ts
+++ b/packages/remirror__extension-heading/__tests__/heading-extension.spec.ts
@@ -43,7 +43,7 @@ describe('schema', () => {
 
     it('sets the extra attributes', () => {
       expect(schema.nodes.heading.spec.attrs).toEqual({
-        level: { default: 1, validate: 'number' },
+        level: { default: 1 },
         title: { default: null },
         custom: { default: 'failure' },
       });
@@ -55,7 +55,7 @@ describe('schema', () => {
       ]);
 
       expect(schema.nodes.heading.spec.attrs).toEqual({
-        level: { default: 1, validate: 'number' },
+        level: { default: 1 },
       });
     });
   });

--- a/packages/remirror__extension-heading/src/heading-extension.ts
+++ b/packages/remirror__extension-heading/src/heading-extension.ts
@@ -74,7 +74,6 @@ export class HeadingExtension extends NodeExtension<HeadingOptions> {
         ...extra.defaults(),
         level: {
           default: this.options.defaultLevel,
-          validate: 'number',
         },
       },
       parseDOM: [

--- a/packages/remirror__extension-image/src/image-extension.ts
+++ b/packages/remirror__extension-image/src/image-extension.ts
@@ -121,16 +121,16 @@ export class ImageExtension extends NodeExtension<ImageOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        alt: { default: '', validate: 'string' },
-        crop: { default: null, validate: 'string|null' },
-        height: { default: null, validate: 'number|null' },
-        width: { default: null, validate: 'number|null' },
-        rotate: { default: null, validate: 'string|null' },
-        src: { default: null, validate: 'string|null' },
-        title: { default: '', validate: 'string' },
-        fileName: { default: null, validate: 'string|null' },
+        alt: { default: '' },
+        crop: { default: null },
+        height: { default: null },
+        width: { default: null },
+        rotate: { default: null },
+        src: { default: null },
+        title: { default: '' },
+        fileName: { default: null },
 
-        resizable: { default: false, validate: 'boolean' },
+        resizable: { default: false },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-link/__tests__/link-extension.spec.ts
+++ b/packages/remirror__extension-link/__tests__/link-extension.spec.ts
@@ -73,9 +73,9 @@ describe('schema', () => {
 
     it('sets the extra attributes', () => {
       expect(schema.marks.link.spec.attrs).toEqual({
-        href: { validate: 'string|null' },
-        target: { default: null, validate: 'string|null' },
-        auto: { default: false, validate: 'boolean' },
+        href: {},
+        target: { default: null },
+        auto: { default: false },
         title: { default: null },
         custom: { default: 'failure' },
       });
@@ -94,9 +94,9 @@ describe('schema', () => {
       expect(schema.marks.link.spec.attrs).toEqual({
         custom: { default: 'failure' },
         title: { default: null },
-        href: { validate: 'string|null' },
-        target: { default: null, validate: 'string|null' },
-        auto: { default: false, validate: 'boolean' },
+        href: {},
+        target: { default: null },
+        auto: { default: false },
       });
     });
 

--- a/packages/remirror__extension-link/src/link-extension.ts
+++ b/packages/remirror__extension-link/src/link-extension.ts
@@ -319,9 +319,9 @@ export class LinkExtension extends MarkExtension<LinkOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        href: { validate: 'string|null' },
-        target: { default: this.options.defaultTarget, validate: 'string|null' },
-        auto: { default: false, validate: 'boolean' },
+        href: {},
+        target: { default: this.options.defaultTarget },
+        auto: { default: false },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-list/src/list-item-extension.ts
+++ b/packages/remirror__extension-list/src/list-item-extension.ts
@@ -48,8 +48,8 @@ export class ListItemExtension extends NodeExtension<ListItemOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        closed: { default: false, validate: 'boolean' },
-        nested: { default: false, validate: 'boolean' },
+        closed: { default: false },
+        nested: { default: false },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-list/src/ordered-list-extension.ts
+++ b/packages/remirror__extension-list/src/ordered-list-extension.ts
@@ -42,7 +42,6 @@ export class OrderedListExtension extends NodeExtension {
         ...extra.defaults(),
         order: {
           default: 1,
-          validate: 'number',
         },
       },
       parseDOM: [

--- a/packages/remirror__extension-list/src/task-list-item-extension.ts
+++ b/packages/remirror__extension-list/src/task-list-item-extension.ts
@@ -44,7 +44,7 @@ export class TaskListItemExtension extends NodeExtension {
       ...override,
       attrs: {
         ...extra.defaults(),
-        checked: { default: false, validate: 'boolean' },
+        checked: { default: false },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-mention-atom/src/mention-atom-extension.ts
+++ b/packages/remirror__extension-mention-atom/src/mention-atom-extension.ts
@@ -153,9 +153,9 @@ export class MentionAtomExtension extends NodeExtension<MentionAtomOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        id: { validate: 'string|null' },
-        label: { validate: 'string|null' },
-        name: { validate: 'string|null' },
+        id: {},
+        label: {},
+        name: {},
       },
       parseDOM: [
         ...this.options.matchers.map((matcher) => ({

--- a/packages/remirror__extension-mention/src/mention-extension.ts
+++ b/packages/remirror__extension-mention/src/mention-extension.ts
@@ -183,9 +183,9 @@ export class MentionExtension extends MarkExtension<MentionOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        id: { validate: 'string|null' },
-        label: { validate: 'string|null' },
-        name: { validate: 'string|null' },
+        id: {},
+        label: {},
+        name: {},
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
+++ b/packages/remirror__extension-node-formatting/src/node-formatting-extension.ts
@@ -79,7 +79,7 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
           nodeLineHeight: this.nodeLineHeight(),
           style: {
             default: '',
-            validate: 'string',
+
             parseDOM: () => '',
             toDOM: ({ nodeIndent, nodeTextAlignment, nodeLineHeight, style }) => {
               const marginLeft = nodeIndent ? this.options.indents[nodeIndent] : undefined;
@@ -235,7 +235,7 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
   private nodeIndent(): SchemaAttributesObject {
     return {
       default: null,
-      validate: 'string|null',
+
       parseDOM: (element) =>
         element.getAttribute(NODE_INDENT_ATTRIBUTE) ??
         extractIndent(this.options.indents, element.style.marginLeft),
@@ -265,7 +265,7 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
   private nodeTextAlignment(): SchemaAttributesObject {
     return {
       default: null,
-      validate: 'string|null',
+
       parseDOM: (element) =>
         element.getAttribute(NODE_TEXT_ALIGNMENT_ATTRIBUTE) ?? element.style.textAlign,
       toDOM: (attrs) => {
@@ -288,7 +288,7 @@ export class NodeFormattingExtension extends PlainExtension<NodeFormattingOption
   private nodeLineHeight(): SchemaAttributesObject {
     return {
       default: null,
-      validate: 'number|null',
+
       parseDOM: (element) => {
         const val = element.getAttribute(NODE_LINE_HEIGHT_ATTRIBUTE);
         return extractLineHeight(val) ?? extractLineHeight(element.style.lineHeight);

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -88,8 +88,8 @@ export class TableExtension extends BaseTableExtension {
       isolating: true,
       attrs: {
         ...extra.defaults(),
-        isControllersInjected: { default: false, validate: 'boolean' },
-        insertButtonAttrs: { default: null, validate: 'boolean|null' },
+        isControllersInjected: { default: false },
+        insertButtonAttrs: { default: null },
       },
       content: 'tableRow+',
       tableRole: 'table',
@@ -338,10 +338,10 @@ export class TableControllerCellExtension extends BaseTableControllerCellExtensi
     const cellAttrs = {
       ...extra.defaults(),
 
-      colspan: { default: 1, validate: 'number' },
-      rowspan: { default: 1, validate: 'number' },
-      colwidth: { default: null, validate: 'number|null' },
-      background: { default: null, validate: 'string|null' },
+      colspan: { default: 1 },
+      rowspan: { default: 1 },
+      colwidth: { default: null },
+      background: { default: null },
     };
 
     return {

--- a/packages/remirror__extension-tables/src/table-utils.ts
+++ b/packages/remirror__extension-tables/src/table-utils.ts
@@ -102,10 +102,10 @@ export function createTableNodeSchema(
 ): Record<'table' | 'tableRow' | 'tableCell' | 'tableHeaderCell', TableSchemaSpec> {
   const cellAttrs = {
     ...extra.defaults(),
-    colspan: { default: 1, validate: 'number' },
-    rowspan: { default: 1, validate: 'number' },
-    colwidth: { default: null, validate: 'number|null' },
-    background: { default: null, validate: 'string|null' },
+    colspan: { default: 1 },
+    rowspan: { default: 1 },
+    colwidth: { default: null },
+    background: { default: null },
   };
 
   return {

--- a/packages/remirror__extension-text-case/src/text-case-extension.ts
+++ b/packages/remirror__extension-text-case/src/text-case-extension.ts
@@ -46,7 +46,7 @@ export class TextCaseExtension extends MarkExtension<TextCaseOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        casing: { default: this.options.defaultCasing, validate: 'string' },
+        casing: { default: this.options.defaultCasing },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-text-color/src/text-color-extension.ts
+++ b/packages/remirror__extension-text-color/src/text-color-extension.ts
@@ -51,7 +51,7 @@ export class TextColorExtension extends MarkExtension<TextColorOptions> {
       ...override,
       attrs: {
         ...extra.defaults(),
-        color: { default: this.options.defaultColor, validate: 'string|null' },
+        color: { default: this.options.defaultColor },
       },
       parseDOM: [
         {

--- a/packages/remirror__extension-text-highlight/src/text-highlight-extension.ts
+++ b/packages/remirror__extension-text-highlight/src/text-highlight-extension.ts
@@ -53,7 +53,7 @@ export class TextHighlightExtension extends MarkExtension<TextHighlightOptions> 
       ...override,
       attrs: {
         ...extra.defaults(),
-        highlight: { default: this.options.defaultHighlight, validate: 'string|null' },
+        highlight: { default: this.options.defaultHighlight },
       },
       parseDOM: [
         {


### PR DESCRIPTION
### Description

Drop the explicit `validate` property, added to attributes in #2264

Some users have reported issues with legacy JSON data in JavaScript repos where attribute types have not been strictly checked (i.e. calling a command with a _string_ attribute value instead of a _number_).

[The XSS issue in ProseMirror](https://discuss.prosemirror.net/t/heads-up-xss-risk-in-domserializer/6572) has been largely resolved since the changes added in prosemirror-model 1.22.1, which actively guards against corrupted-attribute XSS attacks in `DOMSerializer`. This makes the additional protection of an explicit `validate` attribute largely redundant.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

