### PR TITLE
fix: update prettier log level arg in helper script

### DIFF
--- a/support/scripts/src/helpers.ts
+++ b/support/scripts/src/helpers.ts
@@ -127,7 +127,7 @@ export async function formatFiles(
 
   if (formatter !== 'eslint') {
     promises.push(
-      execFile(`prettier`, [`--loglevel`, `warn`, ...paths, `--write`], {
+      execFile(`prettier`, [`--log-level`, `warn`, ...paths, `--write`], {
         // @ts-expect-error
         stdio: 'pipe',
       }),


### PR DESCRIPTION
### Description

A `--loglevel` to `--log-level` CLI argument update was missed in PR #2255. Fix it.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
