### PR TITLE
chore(deps): override prismjs to v1.30.0 [security]

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
   "pnpm": {
     "overrides": {
       "postcss": ">= 8.0.0",
+      "prismjs": ">= 1.30.0",
       "typescript": "~5.0.4"
     },
     "patchedDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss: '>= 8.0.0'
+  prismjs: '>= 1.30.0'
   typescript: ~5.0.4
 
 patchedDependencies:
@@ -9356,7 +9357,7 @@ packages:
       nprogress: 0.2.0
       postcss: 8.4.40
       prism-react-renderer: 1.3.5(react@18.2.0)
-      prismjs: 1.28.0
+      prismjs: 1.30.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router-dom: 5.3.3(react@18.2.0)
@@ -26151,13 +26152,8 @@ packages:
     dependencies:
       react: 18.2.0
 
-  /prismjs@1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
-    engines: {node: '>=6'}
-    dev: false
-
-  /prismjs@1.28.0:
-    resolution: {integrity: sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==}
+  /prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
   /process-nextick-args@2.0.1:
@@ -26978,7 +26974,7 @@ packages:
       '@babel/runtime': 7.22.6
       highlight.js: 10.7.3
       lowlight: 1.20.0
-      prismjs: 1.28.0
+      prismjs: 1.30.0
       react: 18.2.0
       refractor: 3.6.0
     dev: false
@@ -27252,7 +27248,7 @@ packages:
     dependencies:
       hastscript: 6.0.0
       parse-entities: 2.0.0
-      prismjs: 1.27.0
+      prismjs: 1.30.0
     dev: false
 
   /regenerate-unicode-properties@10.1.0:


### PR DESCRIPTION
### Description

Override the version of prismjs used by `@docusaurus/theme-classic` (v1.28.0), `react-syntax-highlighter` (v1.28.0), and `refractor` (v1.27.0) to v1.30.0 to address https://github.com/advisories/GHSA-x7hr-w5r2-h6wg.

Fixes #2312

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

