### PR TITLE
 feat(yjs-extension): add document key option to YjsExtension

### DIFF
--- a/packages/remirror__extension-yjs/src/yjs-extension.ts
+++ b/packages/remirror__extension-yjs/src/yjs-extension.ts
@@ -63,6 +63,11 @@ interface YjsRealtimeProvider {
 
 export interface YjsOptions<Provider extends YjsRealtimeProvider = YjsRealtimeProvider> {
   /**
+   * Set a document key in case you're sharing the same provider
+   */
+  documentKey?: string;
+
+  /**
    * Get the provider for this extension.
    */
   getProvider: Provider | (() => Provider);
@@ -129,6 +134,7 @@ export interface YjsOptions<Provider extends YjsRealtimeProvider = YjsRealtimePr
         message: 'You must provide a YJS Provider to the `YjsExtension`.',
       });
     },
+    documentKey: 'prosemirror',
     destroyProvider: defaultDestroyProvider,
     syncPluginOptions: undefined,
     cursorBuilder: defaultCursorBuilder,
@@ -177,10 +183,11 @@ export class YjsExtension extends PlainExtension<YjsOptions> {
       protectedNodes,
       trackedOrigins,
       selectionBuilder,
+      documentKey,
     } = this.options;
 
     const yDoc = this.provider.doc;
-    const type = yDoc.getXmlFragment('prosemirror');
+    const type = yDoc.getXmlFragment(documentKey);
 
     const plugins = [
       ySyncPlugin(type, syncPluginOptions),


### PR DESCRIPTION
### Description

A new optional property, documentKey, has been added to the YjsOptions. This allows you to specify a custom key for the Yjs document fragment, defaulting to "prosemirror". This is useful if you are sharing the same Yjs provider across multiple editor instances or documents, helping to keep their data separate. The code was updated to use this documentKey instead of the previously hardcoded value when interacting with the Yjs document.

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [ ] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.