### PR TITLE
refactor(test-keyboard): remove `@remirror/core-helpers`

### DIFF
--- a/.changeset/short-shirts-retire.md
+++ b/.changeset/short-shirts-retire.md
@@ -1,0 +1,5 @@
+---
+'test-keyboard': patch
+---
+
+Remove dependency of `test-keyboard` on `@remirror/core-helpers`.

--- a/packages/test-keyboard/__tests__/tsconfig.json
+++ b/packages/test-keyboard/__tests__/tsconfig.json
@@ -35,9 +35,6 @@
       "path": "../../remirror/src"
     },
     {
-      "path": "../../remirror__core-helpers/src"
-    },
-    {
       "path": "../../remirror__core-types/src"
     }
   ]

--- a/packages/test-keyboard/package.json
+++ b/packages/test-keyboard/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.22.3",
-    "@remirror/core-helpers": "4.0.0",
     "@remirror/core-types": "3.0.0"
   },
   "devDependencies": {

--- a/packages/test-keyboard/src/test-keyboard-utils.ts
+++ b/packages/test-keyboard/src/test-keyboard-utils.ts
@@ -1,4 +1,3 @@
-import { omit } from '@remirror/core-helpers';
 import type { Shape } from '@remirror/core-types';
 
 import type { KeyboardEventName, ModifierInformation } from './test-keyboard-types';
@@ -74,5 +73,6 @@ export function getModifierInformation(props: GetModifierInformationProps): Modi
  * @param key
  */
 export function cleanKey(key: SupportedCharacters): Omit<KeyDefinition, 'shiftKey'> {
-  return omit(usKeyboardLayout[key], ['shiftKey']);
+  const { shiftKey, ...keyDefinition } = usKeyboardLayout[key];
+  return keyDefinition;
 }

--- a/packages/test-keyboard/src/test-keyboard.ts
+++ b/packages/test-keyboard/src/test-keyboard.ts
@@ -1,5 +1,3 @@
-import { includes, object, take } from '@remirror/core-helpers';
-
 import type {
   KeyboardConstructorProps,
   KeyboardEventName,
@@ -150,7 +148,7 @@ export class Keyboard {
    *
    * @param props - see {@link TextInputProps}
    */
-  usChar({ text, options = object(), typing = false }: TextInputProps<SupportedCharacters>): this {
+  usChar({ text, options = {}, typing = false }: TextInputProps<SupportedCharacters>): this {
     if (!isUSKeyboardCharacter(text)) {
       throw new Error(
         'This is not a supported character. For generic characters use the `keyboard.char` method instead',
@@ -203,7 +201,7 @@ export class Keyboard {
    *
    * @param props - see {@link TypingInputProps}
    */
-  type({ text, options = object() }: TypingInputProps): this {
+  type({ text, options = {} }: TypingInputProps): this {
     for (const char of text) {
       this.char({ text: char, options, typing: true });
     }
@@ -224,10 +222,10 @@ export class Keyboard {
    *
    * @param props - see {@link TextInputProps}
    */
-  mod({ text, options = object() }: TextInputProps): this {
+  mod({ text, options = {} }: TextInputProps): this {
     let modifiers = text.split(/-(?!$)/);
     let result = modifiers[modifiers.length - 1] ?? '';
-    modifiers = take(modifiers, modifiers.length - 1);
+    modifiers = modifiers.slice(0, -1);
 
     if (result === 'Space') {
       result = ' ';
@@ -251,13 +249,14 @@ export class Keyboard {
     this.keyDown({ options });
 
     if (
-      !includes(noKeyPress, options.key) ||
-      (typing && isUSKeyboardCharacter(options.key) && usKeyboardLayout[options.key].text)
+      options.key &&
+      (!noKeyPress.includes(options.key) ||
+        (typing && isUSKeyboardCharacter(options.key) && usKeyboardLayout[options.key].text))
     ) {
       this.keyPress({ options });
     }
 
-    if (!includes(noKeyUp, options.key)) {
+    if (options.key && !noKeyUp.includes(options.key)) {
       this.keyUp({ options });
     }
 

--- a/packages/test-keyboard/src/tsconfig.json
+++ b/packages/test-keyboard/src/tsconfig.json
@@ -17,9 +17,6 @@
   "include": ["./"],
   "references": [
     {
-      "path": "../../remirror__core-helpers/src"
-    },
-    {
       "path": "../../remirror__core-types/src"
     }
   ]

--- a/packages/test-keyboard/src/us-keyboard-layout.ts
+++ b/packages/test-keyboard/src/us-keyboard-layout.ts
@@ -1,5 +1,3 @@
-import { isString } from '@remirror/core-helpers';
-
 /**
  * See
  * {@link https://github.com/GoogleChrome/puppeteer/blob/07febb637c78cd59e22a15166f816d838a36e614/lib/USKeyboardLayout.js}
@@ -421,5 +419,5 @@ export type SupportedCharacters = Extract<keyof USKeyboardLayout, string>;
  * @param char
  */
 export function isUSKeyboardCharacter(char: unknown): char is SupportedCharacters {
-  return isString(char) && Object.keys(rawUSKeyboardLayout).includes(char);
+  return typeof char === 'string' && Object.keys(rawUSKeyboardLayout).includes(char);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3672,9 +3672,6 @@ importers:
       '@babel/runtime':
         specifier: ^7.22.3
         version: 7.22.3
-      '@remirror/core-helpers':
-        specifier: 4.0.0
-        version: link:../remirror__core-helpers
       '@remirror/core-types':
         specifier: 3.0.0
         version: link:../remirror__core-types


### PR DESCRIPTION
### Description

Replace use of `@remirror/core-helpers` with equivalents that rely on
standard built-ins, allowing us to avoid importing the rest of
`@remirror/core-helpers`, which we do not need.

- `includes()` -> `Array.includes()` with defined checks
- `object()` -> `{}`
- `take()` -> `Array.slice()`
- `isString()` -> `typeof char === 'string'`
- `omit()` -> destructuring using the spread operator

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Footnotes
- Follow on to #2245 
- Part of work for #2303 
