### PR TITLE
Feature: Propagate Marks on Paste Rules

### DIFF
--- a/.changeset/eleven-trees-speak.md
+++ b/.changeset/eleven-trees-speak.md
@@ -1,0 +1,6 @@
+---
+"prosemirror-paste-rules": minor
+"jest-prosemirror": patch
+---
+
+Propagate marks into inline blocks when paste rules match both

--- a/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-nodes.ts
@@ -185,6 +185,7 @@ const built = pmBuild(schema, {
   p: { nodeType: 'paragraph' },
   text: { nodeType: 'text' },
   atomInline: { nodeType: 'atomInline' },
+  inlineTextBlock: { nodeType: 'inlineTextBlock' },
   atomBlock: { nodeType: 'atomBlock' },
   atomContainer: { nodeType: 'atomContainer' },
   li: { nodeType: 'listItem' },
@@ -241,6 +242,7 @@ export const {
 
 const b = built as any;
 
+export const inlineTextBlock: NodeBuilder = b.inlineTextBlock;
 export const code_block: NodeBuilder = b.code_block;
 export const pre: NodeBuilder = b.pre;
 export const img: NodeBuilder = b.img;

--- a/packages/jest-prosemirror/src/jest-prosemirror-schema.ts
+++ b/packages/jest-prosemirror/src/jest-prosemirror-schema.ts
@@ -49,6 +49,14 @@ const atomInline: NodeSpec = {
   toDOM: () => ['span', { 'data-node-type': 'atomInline' }],
 };
 
+const inlineTextBlock: NodeSpec = {
+  inline: true,
+  group: 'inline',
+  content: 'text*',
+  parseDOM: [{ tag: 'code[data-node-type="inlineTextBlock"]' }],
+  toDOM: () => ['code', { 'data-node-type': 'inlineTextBlock' }, 0],
+};
+
 const atomBlock: NodeSpec = {
   inline: false,
   group: ExtensionTag.Block,
@@ -117,6 +125,7 @@ export const schema = new Schema({
     atomInline,
     atomBlock,
     atomContainer,
+    inlineTextBlock,
     containerWithRestrictedContent,
     table,
     table_row,

--- a/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
+++ b/packages/prosemirror-paste-rules/__tests__/paste-rules-plugin.spec.ts
@@ -6,6 +6,7 @@ import {
   h1,
   h2,
   hardBreak,
+  inlineTextBlock,
   li,
   p,
   schema,
@@ -16,6 +17,7 @@ import {
   ul,
 } from 'jest-prosemirror';
 import type { Node as ProsemirrorNode } from 'prosemirror-model';
+import { ExtensionPriority } from '@remirror/core-constants';
 
 import { pasteRules } from '../';
 
@@ -592,6 +594,32 @@ describe('pasteRules', () => {
                 tableRow(tableCell(p()), tableCell(p()), tableCell(p())),
               ),
             ),
+          );
+        });
+    });
+
+    it('carries the marks to an inline block', () => {
+      const plugin = pasteRules([
+        {
+          regexp: /\*\*([^*]*)\*\*/,
+          markType: schema.marks.strong,
+          type: 'mark',
+          replaceSelection: true,
+          priority: ExtensionPriority.High,
+        },
+        {
+          regexp: /`([^`]*)`/,
+          type: 'node',
+          nodeType: schema.nodes.inlineTextBlock,
+          getContent: (match) => schema.text(match[1]),
+          priority: ExtensionPriority.Low,
+        },
+      ]);
+      createEditor(doc(p('<cursor>')), { plugins: [plugin] })
+        .paste('**Hello `user.name`**')
+        .callback((content) => {
+          expect(content.doc).toEqualProsemirrorNode(
+            doc(p(strong('Hello '), strong(inlineTextBlock('user.name')))),
           );
         });
     });

--- a/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
+++ b/packages/prosemirror-paste-rules/src/paste-rules-plugin.ts
@@ -561,7 +561,7 @@ function nodeRuleTransformer(props: TransformerProps<NodePasteRule>) {
   const { getAttributes, nodeType, getContent } = rule;
   const attributes = isFunction(getAttributes) ? getAttributes(match, false) : getAttributes;
   const content = (getContent ? getContent(match) : textNode) || undefined;
-  nodes.push(nodeType.createChecked(attributes, content));
+  nodes.push(nodeType.createChecked(attributes, content, textNode.marks));
 }
 
 /**


### PR DESCRIPTION
### Motivation

When pasting raw text, two paste rules can trigger over the same range: one applying a mark and another creating an inline text node.

In this scenario, the inline text node can't have marks inside of it, but can be marked as a whole.
In addition, the mark rule has to run first, to mark the whole text, to only after that create the inline text node.

Since this mark rule runs before the node rule, the node rule receives text that already has marks applied.
Currently, `nodeRuleTransformer` always creates a clean node, discarding those existing marks.

This fix should preserve marks applied by earlier rules by carrying them over to the resulting node, while keeping the `ignoreNodes`/`ignoreMarks` param functional to prevent invalid combinations.

### Description

- Fixes mark propagation when an inline node paste rule fires within marked content
  - e.g. \*\*Hello \`user.name\`\*\* where both a mark rule and an inline node rule apply.
- The `nodeRuleTransformer` now passes the surrounding text node's marks when calling `nodeType.createChecked(...)`, so inline nodes created by paste rules correctly inherit marks.
- Adds an `inlineTextBlock` node to the `jest-prosemirror` test schema
- Adds an unit test for this case

### Checklist

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.
