### PR TITLE
Fix Backspace deletion for React tables

### DIFF
--- a/.changeset/quiet-tables-leave.md
+++ b/.changeset/quiet-tables-leave.md
@@ -1,0 +1,5 @@
+---
+"@remirror/extension-react-tables": patch
+---
+
+Fix Backspace handling so React tables can be deleted from the following paragraph.

--- a/packages/remirror__extension-react-tables/__tests__/table-extensions.spec.ts
+++ b/packages/remirror__extension-react-tables/__tests__/table-extensions.spec.ts
@@ -1,4 +1,4 @@
-import { extensionValidityTest } from 'jest-remirror';
+import { extensionValidityTest, renderEditor } from 'jest-remirror';
 
 import {
   TableCellExtension,
@@ -13,3 +13,23 @@ extensionValidityTest(TableCellExtension);
 extensionValidityTest(TableControllerCellExtension);
 extensionValidityTest(TableHeaderCellExtension);
 extensionValidityTest(TableRowExtension);
+
+describe('keyboard shortcuts', () => {
+  it('deletes a React table with Backspace from the following paragraph', () => {
+    const editor = renderEditor<TableExtension>([new TableExtension({ resizable: false })]);
+    const { add, attributeNodes, nodes, press, view } = editor;
+    const { doc, p, tableCell: cell, tableControllerCell: controller, tableRow: row } = nodes;
+    const { table } = attributeNodes;
+
+    const reactTable = table({ isControllersInjected: true })(
+      row(controller(), controller(), controller()),
+      row(controller(), cell(p('A1')), cell(p('B1'))),
+      row(controller(), cell(p('A2')), cell(p('B2'))),
+    );
+
+    add(doc(reactTable, p('<cursor>')));
+    press('Backspace');
+
+    expect(view.state.doc).toEqualRemirrorDocument(doc(p()));
+  });
+});

--- a/packages/remirror__extension-react-tables/src/table-extensions.tsx
+++ b/packages/remirror__extension-react-tables/src/table-extensions.tsx
@@ -12,6 +12,8 @@ import {
   findChildren,
   getChangedNodes,
   isElementDomNode,
+  keyBinding,
+  KeyBindingProps,
   NodeSpecOverride,
   NodeViewMethod,
   ProsemirrorNode,
@@ -234,6 +236,34 @@ export class TableExtension extends BaseTableExtension {
   @command()
   addTableRowAfter(): CommandFunction {
     return convertCommand(addRowAfter);
+  }
+
+  @keyBinding<TableExtension>({ shortcut: 'Backspace', priority: ExtensionPriority.High })
+  deleteTableBeforeOnBackspace(props: KeyBindingProps): boolean {
+    const { dispatch, tr } = props;
+    const { selection } = tr;
+
+    if (!(selection instanceof TextSelection) || !selection.empty || !selection.$cursor) {
+      return false;
+    }
+
+    const { $cursor } = selection;
+
+    if ($cursor.parentOffset !== 0) {
+      return false;
+    }
+
+    const $before = tr.doc.resolve($cursor.before());
+    const nodeBefore = $before.nodeBefore;
+
+    if (!nodeBefore || nodeBefore.type !== this.type) {
+      return false;
+    }
+
+    const tablePos = $before.pos - nodeBefore.nodeSize;
+    dispatch?.(tr.delete(tablePos, tablePos + nodeBefore.nodeSize).scrollIntoView());
+
+    return true;
   }
 
   createPlugin(): CreateExtensionPlugin {


### PR DESCRIPTION
## Summary
- delete the previous React table when Backspace is pressed at the start of the following paragraph
- add a regression test for deleting an injected-controller React table via Backspace

Fixes #952

## Tests
- corepack pnpm test -- packages/remirror__extension-react-tables/__tests__/table-extensions.spec.ts --runInBand