### PR TITLE
fix: use the original typing for legacy command decorator

### DIFF
--- a/.changeset/calm-paws-divide.md
+++ b/.changeset/calm-paws-divide.md
@@ -1,0 +1,6 @@
+---
+"remirror": patch
+"@remirror/core": patch
+---
+
+Use the original typing for legacy command decorator.

--- a/.changeset/calm-paws-divide.md
+++ b/.changeset/calm-paws-divide.md
@@ -1,6 +1,6 @@
 ---
-"remirror": patch
-"@remirror/core": patch
+'remirror': patch
+'@remirror/core': patch
 ---
 
 Use the original typing for legacy command decorator.

--- a/packages/remirror__core/src/builtins/builtin-decorators.ts
+++ b/packages/remirror__core/src/builtins/builtin-decorators.ts
@@ -400,7 +400,7 @@ type ExtensionDecorator<Extension extends AnyExtension, Fn, Return> = (
   context: ClassMethodDecoratorContext<Extension, AnyFunction<Fn>>,
 ) => Return;
 
-type LegacyExtensionDecorator<Extension extends AnyExtension, Fn, Return> = (
+export type LegacyExtensionDecorator<Extension extends AnyExtension, Fn, Return> = (
   target: Extension,
   propertyKey: string,
   _descriptor: TypedPropertyDescriptor<AnyFunction<Fn>>,

--- a/packages/remirror__core/src/builtins/builtin-decorators.ts
+++ b/packages/remirror__core/src/builtins/builtin-decorators.ts
@@ -275,10 +275,10 @@ export function command(
  */
 export function legacyCommand<Extension extends AnyExtension>(
   options?: ChainableCommandDecoratorOptions<Required<GetOptions<Extension>>>,
-): ExtensionDecorator<Extension, CommandFunction, void>;
+): LegacyExtensionDecorator<Extension, CommandFunction, void>;
 export function legacyCommand<Extension extends AnyExtension>(
   options: NonChainableCommandDecoratorOptions<Required<GetOptions<Extension>>>,
-): ExtensionDecorator<Extension, NonChainableCommandFunction, void>;
+): LegacyExtensionDecorator<Extension, NonChainableCommandFunction, void>;
 export function legacyCommand(options: CommandDecoratorOptions = {}): any {
   return (target: any, propertyKey: string, _descriptor: any): void => {
     // Attach the options to the decoratedCommands property for this extension.
@@ -398,6 +398,12 @@ export interface KeybindingDecoratorOptions<Options extends Shape = Shape> {
 type ExtensionDecorator<Extension extends AnyExtension, Fn, Return> = (
   method: AnyFunction<Fn>,
   context: ClassMethodDecoratorContext<Extension, AnyFunction<Fn>>,
+) => Return;
+
+type LegacyExtensionDecorator<Extension extends AnyExtension, Fn, Return> = (
+  target: Extension,
+  propertyKey: string,
+  _descriptor: TypedPropertyDescriptor<AnyFunction<Fn>>,
 ) => Return;
 
 export interface CommandUiIcon {


### PR DESCRIPTION
### Description

While legacy decorators have been exposed back in https://github.com/remirror/remirror/pull/2285, the typing for `@legacyCommand` is not correct, as it relates to the new decorators. 

This PR attempts to fix this issue.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `pnpm test`.

