### PR TITLE
fix(storybook): "link > edit dialog" menu doesn't work

### DIFF
--- a/packages/storybook-react/stories/extension-link/edit-dialog.tsx
+++ b/packages/storybook-react/stories/extension-link/edit-dialog.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/css';
 import type { ChangeEvent, HTMLProps, KeyboardEvent } from 'react';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createMarkPositioner,
   LinkExtension,
   ShortcutHandlerProps,
   StringPositioner,
 } from 'remirror/extensions';
+import { cx } from '@remirror/core';
 import {
   EditorComponent,
   FloatingWrapper,
@@ -98,7 +99,6 @@ function useFloatingLinkState() {
   return useMemo(
     () => ({
       href,
-      url,
       setHref,
       linkShortcut,
       linkPositioner,
@@ -112,7 +112,6 @@ function useFloatingLinkState() {
     }),
     [
       href,
-      url,
       linkShortcut,
       linkPositioner,
       isEditing,
@@ -145,11 +144,15 @@ const PositionerIllustration = ({ positioner }: PositionerIllustrationProps) => 
   return (
     <div
       ref={ref}
-      className={css`
-        border: 1px solid var(--rmr-hue-red-9);
-        position: absolute;
-        pointer-events: none;
-      `}
+      className={cx(
+        'link-highlight',
+        css`
+          background-color: var(--rmr-hue-blue-7);
+          opacity: 0.2;
+          pointer-events: none;
+          position: absolute;
+        `,
+      )}
       style={{
         left: x,
         top: y,
@@ -212,7 +215,6 @@ const FloatingLinkToolbar = () => {
     onRemoveLink,
     onUpdateLink,
     href,
-    url,
     setHref,
     cancelHref,
   } = useFloatingLinkState();
@@ -246,7 +248,6 @@ const FloatingLinkToolbar = () => {
 
   return (
     <>
-      <Debug isEditing={isEditing} emptySelection={emptySelection} url={url} href={href} />
       {!isEditing && <FloatingToolbar>{linkEditButtons}</FloatingToolbar>}
       {!isEditing && emptySelection && (
         <FloatingToolbar positioner={linkPositioner}>{linkEditButtons}</FloatingToolbar>
@@ -281,27 +282,6 @@ const FloatingLinkToolbar = () => {
       <PositionerPortal>
         <PositionerIllustration positioner='selection' />
       </PositionerPortal>
-    </>
-  );
-};
-
-const Debug = ({
-  isEditing,
-  emptySelection,
-  url,
-  href,
-}: {
-  isEditing: boolean;
-  emptySelection: boolean;
-  url: string;
-  href: string;
-}) => {
-  return (
-    <>
-      <p>isEditing: {String(isEditing)}</p>
-      <p>emptySelection: {String(emptySelection)}</p>
-      <p>href: {href}</p>
-      <p>url: {url}</p>
     </>
   );
 };

--- a/packages/storybook-react/stories/extension-link/edit-dialog.tsx
+++ b/packages/storybook-react/stories/extension-link/edit-dialog.tsx
@@ -223,37 +223,51 @@ const FloatingLinkToolbar = () => {
   const activeLink = active.link();
   const { empty: isSelectionEmpty } = useCurrentSelection();
 
-  const handleonEditLink = useCallback(() => {
+  const handleOnEditLink = useCallback(() => {
     onEditLink();
   }, [onEditLink]);
 
-  const linkEditButtons = activeLink ? (
-    <>
-      <CommandButton
-        commandName='updateLink'
-        onSelect={handleonEditLink}
-        icon='pencilLine'
-        enabled
-      />
-      <CommandButton commandName='removeLink' onSelect={onRemoveLink} icon='linkUnlink' enabled />
-      <CommandButton
-        commandName='activateLink'
-        onSelect={onLinkOpen}
-        icon='externalLinkFill'
-        enabled
-      />
-    </>
-  ) : (
-    <CommandButton commandName='updateLink' onSelect={handleonEditLink} icon='link' enabled />
-  );
+  const linkMenuButtons = useMemo(() => {
+    if (activeLink) {
+      return (
+        <>
+          <CommandButton
+            commandName='updateLink'
+            onSelect={handleOnEditLink}
+            icon='pencilLine'
+            enabled
+          />
+          <CommandButton
+            commandName='removeLink'
+            onSelect={onRemoveLink}
+            icon='linkUnlink'
+            enabled
+          />
+          <CommandButton
+            commandName='activateLink'
+            onSelect={onLinkOpen}
+            icon='externalLinkFill'
+            enabled
+          />
+        </>
+      );
+    }
+
+    if (!isSelectionEmpty) {
+      return (
+        <CommandButton commandName='updateLink' onSelect={handleOnEditLink} icon='link' enabled />
+      );
+    }
+
+    return <></>;
+  }, [activeLink, isSelectionEmpty, handleOnEditLink, onRemoveLink, onLinkOpen]);
 
   return (
     <>
-      {!isEditing && <FloatingToolbar>{linkEditButtons}</FloatingToolbar>}
+      {!isEditing && <FloatingToolbar>{linkMenuButtons}</FloatingToolbar>}
       {!isEditing && isSelectionEmpty && (
-        <FloatingToolbar positioner={linkPositioner}>{linkEditButtons}</FloatingToolbar>
+        <FloatingToolbar positioner={linkPositioner}>{linkMenuButtons}</FloatingToolbar>
       )}
-
       <FloatingWrapper
         enabled={isEditing}
         placement='bottom-start'

--- a/packages/storybook-react/stories/extension-link/edit-dialog.tsx
+++ b/packages/storybook-react/stories/extension-link/edit-dialog.tsx
@@ -164,7 +164,7 @@ const FloatingLinkToolbar = () => {
         positioner='always'
         placement='bottom'
         enabled={isEditing}
-        renderOutsideEditor
+        renderOutsideEditor={!isEditing}
       >
         <DelayAutoFocusInput
           style={{ zIndex: 20 }}
@@ -172,7 +172,7 @@ const FloatingLinkToolbar = () => {
           placeholder='Enter link...'
           onChange={(event: ChangeEvent<HTMLInputElement>) => setHref(event.target.value)}
           value={href}
-          onKeyPress={(event: KeyboardEvent<HTMLInputElement>) => {
+          onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
             const { code } = event;
 
             if (code === 'Enter') {


### PR DESCRIPTION
### Description

There are several references to the the https://remirror.vercel.app/?path=/story/extensions-link--edit-dialog not working.

https://github.com/remirror/remirror/discussions/2182 
https://github.com/remirror/remirror/issues/2013
https://github.com/remirror/remirror/issues/2215 
https://github.com/remirror/remirror/pull/2243

A "menu" that allows the user to manipulate links is a pretty common use case for rich text editors. In fact, I would argue that without this feature Remirror can't be used in most real-world web applications.

This is my solution to the broken storybook story:

1. fixed the menu not opening
2. added a "open link" button to the floating menu
3. added an input box to update the link text, in addi

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.