### PR TITLE
Correct link extension link to extension-link from LinkExtension

### DIFF
--- a/docs/extensions/link-extension.mdx
+++ b/docs/extensions/link-extension.mdx
@@ -67,4 +67,4 @@ The extension is provided by the `@remirror/extension-link` package.
 
 ## API
 
-- [LinkExtension](../api/extension-link)
+- [LinkExtension](../../api/extension-link)


### PR DESCRIPTION
Currently directs to https://www.remirror.io/docs/extensions/api/extension-link, correct page is https://www.remirror.io/docs/api/extension-link/ (following presumable a migration of a lot of extensions to be top level).

![image](https://github.com/user-attachments/assets/7b230403-63c2-45b9-a183-6e5b31179595)
