### PR TITLE
Fix FontWeightProperty in BoldExtension example readme

### DIFF
--- a/packages/remirror__extension-bold/readme.md
+++ b/packages/remirror__extension-bold/readme.md
@@ -35,7 +35,7 @@ import { ExtensionPriority, RemirrorManager } from 'remirror';
 import { BoldExtension, CorePreset } from 'remirror/extensions';
 
 // Create the bold extension
-const boldExtension = new BoldExtension({ weight: '500' });
+const boldExtension = new BoldExtension({ weight: 'bold' });
 const corePreset = new CorePreset();
 
 // Create the Editor Manager with the bold extension passed through.


### PR DESCRIPTION
### Description

Just a small change in the README of `BoldExtension` to use one of actual values of `FontWeightProperty`

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [ ] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

