### PR TITLE
feat: Add configurable min & max width to resizable images

### DIFF
--- a/.changeset/hip-laws-jam.md
+++ b/.changeset/hip-laws-jam.md
@@ -1,0 +1,6 @@
+---
+"prosemirror-resizable-view": minor
+"@remirror/extension-image": minor
+---
+
+Add optional `minWidth` and `maxWidth` parameters for resizable images.

--- a/docs/extensions/image-extension.mdx
+++ b/docs/extensions/image-extension.mdx
@@ -5,6 +5,7 @@ title: 'ImageExtension'
 
 import Basic from '../../website/extension-examples/extension-image/basic';
 import Resizable from '../../website/extension-examples/extension-image/resizable';
+import ResizableWithMinMaxWidth from '../../website/extension-examples/extension-image/resizable-with-min-max-width';
 import WithFigcaption from '../../website/extension-examples/extension-image/with-figcaption';
 
 # `ImageExtension`
@@ -36,6 +37,10 @@ Here is a basic image example. You can see a grean image below.
 You can also make an image resizable by using `enableResizing` option.
 
 <Resizable />
+
+You can constrain the resize range using `minWidth` and `maxWidth` options.
+
+<ResizableWithMinMaxWidth />
 
 You can further customize `ImageExtension` by extending it. For example, using a `<figure>` element to wrap the image and adding a `<figcaption>` element.
 

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -219,11 +219,10 @@ export abstract class ResizableNodeView implements NodeView {
       }
 
       if (typeof newWidth === 'number' && newWidth < MIN_WIDTH) {
+        newWidth = MIN_WIDTH;
+
         if (this.aspectRatio === ResizableRatioType.Fixed && startWidth && startHeight) {
-          newWidth = MIN_WIDTH;
           newHeight = (startHeight / startWidth) * newWidth;
-        } else if (this.aspectRatio === ResizableRatioType.Flexible) {
-          newWidth = MIN_WIDTH;
         }
       }
 

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -5,7 +5,7 @@ import { setStyle } from '@remirror/core-utils';
 
 import { ResizableHandle, ResizableHandleType } from './resizable-view-handle';
 
-const MIN_WIDTH = 50;
+const DEFAULT_MIN_WIDTH = 50;
 
 export enum ResizableRatioType {
   Fixed,
@@ -26,6 +26,8 @@ interface OptionShape {
  * @param aspectRatio? - to determine which type of aspect ratio should be used.
  * @param options? - extra options to pass to `createElement` method.
  * @param initialSize? - initial view size.
+ * @param minWidth? - the minimum width (in pixels) the node can be resized to. Defaults to {@link DEFAULT_MIN_WIDTH}.
+ * @param maxWidth? - the maximum width (in pixels) the node can be resized to. Defaults to `Infinity`.
  */
 export abstract class ResizableNodeView implements NodeView {
   dom: HTMLElement;
@@ -33,6 +35,8 @@ export abstract class ResizableNodeView implements NodeView {
   #node: ProsemirrorNode;
   #destroyList: Array<() => void> = [];
   readonly aspectRatio: ResizableRatioType;
+  readonly minWidth: number;
+  readonly maxWidth: number;
 
   // cache the current element's size so that we can compare with new node's
   // size when `update` method is called.
@@ -46,6 +50,8 @@ export abstract class ResizableNodeView implements NodeView {
     aspectRatio = ResizableRatioType.Fixed,
     options,
     initialSize,
+    minWidth = DEFAULT_MIN_WIDTH,
+    maxWidth = Number.POSITIVE_INFINITY,
   }: {
     node: ProsemirrorNode;
     view: EditorView;
@@ -53,7 +59,12 @@ export abstract class ResizableNodeView implements NodeView {
     aspectRatio?: ResizableRatioType;
     options?: OptionShape;
     initialSize?: { width: number; height: number };
+    minWidth?: number;
+    maxWidth?: number;
   }) {
+    this.minWidth = minWidth;
+    this.maxWidth = maxWidth;
+
     const outer = this.createWrapper(node, initialSize);
     const element = this.createElement({ node, view, getPos, options });
 
@@ -137,8 +148,8 @@ export abstract class ResizableNodeView implements NodeView {
     }
 
     setStyle(outer, {
-      maxWidth: '100%',
-      minWidth: `${MIN_WIDTH}px`,
+      maxWidth: Number.isFinite(this.maxWidth) ? `min(100%, ${this.maxWidth}px)` : '100%',
+      minWidth: `${this.minWidth}px`,
 
       // By default, inline-block has "vertical-align: baseline", which makes
       // the outer wrapper slightly taller than the resizable view, which will
@@ -222,8 +233,8 @@ export abstract class ResizableNodeView implements NodeView {
         }
       }
 
-      if (typeof newWidth === 'number' && newWidth < MIN_WIDTH) {
-        newWidth = MIN_WIDTH;
+      if (typeof newWidth === 'number') {
+        newWidth = Math.min(this.maxWidth, Math.max(this.minWidth, newWidth));
 
         if (this.aspectRatio === ResizableRatioType.Fixed) {
           newHeight = (startHeight / startWidth) * newWidth;

--- a/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
+++ b/packages/prosemirror-resizable-view/src/prosemirror-resizable-view.ts
@@ -179,7 +179,11 @@ export abstract class ResizableNodeView implements NodeView {
       let newWidth: number | null = null;
       let newHeight: number | null = null;
 
-      if (this.aspectRatio === ResizableRatioType.Fixed && startWidth && startHeight) {
+      if (this.aspectRatio === ResizableRatioType.Fixed && (!startWidth || !startHeight)) {
+        return;
+      }
+
+      if (this.aspectRatio === ResizableRatioType.Fixed) {
         switch (handle.type) {
           case ResizableHandleType.Right:
           case ResizableHandleType.BottomRight:
@@ -221,7 +225,7 @@ export abstract class ResizableNodeView implements NodeView {
       if (typeof newWidth === 'number' && newWidth < MIN_WIDTH) {
         newWidth = MIN_WIDTH;
 
-        if (this.aspectRatio === ResizableRatioType.Fixed && startWidth && startHeight) {
+        if (this.aspectRatio === ResizableRatioType.Fixed) {
           newHeight = (startHeight / startWidth) * newWidth;
         }
       }

--- a/packages/remirror__extension-image/__tests__/image-extension.spec.ts
+++ b/packages/remirror__extension-image/__tests__/image-extension.spec.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { fireEvent } from '@testing-library/dom';
 import { extensionValidityTest, renderEditor } from 'jest-remirror';
 import { DelayedPromiseCreator } from 'remirror';
 import { delay } from 'testing';
@@ -51,6 +52,139 @@ describe('commands', () => {
       expect(editor.doc).toEqualProsemirrorNode(
         doc(p('content ', image({ src: 'https://test.com' })())),
       );
+    });
+  });
+});
+
+describe('resizing', () => {
+  const IMAGE_WIDTH = 200;
+  const IMAGE_HEIGHT = 100;
+
+  const renderResizableEditor = (options: { minWidth?: number; maxWidth?: number } = {}) =>
+    renderEditor(() => [new ImageExtension({ enableResizing: true, ...options })]);
+
+  const insertImageAndGetWrapper = (
+    editor: ReturnType<typeof renderResizableEditor>,
+  ): HTMLElement => {
+    const { doc, p } = editor.nodes;
+    editor.add(doc(p('<cursor>')));
+    editor.commands.insertImage({
+      src: 'https://test.com',
+      width: IMAGE_WIDTH,
+      height: IMAGE_HEIGHT,
+    });
+    const wrapper = editor.dom.querySelector<HTMLElement>('.remirror-resizable-view');
+
+    if (!wrapper) {
+      throw new Error('Expected `.remirror-resizable-view` wrapper to be rendered.');
+    }
+
+    return wrapper;
+  };
+
+  it('renders a wrapper with default min/max width when no bounds are provided', () => {
+    const editor = renderResizableEditor();
+    const wrapper = insertImageAndGetWrapper(editor);
+
+    expect(wrapper.style.minWidth).toBe('50px');
+    expect(wrapper.style.maxWidth).toBe('100%');
+  });
+
+  it('applies a custom `minWidth` to the wrapper', () => {
+    const editor = renderResizableEditor({ minWidth: 120 });
+    const wrapper = insertImageAndGetWrapper(editor);
+
+    expect(wrapper.style.minWidth).toBe('120px');
+  });
+
+  it('applies a custom `maxWidth` to the wrapper, capped by the container width', () => {
+    const editor = renderResizableEditor({ maxWidth: 480 });
+    const wrapper = insertImageAndGetWrapper(editor);
+
+    expect(wrapper.style.maxWidth).toBe('min(100%, 480px)');
+  });
+
+  describe('drag clamping', () => {
+    // `jsdom` doesn't compute `pageX`/`pageY` (which is `clientX`/`clientY` +
+    // `scrollX`/`scrollY`)
+    beforeAll(() => {
+      Object.defineProperty(MouseEvent.prototype, 'pageX', {
+        configurable: true,
+        get() {
+          return this.clientX;
+        },
+      });
+      Object.defineProperty(MouseEvent.prototype, 'pageY', {
+        configurable: true,
+        get() {
+          return this.clientY;
+        },
+      });
+    });
+
+    afterAll(() => {
+      delete (MouseEvent.prototype as { pageX?: number }).pageX;
+      delete (MouseEvent.prototype as { pageY?: number }).pageY;
+    });
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const performRightHandleDrag = (wrapper: HTMLElement, { pageX }: { pageX: number }): void => {
+      const innerImage = wrapper.querySelector<HTMLElement>('img');
+      const handles = wrapper.querySelectorAll<HTMLElement>('div[style*="cursor: col-resize"]');
+      // Counter-intuitively, the right handle is first.
+      const rightHandle = handles[0];
+
+      if (!innerImage || !rightHandle) {
+        throw new Error('Expected resizable wrapper to render inner image and handles.');
+      }
+
+      // `jsdom` doesn't implement `getBoundingClientRect`
+      jest.spyOn(innerImage, 'getBoundingClientRect').mockReturnValue({
+        width: IMAGE_WIDTH,
+        height: IMAGE_HEIGHT,
+        top: 0,
+        left: 0,
+        right: IMAGE_WIDTH,
+        bottom: IMAGE_HEIGHT,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      });
+
+      fireEvent.mouseDown(rightHandle, { clientX: 0, clientY: 0 });
+      fireEvent.mouseMove(document, { clientX: pageX, clientY: 0 });
+      fireEvent.mouseUp(document, { clientX: pageX, clientY: 0 });
+    };
+
+    it('clamps an oversized drag at `maxWidth`', () => {
+      const editor = renderResizableEditor({ minWidth: 100, maxWidth: 400 });
+      const wrapper = insertImageAndGetWrapper(editor);
+
+      // Drag the right handle far past `maxWidth`
+      performRightHandleDrag(wrapper, { pageX: 9999 });
+
+      const imageNode = editor.doc.firstChild?.firstChild;
+      expect(imageNode?.attrs.width).toBe(400);
+      expect(imageNode?.attrs.height).toBe(200);
+    });
+
+    it('clamps an undersized drag at `minWidth`', () => {
+      const editor = renderResizableEditor({ minWidth: 100, maxWidth: 400 });
+      const wrapper = insertImageAndGetWrapper(editor);
+
+      // Drag the right handle far below `minWidth`
+      performRightHandleDrag(wrapper, { pageX: -9999 });
+
+      const imageNode = editor.doc.firstChild?.firstChild;
+      expect(imageNode?.attrs.width).toBe(100);
+      expect(imageNode?.attrs.height).toBe(50);
     });
   });
 });

--- a/packages/remirror__extension-image/src/image-extension.ts
+++ b/packages/remirror__extension-image/src/image-extension.ts
@@ -59,6 +59,22 @@ export interface ImageOptions {
   enableResizing?: boolean;
 
   /**
+   * The minimum width (in pixels) the image can be resized to when
+   * {@link ImageOptions.enableResizing} is `true`.
+   *
+   * @defaultValue 50
+   */
+  minWidth?: number;
+
+  /**
+   * The maximum width (in pixels) the image can be resized to when
+   * {@link ImageOptions.enableResizing} is `true`.
+   *
+   * @defaultValue Infinity
+   */
+  maxWidth?: number;
+
+  /**
    * When pasting mixed text and image content (usually from Microsoft Office products) the content on the clipboard is either:
    *
    * a. one large image: containing effectively a screenshot of the original content (an image with text in it).
@@ -100,6 +116,8 @@ type SetProgress = (progress: number) => void;
     destroyPlaceholder: () => {},
     uploadHandler,
     enableResizing: false,
+    minWidth: 50,
+    maxWidth: Number.POSITIVE_INFINITY,
     preferPastedTextContent: true,
   },
 })
@@ -276,8 +294,9 @@ export class ImageExtension extends NodeExtension<ImageOptions> {
 
   createNodeViews(): NodeViewMethod | Record<string, NodeViewMethod> {
     if (this.options.enableResizing) {
+      const { minWidth, maxWidth } = this.options;
       return (node: ProsemirrorNode, view: EditorView, getPos: () => number | undefined) =>
-        new ResizableImageView(node, view, getPos as () => number);
+        new ResizableImageView(node, view, getPos as () => number, { minWidth, maxWidth });
     }
 
     return {};

--- a/packages/remirror__extension-image/src/resizable-image-view.ts
+++ b/packages/remirror__extension-image/src/resizable-image-view.ts
@@ -2,13 +2,23 @@ import { ResizableNodeView, ResizableRatioType } from 'prosemirror-resizable-vie
 import { setStyle } from '@remirror/core';
 import { EditorView, NodeView, ProsemirrorNode } from '@remirror/pm';
 
+interface ResizableImageViewOptions {
+  minWidth?: number;
+  maxWidth?: number;
+}
+
 /**
  * ResizableImageView is a NodeView for image. You can resize the image by
  * dragging the handle over the image.
  */
 export class ResizableImageView extends ResizableNodeView implements NodeView {
-  constructor(node: ProsemirrorNode, view: EditorView, getPos: () => number) {
-    super({ node, view, getPos, aspectRatio: ResizableRatioType.Fixed });
+  constructor(
+    node: ProsemirrorNode,
+    view: EditorView,
+    getPos: () => number,
+    options: ResizableImageViewOptions = {},
+  ) {
+    super({ node, view, getPos, aspectRatio: ResizableRatioType.Fixed, ...options });
   }
 
   createElement({ node }: { node: ProsemirrorNode }): HTMLImageElement {
@@ -18,7 +28,7 @@ export class ResizableImageView extends ResizableNodeView implements NodeView {
 
     setStyle(inner, {
       width: '100%',
-      minWidth: '50px',
+      minWidth: `${this.minWidth}px`,
       objectFit: 'contain', // maintain image's aspect ratio
     });
 

--- a/packages/storybook-react/stories/extension-image/image.stories.tsx
+++ b/packages/storybook-react/stories/extension-image/image.stories.tsx
@@ -2,6 +2,7 @@ import type { Story } from '@storybook/react';
 
 import BasicComponent from './basic';
 import ResizableComponent from './resizable';
+import ResizableWithMinMaxWidthComponent from './resizable-with-min-max-width';
 import WithFigcaption from './with-figcaption';
 
 const Basic: Story = BasicComponent.bind({});
@@ -10,6 +11,9 @@ Basic.storyName = 'Basic';
 const Resizable: Story = ResizableComponent.bind({});
 Resizable.storyName = 'Resizable';
 
-export { Basic, Resizable, WithFigcaption };
+const ResizableWithMinMaxWidth: Story = ResizableWithMinMaxWidthComponent.bind({});
+ResizableWithMinMaxWidth.storyName = 'ResizableWithMinMaxWidth';
+
+export { Basic, Resizable, ResizableWithMinMaxWidth, WithFigcaption };
 
 export default { title: 'Extensions / Image' };

--- a/packages/storybook-react/stories/extension-image/resizable-with-min-max-width.tsx
+++ b/packages/storybook-react/stories/extension-image/resizable-with-min-max-width.tsx
@@ -1,0 +1,68 @@
+import 'remirror/styles/all.css';
+
+import React from 'react';
+import { DropCursorExtension, ImageExtension } from 'remirror/extensions';
+import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+
+const extensions = () => [
+  new ImageExtension({ enableResizing: true, minWidth: 200, maxWidth: 600 }),
+  new DropCursorExtension(),
+];
+
+const ResizableWithMinMaxWidth = (): JSX.Element => {
+  const imageSrc = 'https://dummyimage.com/2000x800/479e0c/fafafa';
+
+  const { manager, state, onChange } = useRemirror({
+    extensions,
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'image',
+              attrs: {
+                height: 160,
+                width: 400,
+                src: imageSrc,
+              },
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'You can see a resizable image above. Move your mouse over the image and drag the resizing handler to resize it.',
+            },
+          ],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: 'This image will only resize to the minimum of 200px and the maximum of 600px.',
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  return (
+    <ThemeProvider>
+      <Remirror
+        manager={manager}
+        autoFocus
+        onChange={onChange}
+        initialContent={state}
+        autoRender='end'
+      />
+    </ThemeProvider>
+  );
+};
+
+export default ResizableWithMinMaxWidth;

--- a/website/extension-examples/extension-image/resizable-with-min-max-width.tsx
+++ b/website/extension-examples/extension-image/resizable-with-min-max-width.tsx
@@ -1,0 +1,30 @@
+/**
+ * THIS FILE IS AUTO GENERATED!
+ *
+ * Run `pnpm -w generate:website-examples` to regenerate this file.
+ */
+
+// @ts-nocheck
+
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import ComponentSource from '!!raw-loader!../../../packages/storybook-react/stories/extension-image/resizable-with-min-max-width.tsx';
+
+import { StoryExample } from '../../src/components/story-example-component';
+
+const ExampleComponent = (): JSX.Element => {
+  const story = (
+    <BrowserOnly>
+      {() => {
+        const ComponentStory = require('../../../packages/storybook-react/stories/extension-image/resizable-with-min-max-width').default
+        return <ComponentStory/>
+      }}
+    </BrowserOnly>
+  );
+  const source = <CodeBlock className='language-tsx'>{ComponentSource}</CodeBlock>;
+
+  return <StoryExample story={story} source={source} />;
+};
+
+export default ExampleComponent;


### PR DESCRIPTION
### Description

<!-- Describe your changes in detail and reference any issues it addresses-->

Images inserted into the editor can be resized, but there is no way to configure the minimum and maximum widths. This PR adds two options for controlling those parameters.

I didn't add any assertions that the provided values are positive numbers, `maxWidth > minWidth`, etc. I assume that users will just use "sensible" values.

(Some refactoring comes first to make the diff easier to understand.)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/remirror/remirror/blob/HEAD/docs/contributing.md) document.
- [x] My code follows the code style of this project and `pnpm fix` completed successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `pnpm test`.

### Screenshots

<!-- Delete this section if not applicable -->
n/a
