### PR TITLE
fix: expose old version of decorators with legacy prefix

### DIFF
--- a/.changeset/brave-suits-grab.md
+++ b/.changeset/brave-suits-grab.md
@@ -1,0 +1,6 @@
+---
+'@remirror/core': patch
+'remirror': patch
+---
+
+Expose the previous versions of Remirror's decorators with a _legacy_ prefix, so users who are unable to use ES2023 decorators are not blocked updating to Remirror v3.

--- a/.changeset/brave-suits-grab.md
+++ b/.changeset/brave-suits-grab.md
@@ -3,4 +3,4 @@
 'remirror': patch
 ---
 
-Expose the previous versions of Remirror's decorators with a _legacy_ prefix, so users who are unable to use ES2023 decorators are not blocked updating to Remirror v3.
+Expose the previous versions of Remirror's decorators with a _legacy_ prefix, so users who are unable to use Stage 3 decorators are not blocked updating to Remirror v3.

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -15,9 +15,9 @@ Consult the [announcement post](/blog/announcement-v3) to learn more about the v
 npm add --save remirror@latest @remirror/react@latest @remirror/pm@latest
 ```
 
-## ES2023 decorators
+## Stage 3 decorators
 
-Remirror v3 has been updated to use ES2023 decorators, now they have [reached Stage 3](https://github.com/tc39/proposal-decorators), and [esbuild supports them](https://github.com/evanw/esbuild/releases/tag/v0.21.0). Previously Remirror used TypeScript's experimental decorators, which use an older version of the spec.
+Remirror v3 has been updated to use [Stage 3 decorators](https://github.com/tc39/proposal-decorators), now they have reached candidate status, and [esbuild supports them](https://github.com/evanw/esbuild/releases/tag/v0.21.0). Previously Remirror used TypeScript's experimental decorators, which use an older version of the spec.
 
 If you use Remirror's decorators (`@extension`, `@command`, `@helper` and `@keyBinding`) in your custom extensions, you may find they no longer work. Here are a few things to try
 
@@ -51,7 +51,7 @@ Update your Babel config to use the latest version of the decorator spec.
 
 ### Next.js
 
-At time of writing [SWC does not support the latest decorator syntax](https://github.com/vitejs/vite-plugin-react-swc/issues/86).
+At time of writing [Next.js does not support Stage 3 decorators](https://github.com/vercel/next.js/issues/48360).
 
 We recommend using our _legacy_ decorators (see below).
 

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -15,6 +15,66 @@ Consult the [announcement post](/blog/announcement-v3) to learn more about the v
 npm add --save remirror@latest @remirror/react@latest @remirror/pm@latest
 ```
 
+## ES2023 decorators
+
+Remirror v3 has been updated to use ES2023 decorators, now they have [reached Stage 3](https://github.com/tc39/proposal-decorators), and [esbuild supports them](https://github.com/evanw/esbuild/releases/tag/v0.21.0). Previously Remirror used TypeScript's experimental decorators, which use an older version of the spec.
+
+If you use Remirror's decorators (`@extension`, `@command`, `@helper` and `@keyBinding`) in your custom extensions, you may find they no longer work. Here are a few things to try
+
+### TypeScript
+
+Set `experimentalDecorators` to **false** in your `tsconfig`. This ensures you don't use the older version of the decorator spec.
+
+### Vite
+
+If you are using Vite with the SWC plugin, see Next.js below, otherwise:
+
+Ensure the `esbuild` version you use is _at least_ `0.21.0`, and update the `target` your Vite config
+
+```json
+{
+  "esbuild": {
+    "target": "ES2020"
+  }
+}
+```
+
+### Babel
+
+Update your Babel config to use the latest version of the decorator spec.
+
+```json
+{
+  "plugins": [["@babel/plugin-proposal-decorators", { "version": "2023-11" }]]
+}
+```
+
+### Next.js
+
+At time of writing [SWC does not support the latest decorator syntax](https://github.com/vitejs/vite-plugin-react-swc/issues/86).
+
+We recommend using our _legacy_ decorators (see below).
+
+### Help! None of the above worked
+
+If all else fails, you can revert to using the legacy decorators. Please update your imports so that
+
+| Old name     | New name           |
+| ------------ | ------------------ |
+| `command`    | `legacyCommand`    |
+| `helper`     | `legacyHelper`     |
+| `keyBinding` | `legacyKeyBinding` |
+
+i.e.
+
+```ts
+import { legacyCommand as command } from 'remirror';
+```
+
+The `extension` decorator is backwards compatible, so does not need updating.
+
+Please bear in mind that these legacy decorators **are considered deprecated**, and will be removed in a future release of Remirror.
+
 ## `i18n` prop removed from `<Remirror />`
 
 In previous versions of Remirror, the `i18n` prop of the root `<Remirror />` component allowed you to pass a customised **Lingui** instance.

--- a/packages/remirror__core/src/builtins/builtin-decorators.ts
+++ b/packages/remirror__core/src/builtins/builtin-decorators.ts
@@ -82,7 +82,7 @@ export function helper(options: HelperDecoratorOptions = {}) {
 }
 
 /**
- * A legacy decorator (pre ES2023) which can be applied to top level methods
+ * A legacy decorator (pre Stage 3) which can be applied to top level methods
  * on an extension to identify them as helpers. This can be used as a
  * replacement for the `createHelpers` method.
  *
@@ -221,7 +221,7 @@ export function command(
 }
 
 /**
- * A legacy decorator (pre ES2023) which can be applied to top level methods
+ * A legacy decorator (pre Stage 3) which can be applied to top level methods
  * on an extension to identify them as commands. This can be used as a
  * replacement for the `createCommands` method.
  *
@@ -321,7 +321,7 @@ export function keyBinding<Extension extends AnyExtension>(
 }
 
 /**
- * A legacy decorator (pre ES2023) which can be applied to an extension
+ * A legacy decorator (pre Stage 3) which can be applied to an extension
  * method to identify as a key binding method. This can be used as a
  * replacement for the `createKeymap` method depending on your
  * preference.

--- a/packages/remirror__react-ui/readme.md
+++ b/packages/remirror__react-ui/readme.md
@@ -26,3 +26,31 @@ npm install @remirror/react-ui @remirror/react
 ```
 
 This is **NOT** included by default when you install the recommended `@remirror/react` package.
+
+## Translations
+
+The components used here expect a translation library to be present to render tooltips etc.
+
+This can be provided via the `i18nFormat` prop to the root `Remirror` component.
+
+You can use the provided `@remirror/i18n` package, or you can provide your own i18n library (see the [i18n examples in Storybook](https://remirror.vercel.app/?path=/story/i18n-react-i18next--basic))
+
+```tsx
+import { i18nFormat } from '@remirror/i18n';
+import { Remirror, useRemirror } from '@remirror/react';
+import { TopToolbar } from '@remirror/react';
+
+const Editor: React.FC = () => {
+  const { manager } = useRemirror({
+    extensions: () => [
+      // Some extensions here
+    ],
+  });
+
+  return (
+    <Remirror manager={manager} i18nFormat={i18nFormat} autoRender='end'>
+      <TopToolbar />
+    </Remirror>
+  );
+};
+```

--- a/website/sidebar.cjs
+++ b/website/sidebar.cjs
@@ -127,8 +127,10 @@ const docs = [
   {
     type: 'category',
     label: 'More',
-    items: ['contributing', 'tooling', 'errors', 'projects', 'migration-v2', 'migration-v3'],
+    items: ['contributing', 'tooling', 'errors', 'projects'],
   },
+  'migration-v2',
+  'migration-v3',
 ];
 
 if (getApiItems().length > 0) {

--- a/website/sidebar.cjs
+++ b/website/sidebar.cjs
@@ -127,7 +127,7 @@ const docs = [
   {
     type: 'category',
     label: 'More',
-    items: ['contributing', 'tooling', 'errors', 'projects', 'migration-v2'],
+    items: ['contributing', 'tooling', 'errors', 'projects', 'migration-v2', 'migration-v3'],
   },
 ];
 


### PR DESCRIPTION
### Description

Expose the previous versions of Remirror's decorators with a _legacy_ prefix, so users who are unable to use Stage 3 decorators are not blocked updating to Remirror v3.

Update the migration guide.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.
